### PR TITLE
Move gravel ore spawn earlier in biome decoration

### DIFF
--- a/mods/tinker/tconstruct/TConstruct.java
+++ b/mods/tinker/tconstruct/TConstruct.java
@@ -2,7 +2,6 @@ package mods.tinker.tconstruct;
 
 import mods.tinker.tconstruct.common.TContent;
 import mods.tinker.tconstruct.common.TProxyCommon;
-import mods.tinker.tconstruct.dimension.TinkerWorldProvider;
 import mods.tinker.tconstruct.library.SkillRegistry;
 import mods.tinker.tconstruct.library.TConstructRegistry;
 import mods.tinker.tconstruct.library.crafting.Detailing;
@@ -13,10 +12,10 @@ import mods.tinker.tconstruct.util.TCraftingHandler;
 import mods.tinker.tconstruct.util.TEventHandler;
 import mods.tinker.tconstruct.util.player.TPlayerHandler;
 import mods.tinker.tconstruct.worldgen.TBaseWorldGenerator;
+import mods.tinker.tconstruct.worldgen.TerrainGenEventHandler;
 import mods.tinker.tconstruct.worldgen.village.TVillageTrades;
 import mods.tinker.tconstruct.worldgen.village.VillageSmelteryHandler;
 import mods.tinker.tconstruct.worldgen.village.VillageToolStationHandler;
-import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.Init;
@@ -84,6 +83,7 @@ public class TConstruct
         proxy.registerKeys();
 
         GameRegistry.registerWorldGenerator(new TBaseWorldGenerator());
+        MinecraftForge.TERRAIN_GEN_BUS.register(new TerrainGenEventHandler());
         GameRegistry.registerFuelHandler(content);
         GameRegistry.registerCraftingHandler(new TCraftingHandler());
         NetworkRegistry.instance().registerGuiHandler(instance, proxy);

--- a/mods/tinker/tconstruct/worldgen/TBaseWorldGenerator.java
+++ b/mods/tinker/tconstruct/worldgen/TBaseWorldGenerator.java
@@ -1,12 +1,10 @@
 package mods.tinker.tconstruct.worldgen;
 
-import java.util.HashMap;
 import java.util.Random;
 
 import mods.tinker.tconstruct.common.TContent;
 import mods.tinker.tconstruct.crystal.TheftValueTracker;
 import mods.tinker.tconstruct.library.util.ValueCoordTuple;
-import mods.tinker.tconstruct.library.util.CoordTuple;
 import mods.tinker.tconstruct.util.PHConstruct;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -26,13 +24,6 @@ public class TBaseWorldGenerator implements IWorldGenerator
 
         cobalt = new WorldGenMinable(TContent.oreSlag.blockID, 1, 3, Block.netherrack.blockID);
         ardite = new WorldGenMinable(TContent.oreSlag.blockID, 2, 3, Block.netherrack.blockID);
-
-        ironSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 0, 12, true);
-        goldSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 1, 20, true);
-        copperSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 2, 12, true);
-        tinSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 3, 12, true);
-        aluminumSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 4, 12, true);
-        cobaltSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 5, 30, true);
 
         ironBush = new OreberryBushGen(TContent.oreBerry.blockID, 12, 12);
         goldBush = new OreberryBushGen(TContent.oreBerry.blockID, 13, 6);
@@ -77,16 +68,13 @@ public class TBaseWorldGenerator implements IWorldGenerator
 
     void generateSurface (Random random, int xChunk, int zChunk, World world)
     {
-        int xPos, yPos, zPos;
         String biomeName = world.getWorldChunkManager().getBiomeGenAt(xChunk, zChunk).biomeName;
 
         generateUndergroundOres(random, xChunk, zChunk, world);
-        generateSurfaceOres(random, xChunk, zChunk, world);
 
         if (biomeName == "Extreme Hills Edge" || biomeName == "Extreme Hills")
         {
             generateUndergroundOres(random, xChunk, zChunk, world);
-            generateSurfaceOres(random, xChunk, zChunk, world);
         }
     }
 
@@ -122,53 +110,6 @@ public class TBaseWorldGenerator implements IWorldGenerator
                 zPos = zChunk + random.nextInt(16);
                 aluminum.generate(world, random, xPos, yPos, zPos);
             }
-        }
-    }
-
-    void generateSurfaceOres (Random random, int xChunk, int zChunk, World world)
-    {
-        int xPos, yPos, zPos;
-        if (PHConstruct.generateIronSurface && random.nextInt(PHConstruct.ironsRarity) == 0)
-        {
-            xPos = xChunk + random.nextInt(16);
-            yPos = 64 + PHConstruct.seaLevel;
-            zPos = zChunk + random.nextInt(16);
-            ironSurface.generate(world, random, xPos, yPos, zPos);
-        }
-        if (PHConstruct.generateGoldSurface && random.nextInt(PHConstruct.goldsRarity) == 0)
-        {
-            xPos = xChunk + random.nextInt(16);
-            yPos = 64 + PHConstruct.seaLevel;
-            zPos = zChunk + random.nextInt(16);
-            goldSurface.generate(world, random, xPos, yPos, zPos);
-        }
-        if (PHConstruct.generateCopperSurface && random.nextInt(PHConstruct.coppersRarity) == 0)
-        {
-            xPos = xChunk + random.nextInt(16);
-            yPos = 64 + PHConstruct.seaLevel;
-            zPos = zChunk + random.nextInt(16);
-            copperSurface.generate(world, random, xPos, yPos, zPos);
-        }
-        if (PHConstruct.generateTinSurface && random.nextInt(PHConstruct.tinsRarity) == 0)
-        {
-            xPos = xChunk + random.nextInt(16);
-            yPos = 64 + PHConstruct.seaLevel;
-            zPos = zChunk + random.nextInt(16);
-            tinSurface.generate(world, random, xPos, yPos, zPos);
-        }
-        if (PHConstruct.generateAluminumSurface && random.nextInt(PHConstruct.aluminumsRarity) == 0)
-        {
-            xPos = xChunk + random.nextInt(16);
-            yPos = 64 + PHConstruct.seaLevel;
-            zPos = zChunk + random.nextInt(16);
-            aluminumSurface.generate(world, random, xPos, yPos, zPos);
-        }
-        if (PHConstruct.generateCobaltSurface && random.nextInt(PHConstruct.cobaltsRarity) == 0)
-        {
-            xPos = xChunk + random.nextInt(16);
-            yPos = 64 + PHConstruct.seaLevel;
-            zPos = zChunk + random.nextInt(16);
-            cobaltSurface.generate(world, random, xPos, yPos, zPos);
         }
     }
 
@@ -381,13 +322,6 @@ public class TBaseWorldGenerator implements IWorldGenerator
     WorldGenMinable aluminum;
     WorldGenMinable cobalt;
     WorldGenMinable ardite;
-
-    SurfaceOreGen ironSurface;
-    SurfaceOreGen goldSurface;
-    SurfaceOreGen copperSurface;
-    SurfaceOreGen tinSurface;
-    SurfaceOreGen aluminumSurface;
-    SurfaceOreGen cobaltSurface;
 
     OreberryBushGen ironBush;
     OreberryBushGen goldBush;

--- a/mods/tinker/tconstruct/worldgen/TerrainGenEventHandler.java
+++ b/mods/tinker/tconstruct/worldgen/TerrainGenEventHandler.java
@@ -1,0 +1,90 @@
+package mods.tinker.tconstruct.worldgen;
+
+import java.util.Random;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+
+import mods.tinker.tconstruct.common.TContent;
+import mods.tinker.tconstruct.util.PHConstruct;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.event.ForgeSubscribe;
+import static net.minecraft.world.biome.BiomeGenBase.extremeHills;
+import static net.minecraft.world.biome.BiomeGenBase.extremeHillsEdge;
+import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate;
+import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND;
+
+public class TerrainGenEventHandler
+{
+    private final SurfaceOreGen ironSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 0, 12, true);
+    private final SurfaceOreGen goldSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 1, 20, true);
+    private final SurfaceOreGen copperSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 2, 12, true);
+    private final SurfaceOreGen tinSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 3, 12, true);
+    private final SurfaceOreGen aluminumSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 4, 12, true);
+    private final SurfaceOreGen cobaltSurface = new SurfaceOreGen(TContent.oreGravel.blockID, 5, 30, true);
+
+    private static ImmutableCollection<BiomeGenBase> EXTRA_ORE_BIOMES = ImmutableList.of(extremeHills, extremeHillsEdge);
+
+    @ForgeSubscribe
+    public void onDecorateEvent(Decorate e)
+    {
+        // Trigger just before sand pass one--which comes just after vanilla ore generation.
+        if (e.type != SAND)
+            return;
+
+        BiomeGenBase biome = e.world.getWorldChunkManager().getBiomeGenAt(e.chunkX, e.chunkZ);
+        int iterations = EXTRA_ORE_BIOMES.contains(biome) ? 2 : 1;
+        for (int i = 0; i < iterations; i++)
+        {
+            generateSurfaceOres(e.rand, e.chunkX, e.chunkZ, e.world);
+        }
+    }
+
+    private void generateSurfaceOres (Random random, int xChunk, int zChunk, World world)
+    {
+        int xPos, yPos, zPos;
+        if (PHConstruct.generateIronSurface && random.nextInt(PHConstruct.ironsRarity) == 0)
+        {
+            xPos = xChunk + random.nextInt(16);
+            yPos = 64 + PHConstruct.seaLevel;
+            zPos = zChunk + random.nextInt(16);
+            ironSurface.generate(world, random, xPos, yPos, zPos);
+        }
+        if (PHConstruct.generateGoldSurface && random.nextInt(PHConstruct.goldsRarity) == 0)
+        {
+            xPos = xChunk + random.nextInt(16);
+            yPos = 64 + PHConstruct.seaLevel;
+            zPos = zChunk + random.nextInt(16);
+            goldSurface.generate(world, random, xPos, yPos, zPos);
+        }
+        if (PHConstruct.generateCopperSurface && random.nextInt(PHConstruct.coppersRarity) == 0)
+        {
+            xPos = xChunk + random.nextInt(16);
+            yPos = 64 + PHConstruct.seaLevel;
+            zPos = zChunk + random.nextInt(16);
+            copperSurface.generate(world, random, xPos, yPos, zPos);
+        }
+        if (PHConstruct.generateTinSurface && random.nextInt(PHConstruct.tinsRarity) == 0)
+        {
+            xPos = xChunk + random.nextInt(16);
+            yPos = 64 + PHConstruct.seaLevel;
+            zPos = zChunk + random.nextInt(16);
+            tinSurface.generate(world, random, xPos, yPos, zPos);
+        }
+        if (PHConstruct.generateAluminumSurface && random.nextInt(PHConstruct.aluminumsRarity) == 0)
+        {
+            xPos = xChunk + random.nextInt(16);
+            yPos = 64 + PHConstruct.seaLevel;
+            zPos = zChunk + random.nextInt(16);
+            aluminumSurface.generate(world, random, xPos, yPos, zPos);
+        }
+        if (PHConstruct.generateCobaltSurface && random.nextInt(PHConstruct.cobaltsRarity) == 0)
+        {
+            xPos = xChunk + random.nextInt(16);
+            yPos = 64 + PHConstruct.seaLevel;
+            zPos = zChunk + random.nextInt(16);
+            cobaltSurface.generate(world, random, xPos, yPos, zPos);
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue https://github.com/mDiyo/TinkersConstruct/issues/32

Moved gravel ore gen to generate after underground vanilla ores, but before any other biome decoration. Result is that gravel ore is now more integrated with terrain gen, covered with snow, etc.

:exclamation: NOTE; Gravel ores now appear more frequently because they are the first thing genned on the surface.  I recommend testing to make sure you are happy with the frequency.
