### PR TITLE
Added support for Galacticraft inventory with inventory tabs

### DIFF
--- a/mods/tinker/tconstruct/client/TControls.java
+++ b/mods/tinker/tconstruct/client/TControls.java
@@ -60,7 +60,7 @@ public class TControls extends TKeyHandler
 		    {
 		        openArmorGui(mc.thePlayer.username);
 		    }
-		    if (kb == invKey && mc.currentScreen != null && mc.currentScreen.getClass() == GuiInventory.class)// && !mc.playerController.isInCreativeMode())
+		    if (kb == invKey && mc.currentScreen != null && (mc.currentScreen.getClass() == GuiInventory.class || this.classMatches(mc.currentScreen, "micdoodle8.mods.galacticraft.core.client.gui.GCCoreGuiInventory")))// && !mc.playerController.isInCreativeMode())
 		    {
 		        TProxyClient.addTabsToInventory();
 
@@ -106,6 +106,18 @@ public class TControls extends TKeyHandler
 			}
 		}*/
 	}
+
+    public static boolean classMatches(Object paramObject, String paramString)
+    {
+    	try 
+      	{
+    		return paramObject.getClass().getName().equals(paramString); 
+      	} 
+      	catch (Exception localException) 
+      	{
+      		return false;
+      	}
+    }
 
 	@Override
 	public void keyUp (EnumSet<TickType> types, KeyBinding kb, boolean tickEnd)

--- a/mods/tinker/tconstruct/client/TProxyClient.java
+++ b/mods/tinker/tconstruct/client/TProxyClient.java
@@ -10,20 +10,62 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import mods.tinker.tconstruct.TConstruct;
-import mods.tinker.tconstruct.blocks.logic.*;
-import mods.tinker.tconstruct.client.block.*;
-import mods.tinker.tconstruct.client.entity.*;
-import mods.tinker.tconstruct.client.entity.projectile.*;
-import mods.tinker.tconstruct.client.gui.*;
-import mods.tinker.tconstruct.common.*;
-import mods.tinker.tconstruct.entity.*;
-import mods.tinker.tconstruct.entity.projectile.*;
-import mods.tinker.tconstruct.items.tools.*;
-import mods.tinker.tconstruct.library.*;
-import mods.tinker.tconstruct.library.client.*;
-import mods.tinker.tconstruct.library.crafting.*;
-import mods.tinker.tconstruct.library.tools.*;
-import mods.tinker.tconstruct.util.player.*;
+import mods.tinker.tconstruct.blocks.logic.CastingBasinLogic;
+import mods.tinker.tconstruct.blocks.logic.CastingTableLogic;
+import mods.tinker.tconstruct.blocks.logic.FrypanLogic;
+import mods.tinker.tconstruct.blocks.logic.GolemCoreLogic;
+import mods.tinker.tconstruct.blocks.logic.PartCrafterLogic;
+import mods.tinker.tconstruct.blocks.logic.PatternChestLogic;
+import mods.tinker.tconstruct.blocks.logic.PatternShaperLogic;
+import mods.tinker.tconstruct.blocks.logic.SmelteryLogic;
+import mods.tinker.tconstruct.blocks.logic.ToolStationLogic;
+import mods.tinker.tconstruct.client.block.CastingBasinSpecialRender;
+import mods.tinker.tconstruct.client.block.CastingTableSpecialRenderer;
+import mods.tinker.tconstruct.client.block.FluidRender;
+import mods.tinker.tconstruct.client.block.FrypanRender;
+import mods.tinker.tconstruct.client.block.GolemCoreRender;
+import mods.tinker.tconstruct.client.block.GolemCoreSpecialRender;
+import mods.tinker.tconstruct.client.block.OreberryRender;
+import mods.tinker.tconstruct.client.block.SearedRender;
+import mods.tinker.tconstruct.client.block.SmallFontRenderer;
+import mods.tinker.tconstruct.client.block.SmelteryRender;
+import mods.tinker.tconstruct.client.block.TableRender;
+import mods.tinker.tconstruct.client.block.TankRender;
+import mods.tinker.tconstruct.client.entity.CartRender;
+import mods.tinker.tconstruct.client.entity.CrystalRender;
+import mods.tinker.tconstruct.client.entity.FancyItemRender;
+import mods.tinker.tconstruct.client.entity.GolemRender;
+import mods.tinker.tconstruct.client.entity.SkylaRender;
+import mods.tinker.tconstruct.client.entity.SlimeRender;
+import mods.tinker.tconstruct.client.entity.projectile.DaggerRender;
+import mods.tinker.tconstruct.client.entity.projectile.LaunchedItemRender;
+import mods.tinker.tconstruct.client.gui.ArmorExtendedGui;
+import mods.tinker.tconstruct.client.gui.FrypanGui;
+import mods.tinker.tconstruct.client.gui.GuiManual;
+import mods.tinker.tconstruct.client.gui.InventoryTab;
+import mods.tinker.tconstruct.client.gui.PartCrafterGui;
+import mods.tinker.tconstruct.client.gui.PatternChestGui;
+import mods.tinker.tconstruct.client.gui.PatternShaperGui;
+import mods.tinker.tconstruct.client.gui.SmelteryGui;
+import mods.tinker.tconstruct.client.gui.ToolStationGui;
+import mods.tinker.tconstruct.common.TContent;
+import mods.tinker.tconstruct.common.TProxyCommon;
+import mods.tinker.tconstruct.entity.BlueSlime;
+import mods.tinker.tconstruct.entity.CartEntity;
+import mods.tinker.tconstruct.entity.Crystal;
+import mods.tinker.tconstruct.entity.FancyEntityItem;
+import mods.tinker.tconstruct.entity.GolemBase;
+import mods.tinker.tconstruct.entity.NitroCreeper;
+import mods.tinker.tconstruct.entity.Skyla;
+import mods.tinker.tconstruct.entity.projectile.DaggerEntity;
+import mods.tinker.tconstruct.entity.projectile.LaunchedPotion;
+import mods.tinker.tconstruct.items.tools.Dagger;
+import mods.tinker.tconstruct.library.TConstructRegistry;
+import mods.tinker.tconstruct.library.client.TConstructClientRegistry;
+import mods.tinker.tconstruct.library.client.ToolGuiElement;
+import mods.tinker.tconstruct.library.crafting.ToolBuilder;
+import mods.tinker.tconstruct.library.tools.ToolCore;
+import mods.tinker.tconstruct.util.player.ArmorExtended;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
@@ -63,7 +105,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Icon;
 import net.minecraft.world.World;
-import net.minecraftforge.client.MinecraftForgeClient;
 
 import org.w3c.dom.Document;
 
@@ -71,6 +112,7 @@ import com.google.common.collect.Lists;
 
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
+import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.registry.TickRegistry;
 import cpw.mods.fml.relauncher.Side;
 
@@ -123,7 +165,7 @@ public class TProxyClient extends TProxyCommon
     {
         if (mc == null)
             mc = Minecraft.getMinecraft();
-        if (mc.currentScreen.getClass() == GuiInventory.class)
+        if (mc.currentScreen.getClass() == GuiInventory.class || TControls.classMatches(mc.currentScreen, "micdoodle8.mods.galacticraft.core.client.gui.GCCoreGuiInventory"))
         {
             GuiInventory gui = (GuiInventory) mc.currentScreen;
             int cornerX = (gui.width - gui.xSize) / 2;


### PR DESCRIPTION
Hello!

Thought I would do this instead of asking for support, so here it is.

Since I use my own inventory extended from the vanilla one, this change is necessary to have the tabs show up while using galacticraft.
