### PR TITLE
copy on insert, to avoid using an external object

### DIFF
--- a/mods/tinker/tconstruct/blocks/logic/SmelteryLogic.java
+++ b/mods/tinker/tconstruct/blocks/logic/SmelteryLogic.java
@@ -425,7 +425,7 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
         needsUpdate = true;
         if (moltenMetal.size() == 0)
         {
-            moltenMetal.add(liquid);
+            moltenMetal.add(liquid.copy());
             currentLiquid += liquid.amount;
             return true;
         }
@@ -454,9 +454,9 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
             if (!added)
             {
                 if (first)
-                    moltenMetal.add(0, liquid);
+                    moltenMetal.add(0, liquid.copy());
                 else
-                    moltenMetal.add(liquid);
+                    moltenMetal.add(liquid.copy());
             }
             return true;
         }


### PR DESCRIPTION
the copy is avoided if there is already some of the same liquid in the tank.
Without this patch after a fill(dir,resource,true); the callee changing resource (eg resource.amount=10;) modifies the internal contents of the smeltery.
