### PR TITLE
Incorrect meta value of SlimeGrass in SlimeIslandGen

### DIFF
--- a/tconstruct/blocks/slime/SlimeGrass.java
+++ b/tconstruct/blocks/slime/SlimeGrass.java
@@ -53,6 +53,12 @@ public class SlimeGrass extends Block
     @SideOnly(Side.CLIENT)
     public Icon getIcon (int side, int meta)
     {
+        // Worlds could have been generated with meta 2 instead of 1 due to a bug in tconstruct.worldgen.SlimeIslandGen
+        if (meta == 2)
+        {
+            meta = 1;
+        }
+
         if (side == 0)
         {
             return meta % 2 == 1 ? Block.dirt.getIcon(0, 0) : icons[1];

--- a/tconstruct/worldgen/SlimeIslandGen.java
+++ b/tconstruct/worldgen/SlimeIslandGen.java
@@ -252,7 +252,7 @@ public class SlimeIslandGen extends WorldGenerator implements IWorldGenerator
                     if (validLocations[(xPos * 16 + zPos) * 8 + yPos] && world.getBlockId(x + xPos, y + yPos - 1, z + zPos) == baseID
                             && world.getSavedLightValue(EnumSkyBlock.Sky, x + xPos, y + yPos, z + zPos) > 0)
                     {
-                        world.setBlock(x + xPos, y + yPos - 1, z + zPos, topID, 2, 0);
+                        world.setBlock(x + xPos, y + yPos - 1, z + zPos, topID, 1, 0);
                     }
                 }
             }


### PR DESCRIPTION
Playing Minecraft 1.6.2 with TConstruct 1.4.dev.27, I encountered the following crash:

```
java.lang.ArrayIndexOutOfBoundsException: 4
    at tconstruct.blocks.slime.SlimeGrass.func_71858_a(SlimeGrass.java:66)
    at net.minecraft.block.Block.func_71895_b(Block.java:548)
    at net.minecraft.client.renderer.RenderBlocks.func_94170_a(RenderBlocks.java:8162)
    at net.minecraft.client.renderer.RenderBlocks.func_78578_a(RenderBlocks.java:4730)
    at net.minecraft.client.renderer.RenderBlocks.func_78570_q(RenderBlocks.java:4174)
    at net.minecraft.client.renderer.RenderBlocks.func_78612_b(RenderBlocks.java:446)
    at net.minecraft.client.renderer.WorldRenderer.func_78907_a(WorldRenderer.java:224)
    at net.minecraft.client.renderer.RenderGlobal.func_72716_a(RenderGlobal.java:1574)
    at net.minecraft.client.renderer.EntityRenderer.func_78471_a(EntityRenderer.java:1129)
    at net.minecraft.client.renderer.EntityRenderer.func_78480_b(EntityRenderer.java:1002)
    at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:934)
    at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:826)
    at net.minecraft.client.main.Main.main(SourceFile:101)
```

Looking at TConstruct source, it seems like there's a typo in SlimeIslandGen - it sets the block to SlimeGrass with meta 2 instead of 1.
