### PR TITLE
Change checkSameLevel() to use block.isAirBlock instead of checking agai...

### DIFF
--- a/mods/tinker/tconstruct/blocks/logic/SmelteryLogic.java
+++ b/mods/tinker/tconstruct/blocks/logic/SmelteryLogic.java
@@ -576,6 +576,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
         {
             for (int zPos = z - 1; zPos <= z + 1; zPos++)
             {
+                Block block = Block.blocksList[worldObj.getBlockId(xPos, y, zPos)];
                 if (!block.isAirBlock(worldObj, xPos, y, zPos))
                     return false;
             }


### PR DESCRIPTION
...nst ID 0

Maybe this would fix the issue with railcraft tracking aura?
