### PR TITLE
Tinker and Blade 2: Warconstruct

### DIFF
--- a/src/mods/battlegear2/api/IArrowContainer.java
+++ b/src/mods/battlegear2/api/IArrowContainer.java
@@ -1,0 +1,55 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+@Deprecated
+public interface IArrowContainer{
+
+	/**
+	 * 
+	 * @param stack The {@link #ItemStack} representing this item
+	 * @param bow The bow trying to use this container
+	 * @param player The {@link #EntityPlayer} using the bow
+	 * @return true if the item contains at least one arrow
+	 */
+	public boolean hasArrowFor(ItemStack stack, ItemStack bow, EntityPlayer player);
+	/**
+	 * The arrow spawned when bow is used with this non empty container equipped
+	 * @param stack The {@link #ItemStack} representing this item
+	 * @param charge Amount of charge in the bow, ranging from 0.2F to 2.0F
+	 * @param player The {@link #EntityPlayer} using the bow
+	 * @param world 
+	 * @return the arrow entity to spawn when bow is used
+	 */
+	public EntityArrow getArrowType(ItemStack stack, World world, EntityPlayer player, float charge);
+	/**
+	 * Action to take after an arrow has been fired
+	 * Usually equal to removing an arrow from the container
+	 * @param player The {@link #EntityPlayer} using the bow
+	 * @param world 
+	 * @param stack The {@link #ItemStack} representing this item
+	 * @param bow The bow which fired
+	 * @param arrow the arrow fired
+	 */
+	public void onArrowFired(World world, EntityPlayer player, ItemStack stack, ItemStack bow, EntityArrow arrow);
+	/**
+	 * Called before the arrow is fired from this container
+	 * @param arrowEvent Used to decide bow damage, bow sound and arrow enchantment
+	 */
+	public void onPreArrowFired(QuiverArrowEvent arrowEvent);
+	/**
+	 * Called when the container is put on a crafting bench with vanilla arrows
+	 * @param stack
+	 * @return True to receive {@link #addArrows(ItemStack, int)}
+	 */
+	public boolean isCraftableWithArrows(ItemStack stack);
+	/**
+	 * Crafts the item with vanilla arrows
+	 * @param stack
+	 * @param arrows Number of vanilla arrows on the crafting bench
+	 * @return Number of vanilla arrows that couldn't fit in
+	 */
+	public int addArrows(ItemStack stack, int arrows);
+}

--- a/src/mods/battlegear2/api/IArrowContainer2.java
+++ b/src/mods/battlegear2/api/IArrowContainer2.java
@@ -1,0 +1,99 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public interface IArrowContainer2 {
+
+    /**
+     * Returns the maximum amout of slots in the arrow container
+     * @param container {@link #ItemStack} representing this item
+     * @return the amount of slots
+     */
+    public int getSlotCount(ItemStack container);
+
+    /**
+     * Returns the currently selected slot in the arrow container
+     * @param container {@link #ItemStack} representing this item
+     * @return the currently selected slot
+     */
+    public int getSelectedSlot(ItemStack container);
+
+    /**
+     * Sets the currently selected slot to the given value
+     * @param container {@link #ItemStack} representing this item
+     * @param newSlot the new slot index
+     */
+    public void setSelectedSlot(ItemStack container, int newSlot);
+
+    /**
+     * Returns the itemStack in the currently selected slot
+     * @param container The {@link #ItemStack} representing this item
+     * @param slot the slot index
+     * @return The {@link #ItemStack} in the given slot.
+     */
+    public ItemStack getStackInSlot(ItemStack container, int slot);
+
+    /**
+     * Sets places the given item stack in the give slot
+     * @param container {@link #ItemStack} representing this item
+     * @param slot the slot index
+     * @param container {@link #ItemStack} representing the new stack
+     */
+    public void setStackInSlot(ItemStack container, int slot, ItemStack stack);
+
+
+    /**
+     *
+     * @param container The {@link #ItemStack} representing this item
+     * @param bow The bow trying to use this container
+     * @param player The {@link #EntityPlayer} using the bow
+     * @return true if the item contains at least one arrow in the selected slot
+     */
+    public boolean hasArrowFor(ItemStack container, ItemStack bow, EntityPlayer player, int slot);
+
+    /**
+     * The arrow spawned when bow is used with this non empty container equipped
+     * @param container The {@link #ItemStack} representing this item
+     * @param charge Amount of charge in the bow, ranging from 0.2F to 2.0F
+     * @param player The {@link #EntityPlayer} using the bow
+     * @param world
+     * @return the arrow entity to spawn when bow is used
+     */
+    public EntityArrow getArrowType(ItemStack container, World world, EntityPlayer player, float charge);
+    /**
+     * Action to take after an arrow has been fired
+     * Usually equal to removing an arrow from the container
+     * @param player The {@link #EntityPlayer} using the bow
+     * @param world
+     * @param container The {@link #ItemStack} representing this item
+     * @param bow The bow which fired
+     * @param arrow the arrow fired
+     */
+    public void onArrowFired(World world, EntityPlayer player, ItemStack container, ItemStack bow, EntityArrow arrow);
+    /**
+     * Called before the arrow is fired from this container
+     * @param arrowEvent Used to decide bow damage, bow sound and arrow enchantment
+     */
+    public void onPreArrowFired(QuiverArrowEvent arrowEvent);
+    /**
+     * Called when the container is put on a crafting bench with other items
+     * @param container The {@link #ItemStack} representing this item
+     * @param arrowStack The {@link #ItemStack} representing other items
+     * @return True to receive {@link #addArrows(ItemStack, ItemStack)}
+     */
+    public boolean isCraftableWithArrows(ItemStack contaner, ItemStack arrowStack);
+
+    /**
+     * Crafts the item with the items from {@link #isCraftableWithArrows(ItemStack, ItemStack)}
+     * @param container The {@link #ItemStack} representing this item
+     * @param arrows Another valid item on the crafting bench
+     * @return Number of arrows that couldn't fit in
+     */
+    public ItemStack addArrows(ItemStack container, ItemStack newStack);
+
+
+
+}

--- a/src/mods/battlegear2/api/IBackStabbable.java
+++ b/src/mods/battlegear2/api/IBackStabbable.java
@@ -1,0 +1,14 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.EntityLivingBase;
+
+public interface IBackStabbable {
+
+	/**
+	 * Action to perform on back stabbing
+	 * @param entityHit
+	 * @param entityHitting
+     * @return true if it adds an hitting action
+	 */
+	public boolean onBackStab(EntityLivingBase entityHit, EntityLivingBase entityHitting);
+}

--- a/src/mods/battlegear2/api/IBattlegearWeapon.java
+++ b/src/mods/battlegear2/api/IBattlegearWeapon.java
@@ -1,0 +1,70 @@
+package mods.battlegear2.api;
+
+import cpw.mods.fml.relauncher.Side;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+public interface IBattlegearWeapon {
+
+    /**
+     * Returns true if the weapon will allow other weapons to be placed in the partner offhand slot
+     */
+    public boolean willAllowOffhandWeapon();
+
+    /**
+     * Will allow shield
+     */
+    public boolean willAllowShield();
+
+    /**
+     * Returns true if the weapon be dual wielded in the offhand slot
+     */
+    public boolean isOffhandHandDualWeapon();
+
+    /**
+     * Returns true if the weapon should always be sheathed on the back, false if it should be sheathed on the hip
+     */
+    public boolean sheatheOnBack();
+
+    /**
+     * Perform any function when the item is held in the offhand and the user right clicks an entity.
+     * This is generally used to attack an entity with the offhand item. If this is the case the event should
+     * be canceled to prevent any default right clicking events (Eg Villager Trading)
+     *
+     * @param event        the OffhandAttackEvent that was generated
+     * @param mainhandItem the ItemStack currently being held in the right hand
+     * @param offhandItem  the ItemStack currently being held in the left hand
+     * @return true if the off hand swing animation should be performed
+     */
+    public boolean offhandAttackEntity(OffhandAttackEvent event, ItemStack mainhandItem, ItemStack offhandItem);
+
+    /**
+     * Perform any function when the item is held in the offhand and the user right clicks "Air".
+     *
+     * @param event        the PlayerInteractEvent that was generated
+     * @param mainhandItem the ItemStack currently being held in the right hand
+     * @param offhandItem  the ItemStack currently being held in the left hand
+     * @return true if the off hand swing animation should be performed
+     */
+    public boolean offhandClickAir(PlayerInteractEvent event, ItemStack mainhandItem, ItemStack offhandItem);
+
+    /**
+     * Perform any function when the item is held in the offhand and the user right clicks a block.
+     * Note that this will happen prior to the activation of any activation functions of blocks
+     *
+     * @param event        the PlayerInteractEvent that was generated
+     * @param mainhandItem the ItemStack currently being held in the right hand
+     * @param offhandItem  the ItemStack currently being held in the left hand
+     */
+    public boolean offhandClickBlock(PlayerInteractEvent event, ItemStack mainhandItem, ItemStack offhandItem);
+
+    /**
+     * Perform any passive effects on each game tick when the item is held in the offhand
+     *
+     * @param effectiveSide the effective side the method was called from
+     * @param mainhandItem  the ItemStack currently being held in the right hand
+     * @param offhandItem   the ItemStack currently being held in the left hand
+     */
+    public void performPassiveEffects(Side effectiveSide, ItemStack mainhandItem, ItemStack offhandItem);
+
+}

--- a/src/mods/battlegear2/api/IDyable.java
+++ b/src/mods/battlegear2/api/IDyable.java
@@ -1,0 +1,31 @@
+package mods.battlegear2.api;
+
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+//This is a tempory fix until we get the heradry system up and running
+public interface IDyable {
+
+    /**
+     * Return whether the specified armor ItemStack has a color.
+     */
+    public boolean hasColor(ItemStack par1ItemStack);
+
+
+    /**
+     * Return the color for the specified armor ItemStack.
+     */
+    public int getColor(ItemStack par1ItemStack);
+
+    public void setColor(ItemStack dyable, int rgb);
+
+    /**
+     * Remove the color from the specified armor ItemStack.
+     */
+    public void removeColor(ItemStack par1ItemStack);
+
+    public int getDefaultColor(ItemStack par1ItemStack);
+
+
+}

--- a/src/mods/battlegear2/api/IExtendedReachWeapon.java
+++ b/src/mods/battlegear2/api/IExtendedReachWeapon.java
@@ -1,0 +1,12 @@
+package mods.battlegear2.api;
+
+import net.minecraft.item.ItemStack;
+
+public interface IExtendedReachWeapon {
+	/**
+	 * The distance the weapon will hit (note this will ONLY work for main hand weapons)
+	 * @param stack
+	 * @return
+	 */
+	public float getReachModifierInBlocks(ItemStack stack);
+}

--- a/src/mods/battlegear2/api/IHeraldyArmour.java
+++ b/src/mods/battlegear2/api/IHeraldyArmour.java
@@ -1,0 +1,11 @@
+package mods.battlegear2.api;
+
+
+import mods.battlegear2.heraldry.HeraldyPattern;
+
+public interface IHeraldyArmour extends IHeraldyItem{
+	
+	public String getBaseArmourPath(int armourSlot);
+
+    public String getPatternArmourPath(HeraldyPattern pattern, int armourSlot);
+}

--- a/src/mods/battlegear2/api/IHeraldyItem.java
+++ b/src/mods/battlegear2/api/IHeraldyItem.java
@@ -1,0 +1,77 @@
+package mods.battlegear2.api;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Icon;
+
+@Deprecated
+public interface IHeraldyItem {
+	
+	public enum HeraldyRenderPassess{
+		/**
+		 * The first render pass. This will use the items base icon coloured the primary colour
+		 */
+		PrimaryColourBase,
+		/**
+		 * The second render pass. This will use the selected pattern overlayed on top of the base icon with the apropriate colour
+		 */
+		SecondaryColourPattern,
+		/**
+		 * The third render pass. The sigil(s) will be rendered on top of the pattern in the apropriate positions
+		 */
+		Sigil,
+		/**
+		 * Fourth render pass. The items trim icon will be rendered in the secondady colour
+		 */
+		SecondaryColourTrim,
+		/**
+		 * Fifth Render pass, the Items post render icon will be rendered in the default colour
+		 */
+		PostRenderIcon
+	}
+	
+	/**
+	 * Returns the "base" icon. This icon will be coloured the primary colour
+	 */
+	public Icon getBaseIcon(ItemStack stack);
+	/**
+	 * Returns the trim icon, This will be coloured the secondary colour
+	 */
+	public Icon getTrimIcon(ItemStack stack);
+	/**
+	 * Returns the post render icon, this Icon will render after all other rendering passess in it's default colour
+	 */
+	public Icon getPostRenderIcon(ItemStack stack);
+	
+	
+	/**
+	 * Returns true if the given itemstack has heraldy attached
+	 */
+	public boolean hasHeraldry(ItemStack stack);
+	/**
+	 * Returns the current heraldy code, this will only be called on ItemStacks that have been found to have heraldrybackup using the hasHeraldryMethod
+	 */
+	public byte[] getHeraldryCode(ItemStack stack);
+	
+	/**
+	 * Saves the given heraldy code in the given stack. It is recommended to use the stacks NBT Tag compound for this
+	 */
+	public void setHeraldryCode(ItemStack stack, byte[] code);
+	
+	/**
+	 * Removes the heraldy code from the item
+	 */
+	public void removeHeraldry(ItemStack item);
+	
+	/**
+	 * Returns true if the default renderer should perform the given render pass
+	 */
+	public boolean shouldDoPass(HeraldyRenderPassess pass);
+	
+	/**
+	 * Returns true if the default renderer should be used. 
+	 * If the method returns true, the default renderer will be attached. 
+	 * If this method returns false it is the modders responsibility to attach an appropriate renderer
+	 */
+	public boolean useDefaultRenderer();
+
+}

--- a/src/mods/battlegear2/api/IHitTimeModifier.java
+++ b/src/mods/battlegear2/api/IHitTimeModifier.java
@@ -1,0 +1,15 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+public interface IHitTimeModifier {
+	/**
+	 * 
+	 * @param entityHit 
+	 * @return The amount to modify the hit shield
+	 */
+	public int getHitTime(ItemStack stack, EntityLivingBase entityHit);
+
+}

--- a/src/mods/battlegear2/api/IPenetrateWeapon.java
+++ b/src/mods/battlegear2/api/IPenetrateWeapon.java
@@ -1,0 +1,13 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+public interface IPenetrateWeapon {
+	/**
+	 * The amount of damage bypassing armor
+	 * @param stack The {@link net.minecraft.item.ItemStack} representative of the item dealing the hit.
+	 * @return the amount of damage that bypasses armour
+	 */
+	public int getPenetratingPower(ItemStack stack);
+}

--- a/src/mods/battlegear2/api/IPotionEffect.java
+++ b/src/mods/battlegear2/api/IPotionEffect.java
@@ -1,0 +1,23 @@
+package mods.battlegear2.api;
+
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.potion.PotionEffect;
+
+import java.util.Map;
+
+public interface IPotionEffect {
+
+
+    /**
+     * Returns a map containing the potion effects to apply to an entity hit by the weapon. Each effect
+     * has a float value associated with the chance of applying the effect. Note that the "dice roll" only
+     * occurs once so any value under this roll will be applied.
+     *
+     * @param entityHit The entity the effect will be applied to.
+     * @param entityHitting
+     * @return A Map of {@link PotionEffect} with chance value ranging from 0 to 1, to be dealt to the entityHit
+     */
+    public Map<PotionEffect,Float> getEffectsOnHit(EntityLivingBase entityHit, EntityLivingBase entityHitting);
+
+}

--- a/src/mods/battlegear2/api/IShield.java
+++ b/src/mods/battlegear2/api/IShield.java
@@ -1,0 +1,54 @@
+package mods.battlegear2.api;
+
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
+
+public interface IShield {
+
+    /**
+     * Gets the decay rate for the stamina bar when the shield is in use.
+     * The value should be between 0 and 1. The duration of maximum blocking can be calculated
+     * by 1/decayRate/20.
+     *
+     * @param shield The {@link #ItemStack} representing the shield
+     * @return a value between 0 & 1 representing the decay rate per tick
+     */
+    public float getDecayRate(ItemStack shield);
+
+    /**
+     * Returns true if the current shield can and should block the given damage source
+     *
+     * @param shield The {@link #ItemStack} representing the shield
+     * @param source The {@link #DamageSource} representing the current damage
+     * @return true if the shield can block the given damage type
+     */
+    public boolean canBlock(ItemStack shield, DamageSource source);
+
+    /**
+     * Gets the extra decay rate to the stamina bar when the shield is damaged
+     *
+     * @param shield The {@link #ItemStack} representing the shield
+     * @param amount The amount of damage the shield has absorbed
+     * @return a value between 0 & 1 representing the decay rate
+     */
+    public float getDamageDecayRate(ItemStack shield, float amount);
+
+    /**
+     * Returns the block angle in degrees that the shield can block.
+     * This angle is taken as 0 degrees being directly in front of the player. The shield
+     * will block between -blockAngle to blockangle
+     * @param shield The {@link #ItemStack} representing the shield
+     * @return The maximum angle the shield should be able to block at
+     */
+    public float getBlockAngle(ItemStack shield);
+
+
+    /**
+     * Returns the time a shield bash should take to be preformed. A shield bash will disallow actions
+     * for the number of ticks given and will knockback an oponent at time/2
+     *
+     * @return The amount of ticks the shield bash animation will play
+     */
+    public int getBashTimer(ItemStack shield);
+}

--- a/src/mods/battlegear2/api/ISpecialEffect.java
+++ b/src/mods/battlegear2/api/ISpecialEffect.java
@@ -1,0 +1,16 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.PotionEffect;
+
+public interface ISpecialEffect {
+	/**
+	 * 
+	 * @param entityHit The entity the effect will be applied to.
+	 * @param entityHitting
+	 * @return true if it adds an hitting action
+	 */
+    public boolean performEffects(EntityLivingBase entityHit, EntityLivingBase entityHitting);
+}

--- a/src/mods/battlegear2/api/OffhandAttackEvent.java
+++ b/src/mods/battlegear2/api/OffhandAttackEvent.java
@@ -1,0 +1,21 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.Entity;
+import net.minecraftforge.event.entity.player.EntityInteractEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+public class OffhandAttackEvent extends PlayerEventChild {
+
+    public boolean swingOffhand = true;
+    public boolean shouldAttack = true;
+    public EntityInteractEvent event;
+
+    public OffhandAttackEvent(EntityInteractEvent parent) {
+        super(parent);
+        this.event = parent;
+    }
+
+	public Entity getTarget() {
+        return event.target;
+    }
+}

--- a/src/mods/battlegear2/api/PlayerEventChild.java
+++ b/src/mods/battlegear2/api/PlayerEventChild.java
@@ -1,0 +1,32 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.Event.Result;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+public class PlayerEventChild extends PlayerEvent{
+
+	public PlayerEvent parent;
+
+	public PlayerEventChild(PlayerEvent parent) {
+		super(parent.entityPlayer);
+		this.parent = parent;
+	}
+
+    public void setCancelParentEvent(boolean cancel) {
+        parent.setCanceled(cancel);
+    }
+
+    @Override
+    public void setCanceled(boolean cancel) {
+        super.setCanceled(cancel);
+        parent.setCanceled(cancel);
+    }
+
+    @Override
+    public void setResult(Result value) {
+        super.setResult(value);
+        parent.setResult(value);
+    }
+}

--- a/src/mods/battlegear2/api/QuiverArrowEvent.java
+++ b/src/mods/battlegear2/api/QuiverArrowEvent.java
@@ -1,0 +1,29 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.ArrowLooseEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+public class QuiverArrowEvent extends PlayerEventChild{
+
+	public int bowDamage = 1;
+	public float bowSoundVolume = 1.0F;
+	public boolean addEnchantments = true;
+	public ArrowLooseEvent event;
+
+	public QuiverArrowEvent(ArrowLooseEvent parent) {
+		super(parent);
+		this.event = parent;
+	}
+
+	public ItemStack getBow()
+	{
+		return event.bow;
+	}
+	
+	public int getCharge()
+	{
+		return event.charge;
+	}
+}

--- a/src/mods/battlegear2/api/QuiverArrowRegistry.java
+++ b/src/mods/battlegear2/api/QuiverArrowRegistry.java
@@ -1,0 +1,42 @@
+package mods.battlegear2.api;
+
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.item.ItemStack;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class QuiverArrowRegistry {
+
+    private static Map<ItemStack,  Class<? extends EntityArrow>> map = new TreeMap<ItemStack,  Class<? extends EntityArrow>>(new StackComparator());
+
+    public static void addArrowToRegistry(int itemId, int itemMetadata, Class<? extends EntityArrow> entityArrow){
+        ItemStack stack = new ItemStack(itemId, 1, itemMetadata);
+        map.put(stack, entityArrow);
+    }
+
+    public static Class<? extends EntityArrow> getArrowClass(ItemStack stack){
+        return map.get(stack);
+    }
+
+    static class StackComparator implements Comparator<ItemStack> {
+        @Override
+        public int compare(ItemStack stack, ItemStack stack2) {
+
+            if(stack == stack2){
+                return 0;
+            }else{
+
+                int idDiff = stack.itemID - stack2.itemID;
+                if(idDiff != 0){
+                    return idDiff;
+                }else
+                    return stack.getItemDamage() - stack2.getItemDamage();
+            }
+
+        }
+    }
+
+
+}

--- a/src/mods/battlegear2/api/heraldry/HeraldryData.java
+++ b/src/mods/battlegear2/api/heraldry/HeraldryData.java
@@ -1,0 +1,138 @@
+package mods.battlegear2.api.heraldry;
+
+import mods.battlegear2.utils.BattlegearUtils;
+
+import java.io.*;
+import java.util.Arrays;
+
+public class HeraldryData {
+
+
+    public static final int RED = 1;
+    public static final int GREEN = 2;
+    public static final int BLUE = 3;
+
+    private byte pattern;
+    private short crest;
+    private byte crestPosition;
+    private int[] colours = new int[5];
+
+    private byte helm;
+    private byte banner;
+
+    private byte[] byteArray = null;
+
+    public HeraldryData(int pattern, int pattern_col_1, int pattern_col_2, int pattern_col_3, int crest, int crest_col_1, int crest_col_2, int crest_position, int helm, int banner) {
+        this.pattern = (byte) pattern;
+        this.crest = (short) crest;
+        colours = new int[]{pattern_col_1, pattern_col_2, pattern_col_3, crest_col_1, crest_col_2};
+        this.crestPosition = (byte) crest_position;
+        this.helm = (byte) helm;
+        this.banner = (byte) banner;
+    }
+
+    public HeraldryData(byte pattern, int pattern_col_1, int pattern_col_2, int pattern_col_3){
+        this(pattern, pattern_col_1, pattern_col_2, pattern_col_3, 0, 0, 0,0, 0, 0);
+    }
+
+    public HeraldryData(byte[] data){
+        DataInputStream input = null;
+
+        try{
+            input = new DataInputStream(new ByteArrayInputStream(data));
+
+            pattern = input.readByte();;
+            crest = input.readShort();
+            crestPosition = input.readByte();
+            colours= new int[5];
+            for(int i = 0; i < colours.length; i++){
+                colours[i] = input.readInt();
+            }
+
+            helm = input.readByte();
+            banner = input.readByte();
+
+            byteArray = Arrays.copyOf(data, data.length);
+
+        }catch (Exception e){
+            e.printStackTrace();
+        }finally {
+            BattlegearUtils.closeStream(input);
+        }
+    }
+
+    public static HeraldryData getDefault() {
+        return new HeraldryData(10, 0xFF000000, 0xFFFFFFFF, 0xFFFFFF00, 0, 0xFF000000, 0xFF000000, 0, 0, 0);
+    }
+
+    public byte[] getByteArray(){
+
+        if(byteArray != null){
+            return byteArray;
+        }
+
+        DataOutputStream output = null;
+
+        ByteArrayOutputStream bos = null;
+
+        try{
+            bos = new ByteArrayOutputStream();
+            output = new DataOutputStream(bos);
+
+            output.writeByte(pattern);
+            output.writeShort(crest);
+            output.writeByte(crestPosition);
+            for(int i = 0; i < 5; i++){
+                output.writeInt(colours[i]);
+            }
+
+            output.writeByte(helm);
+            output.writeByte(banner);
+
+            return bos.toByteArray();
+        } catch (Exception e){
+            e.printStackTrace();
+        } finally {
+            BattlegearUtils.closeStream(output);
+        }
+
+        return null;
+    }
+
+    public int getColourChanel(int colour, int chanelNo){
+        switch (chanelNo){
+            case RED:
+                return (colours[colour] >> 16) & 0xFF;
+            case GREEN:
+                return (colours[colour] >> 8) & 0xFF;
+            case BLUE:
+                return (colours[colour] >> 0) & 0xFF;
+            default:
+                return (colours[colour] >> 16) & 0xFF;
+        }
+    }
+
+    public byte getPattern() {
+        return pattern;
+    }
+
+    public int getColour(int i) {
+        return colours[i];
+    }
+
+    @Override
+    public String toString() {
+        return byteArrayToHex(getByteArray());
+    }
+
+    public static String byteArrayToHex(byte[] a) {
+        StringBuilder sb = new StringBuilder();
+        for(byte b: a)
+            sb.append(String.format("%02x", b&0xff));
+        return sb.toString();
+    }
+
+    public short getCrest() {
+        return crest;
+    }
+}

--- a/src/mods/battlegear2/api/heraldry/IHeraldryItem.java
+++ b/src/mods/battlegear2/api/heraldry/IHeraldryItem.java
@@ -1,0 +1,59 @@
+package mods.battlegear2.api.heraldry;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Icon;
+
+public interface IHeraldryItem {
+
+    public enum HeraldyRenderPassess{
+        Pattern,
+        SecondaryColourTrim,
+        PostRenderIcon
+    }
+
+    /**
+     * Returns the "base" icon. This icon will be coloured the primary colour
+     */
+    public Icon getBaseIcon(ItemStack stack);
+    /**
+     * Returns the trim icon, This will be coloured the secondary colour
+     */
+    public Icon getTrimIcon(ItemStack stack);
+    /**
+     * Returns the post render icon, this Icon will render after all other rendering passess in it's default colour
+     */
+    public Icon getPostRenderIcon(ItemStack stack);
+
+
+    /**
+     * Returns true if the given itemstack has heraldy attached
+     */
+    public boolean hasHeraldry(ItemStack stack);
+    /**
+     * Returns the current heraldy code, this will only be called on ItemStacks that have been found to have heraldry using the hasHeraldryMethod
+     */
+    public byte[] getHeraldry(ItemStack stack);
+
+    /**
+     * Saves the given heraldry code in the given stack. It is recommended to save the Byte array representation of the crest in the NBT
+     */
+    public void setHeraldry(ItemStack stack, byte[] data);
+
+    /**
+     * Removes the heraldry code from the item
+     */
+    public void removeHeraldry(ItemStack item);
+
+    /**
+     * Returns true if the default renderer should perform the given render pass
+     */
+    public boolean shouldDoPass(HeraldyRenderPassess pass);
+
+    /**
+     * Returns true if the default renderer should be used.
+     * If the method returns true, the default renderer will be attached.
+     * If this method returns false it is the modders responsibility to attach an appropriate renderer
+     */
+    public boolean useDefaultRenderer();
+
+}

--- a/src/mods/battlegear2/api/quiver/IArrowContainer.java
+++ b/src/mods/battlegear2/api/quiver/IArrowContainer.java
@@ -1,0 +1,55 @@
+package mods.battlegear2.api.quiver;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+@Deprecated
+public interface IArrowContainer{
+
+	/**
+	 * 
+	 * @param stack The {@link #ItemStack} representing this item
+	 * @param bow The bow trying to use this container
+	 * @param player The {@link #EntityPlayer} using the bow
+	 * @return true if the item contains at least one arrow
+	 */
+	public boolean hasArrowFor(ItemStack stack, ItemStack bow, EntityPlayer player);
+	/**
+	 * The arrow spawned when bow is used with this non empty container equipped
+	 * @param stack The {@link #ItemStack} representing this item
+	 * @param charge Amount of charge in the bow, ranging from 0.2F to 2.0F
+	 * @param player The {@link #EntityPlayer} using the bow
+	 * @param world 
+	 * @return the arrow entity to spawn when bow is used
+	 */
+	public EntityArrow getArrowType(ItemStack stack, World world, EntityPlayer player, float charge);
+	/**
+	 * Action to take after an arrow has been fired
+	 * Usually equal to removing an arrow from the container
+	 * @param player The {@link #EntityPlayer} using the bow
+	 * @param world 
+	 * @param stack The {@link #ItemStack} representing this item
+	 * @param bow The bow which fired
+	 * @param arrow the arrow fired
+	 */
+	public void onArrowFired(World world, EntityPlayer player, ItemStack stack, ItemStack bow, EntityArrow arrow);
+	/**
+	 * Called before the arrow is fired from this container
+	 * @param arrowEvent Used to decide bow damage, bow sound and arrow enchantment
+	 */
+	public void onPreArrowFired(QuiverArrowEvent arrowEvent);
+	/**
+	 * Called when the container is put on a crafting bench with vanilla arrows
+	 * @param stack
+	 * @return True to receive {@link #addArrows(ItemStack, int)}
+	 */
+	public boolean isCraftableWithArrows(ItemStack stack);
+	/**
+	 * Crafts the item with vanilla arrows
+	 * @param stack
+	 * @param arrows Number of vanilla arrows on the crafting bench
+	 * @return Number of vanilla arrows that couldn't fit in
+	 */
+	public int addArrows(ItemStack stack, int arrows);
+}

--- a/src/mods/battlegear2/api/quiver/IArrowContainer2.java
+++ b/src/mods/battlegear2/api/quiver/IArrowContainer2.java
@@ -1,0 +1,99 @@
+package mods.battlegear2.api.quiver;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public interface IArrowContainer2 {
+
+    /**
+     * Returns the maximum amout of slots in the arrow container
+     * @param container {@link #ItemStack} representing this item
+     * @return the amount of slots
+     */
+    public int getSlotCount(ItemStack container);
+
+    /**
+     * Returns the currently selected slot in the arrow container
+     * @param container {@link #ItemStack} representing this item
+     * @return the currently selected slot
+     */
+    public int getSelectedSlot(ItemStack container);
+
+    /**
+     * Sets the currently selected slot to the given value
+     * @param container {@link #ItemStack} representing this item
+     * @param newSlot the new slot index
+     */
+    public void setSelectedSlot(ItemStack container, int newSlot);
+
+    /**
+     * Returns the itemStack in the currently selected slot
+     * @param container The {@link #ItemStack} representing this item
+     * @param slot the slot index
+     * @return The {@link #ItemStack} in the given slot.
+     */
+    public ItemStack getStackInSlot(ItemStack container, int slot);
+
+    /**
+     * Sets places the given item stack in the give slot
+     * @param container {@link #ItemStack} representing this item
+     * @param slot the slot index
+     * @param container {@link #ItemStack} representing the new stack
+     */
+    public void setStackInSlot(ItemStack container, int slot, ItemStack stack);
+
+
+    /**
+     *
+     * @param container The {@link #ItemStack} representing this item
+     * @param bow The bow trying to use this container
+     * @param player The {@link #EntityPlayer} using the bow
+     * @return true if the item contains at least one arrow in the selected slot
+     */
+    public boolean hasArrowFor(ItemStack container, ItemStack bow, EntityPlayer player, int slot);
+
+    /**
+     * The arrow spawned when bow is used with this non empty container equipped
+     * @param container The {@link #ItemStack} representing this item
+     * @param charge Amount of charge in the bow, ranging from 0.2F to 2.0F
+     * @param player The {@link #EntityPlayer} using the bow
+     * @param world
+     * @return the arrow entity to spawn when bow is used
+     */
+    public EntityArrow getArrowType(ItemStack container, World world, EntityPlayer player, float charge);
+    /**
+     * Action to take after an arrow has been fired
+     * Usually equal to removing an arrow from the container
+     * @param player The {@link #EntityPlayer} using the bow
+     * @param world
+     * @param container The {@link #ItemStack} representing this item
+     * @param bow The bow which fired
+     * @param arrow the arrow fired
+     */
+    public void onArrowFired(World world, EntityPlayer player, ItemStack container, ItemStack bow, EntityArrow arrow);
+    /**
+     * Called before the arrow is fired from this container
+     * @param arrowEvent Used to decide bow damage, bow sound and arrow enchantment
+     */
+    public void onPreArrowFired(QuiverArrowEvent arrowEvent);
+    /**
+     * Called when the container is put on a crafting bench with other items
+     * @param container The {@link #ItemStack} representing this item
+     * @param arrowStack The {@link #ItemStack} representing other items
+     * @return True to receive {@link #addArrows(ItemStack, ItemStack)}
+     */
+    public boolean isCraftableWithArrows(ItemStack contaner, ItemStack arrowStack);
+
+    /**
+     * Crafts the item with the items from {@link #isCraftableWithArrows(ItemStack, ItemStack)}
+     * @param container The {@link #ItemStack} representing this item
+     * @param arrows Another valid item on the crafting bench
+     * @return Number of arrows that couldn't fit in
+     */
+    public ItemStack addArrows(ItemStack container, ItemStack newStack);
+
+
+
+}

--- a/src/mods/battlegear2/api/quiver/QuiverArrowEvent.java
+++ b/src/mods/battlegear2/api/quiver/QuiverArrowEvent.java
@@ -1,0 +1,30 @@
+package mods.battlegear2.api.quiver;
+
+import mods.battlegear2.api.PlayerEventChild;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.ArrowLooseEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+public class QuiverArrowEvent extends PlayerEventChild{
+
+	public int bowDamage = 1;
+	public float bowSoundVolume = 1.0F;
+	public boolean addEnchantments = true;
+	public ArrowLooseEvent event;
+
+	public QuiverArrowEvent(ArrowLooseEvent parent) {
+		super(parent);
+		this.event = parent;
+	}
+
+	public ItemStack getBow()
+	{
+		return event.bow;
+	}
+	
+	public int getCharge()
+	{
+		return event.charge;
+	}
+}

--- a/src/mods/battlegear2/api/quiver/QuiverArrowRegistry.java
+++ b/src/mods/battlegear2/api/quiver/QuiverArrowRegistry.java
@@ -1,0 +1,42 @@
+package mods.battlegear2.api.quiver;
+
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.item.ItemStack;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class QuiverArrowRegistry {
+
+    private static Map<ItemStack,  Class<? extends EntityArrow>> map = new TreeMap<ItemStack,  Class<? extends EntityArrow>>(new StackComparator());
+
+    public static void addArrowToRegistry(int itemId, int itemMetadata, Class<? extends EntityArrow> entityArrow){
+        ItemStack stack = new ItemStack(itemId, 1, itemMetadata);
+        map.put(stack, entityArrow);
+    }
+
+    public static Class<? extends EntityArrow> getArrowClass(ItemStack stack){
+        return map.get(stack);
+    }
+
+    static class StackComparator implements Comparator<ItemStack> {
+        @Override
+        public int compare(ItemStack stack, ItemStack stack2) {
+
+            if(stack == stack2){
+                return 0;
+            }else{
+
+                int idDiff = stack.itemID - stack2.itemID;
+                if(idDiff != 0){
+                    return idDiff;
+                }else
+                    return stack.getItemDamage() - stack2.getItemDamage();
+            }
+
+        }
+    }
+
+
+}

--- a/src/mods/battlegear2/api/weapons/IBackStabbable.java
+++ b/src/mods/battlegear2/api/weapons/IBackStabbable.java
@@ -1,0 +1,14 @@
+package mods.battlegear2.api.weapons;
+
+import net.minecraft.entity.EntityLivingBase;
+
+public interface IBackStabbable {
+
+	/**
+	 * Action to perform on back stabbing
+	 * @param entityHit
+	 * @param entityHitting
+     * @return true if it adds an hitting action
+	 */
+	public boolean onBackStab(EntityLivingBase entityHit, EntityLivingBase entityHitting);
+}

--- a/src/mods/battlegear2/api/weapons/IBattlegearWeapon.java
+++ b/src/mods/battlegear2/api/weapons/IBattlegearWeapon.java
@@ -1,0 +1,70 @@
+package mods.battlegear2.api.weapons;
+
+import cpw.mods.fml.relauncher.Side;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+public interface IBattlegearWeapon {
+
+    /**
+     * Returns true if the weapon will allow other weapons to be placed in the partner offhand slot
+     */
+    public boolean willAllowOffhandWeapon();
+
+    /**
+     * Will allow shield
+     */
+    public boolean willAllowShield();
+
+    /**
+     * Returns true if the weapon be dual wielded in the offhand slot
+     */
+    public boolean isOffhandHandDualWeapon();
+
+    /**
+     * Returns true if the weapon should always be sheathed on the back, false if it should be sheathed on the hip
+     */
+    public boolean sheatheOnBack();
+
+    /**
+     * Perform any function when the item is held in the offhand and the user right clicks an entity.
+     * This is generally used to attack an entity with the offhand item. If this is the case the event should
+     * be canceled to prevent any default right clicking events (Eg Villager Trading)
+     *
+     * @param event        the OffhandAttackEvent that was generated
+     * @param mainhandItem the ItemStack currently being held in the right hand
+     * @param offhandItem  the ItemStack currently being held in the left hand
+     * @return true if the off hand swing animation should be performed
+     */
+    public boolean offhandAttackEntity(OffhandAttackEvent event, ItemStack mainhandItem, ItemStack offhandItem);
+
+    /**
+     * Perform any function when the item is held in the offhand and the user right clicks "Air".
+     *
+     * @param event        the PlayerInteractEvent that was generated
+     * @param mainhandItem the ItemStack currently being held in the right hand
+     * @param offhandItem  the ItemStack currently being held in the left hand
+     * @return true if the off hand swing animation should be performed
+     */
+    public boolean offhandClickAir(PlayerInteractEvent event, ItemStack mainhandItem, ItemStack offhandItem);
+
+    /**
+     * Perform any function when the item is held in the offhand and the user right clicks a block.
+     * Note that this will happen prior to the activation of any activation functions of blocks
+     *
+     * @param event        the PlayerInteractEvent that was generated
+     * @param mainhandItem the ItemStack currently being held in the right hand
+     * @param offhandItem  the ItemStack currently being held in the left hand
+     */
+    public boolean offhandClickBlock(PlayerInteractEvent event, ItemStack mainhandItem, ItemStack offhandItem);
+
+    /**
+     * Perform any passive effects on each game tick when the item is held in the offhand
+     *
+     * @param effectiveSide the effective side the method was called from
+     * @param mainhandItem  the ItemStack currently being held in the right hand
+     * @param offhandItem   the ItemStack currently being held in the left hand
+     */
+    public void performPassiveEffects(Side effectiveSide, ItemStack mainhandItem, ItemStack offhandItem);
+
+}

--- a/src/mods/battlegear2/api/weapons/IExtendedReachWeapon.java
+++ b/src/mods/battlegear2/api/weapons/IExtendedReachWeapon.java
@@ -1,0 +1,12 @@
+package mods.battlegear2.api.weapons;
+
+import net.minecraft.item.ItemStack;
+
+public interface IExtendedReachWeapon {
+	/**
+	 * The distance the weapon will hit (note this will ONLY work for main hand weapons)
+	 * @param stack
+	 * @return
+	 */
+	public float getReachModifierInBlocks(ItemStack stack);
+}

--- a/src/mods/battlegear2/api/weapons/IHitTimeModifier.java
+++ b/src/mods/battlegear2/api/weapons/IHitTimeModifier.java
@@ -1,0 +1,15 @@
+package mods.battlegear2.api.weapons;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+public interface IHitTimeModifier {
+	/**
+	 * 
+	 * @param entityHit 
+	 * @return The amount to modify the hit shield
+	 */
+	public int getHitTime(ItemStack stack, EntityLivingBase entityHit);
+
+}

--- a/src/mods/battlegear2/api/weapons/IPenetrateWeapon.java
+++ b/src/mods/battlegear2/api/weapons/IPenetrateWeapon.java
@@ -1,0 +1,13 @@
+package mods.battlegear2.api.weapons;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+public interface IPenetrateWeapon {
+	/**
+	 * The amount of damage bypassing armor
+	 * @param stack The {@link net.minecraft.item.ItemStack} representative of the item dealing the hit.
+	 * @return the amount of damage that bypasses armour
+	 */
+	public int getPenetratingPower(ItemStack stack);
+}

--- a/src/mods/battlegear2/api/weapons/IPotionEffect.java
+++ b/src/mods/battlegear2/api/weapons/IPotionEffect.java
@@ -1,0 +1,23 @@
+package mods.battlegear2.api.weapons;
+
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.potion.PotionEffect;
+
+import java.util.Map;
+
+public interface IPotionEffect {
+
+
+    /**
+     * Returns a map containing the potion effects to apply to an entity hit by the weapon. Each effect
+     * has a float value associated with the chance of applying the effect. Note that the "dice roll" only
+     * occurs once so any value under this roll will be applied.
+     *
+     * @param entityHit The entity the effect will be applied to.
+     * @param entityHitting
+     * @return A Map of {@link PotionEffect} with chance value ranging from 0 to 1, to be dealt to the entityHit
+     */
+    public Map<PotionEffect,Float> getEffectsOnHit(EntityLivingBase entityHit, EntityLivingBase entityHitting);
+
+}

--- a/src/mods/battlegear2/api/weapons/ISpecialEffect.java
+++ b/src/mods/battlegear2/api/weapons/ISpecialEffect.java
@@ -1,0 +1,16 @@
+package mods.battlegear2.api.weapons;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.PotionEffect;
+
+public interface ISpecialEffect {
+	/**
+	 * 
+	 * @param entityHit The entity the effect will be applied to.
+	 * @param entityHitting
+	 * @return true if it adds an hitting action
+	 */
+    public boolean performEffects(EntityLivingBase entityHit, EntityLivingBase entityHitting);
+}

--- a/src/mods/battlegear2/api/weapons/OffhandAttackEvent.java
+++ b/src/mods/battlegear2/api/weapons/OffhandAttackEvent.java
@@ -1,0 +1,22 @@
+package mods.battlegear2.api.weapons;
+
+import mods.battlegear2.api.PlayerEventChild;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.event.entity.player.EntityInteractEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+public class OffhandAttackEvent extends PlayerEventChild {
+
+    public boolean swingOffhand = true;
+    public boolean shouldAttack = true;
+    public EntityInteractEvent event;
+
+    public OffhandAttackEvent(EntityInteractEvent parent) {
+        super(parent);
+        this.event = parent;
+    }
+
+	public Entity getTarget() {
+        return event.target;
+    }
+}

--- a/src/tconstruct/items/tools/Arrow.java
+++ b/src/tconstruct/items/tools/Arrow.java
@@ -225,4 +225,9 @@ public class Arrow extends ToolCore
             }
         }
     }
+    
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
 }

--- a/src/tconstruct/items/tools/Battleaxe.java
+++ b/src/tconstruct/items/tools/Battleaxe.java
@@ -300,4 +300,19 @@ public class Battleaxe extends HarvestTool
             world.playAuxSFX(2001, x, y, z, woodID + (meta << 12));
         return super.onBlockStartBreak(stack, x, y, z, player);
     }
+    
+	@Override
+	public boolean willAllowOffhandWeapon() {
+		return false;
+	}
+	
+	@Override
+	public boolean willAllowShield() {
+		return false;
+	}
+	
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
 }

--- a/src/tconstruct/items/tools/Broadsword.java
+++ b/src/tconstruct/items/tools/Broadsword.java
@@ -2,7 +2,12 @@ package tconstruct.items.tools;
 
 import tconstruct.common.TContent;
 import tconstruct.library.tools.Weapon;
+import mods.battlegear2.api.OffhandAttackEvent;
+import net.minecraft.item.EnumAction;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EntityDamageSource;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
 public class Broadsword extends Weapon
 {

--- a/src/tconstruct/items/tools/Chisel.java
+++ b/src/tconstruct/items/tools/Chisel.java
@@ -15,6 +15,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumMovingObjectType;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -226,4 +227,18 @@ public class Chisel extends ToolCore
         return new String[] { "utility" };
     }
 
+	@Override
+	public boolean willAllowOffhandWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean willAllowShield() {
+		return false;
+	}
+
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
 }

--- a/src/tconstruct/items/tools/Cleaver.java
+++ b/src/tconstruct/items/tools/Cleaver.java
@@ -3,6 +3,7 @@ package tconstruct.items.tools;
 import tconstruct.common.TContent;
 import tconstruct.library.tools.AbilityHelper;
 import tconstruct.library.tools.Weapon;
+import mods.battlegear2.api.weapons.OffhandAttackEvent;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -10,6 +11,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -161,4 +163,24 @@ public class Cleaver extends Weapon
         entity.swingProgressInt /= 2;
         return false;
     }*/
+    
+    @Override
+	public boolean willAllowOffhandWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean willAllowShield() {
+		return false;
+	}
+
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean sheatheOnBack() {
+		return true;
+	}
 }

--- a/src/tconstruct/items/tools/Cutlass.java
+++ b/src/tconstruct/items/tools/Cutlass.java
@@ -5,8 +5,12 @@ import java.util.List;
 import tconstruct.common.TContent;
 import tconstruct.library.tools.Weapon;
 
+import mods.battlegear2.api.OffhandAttackEvent;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EntityDamageSource;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 
 public class Cutlass extends Weapon
 {

--- a/src/tconstruct/items/tools/Excavator.java
+++ b/src/tconstruct/items/tools/Excavator.java
@@ -293,4 +293,24 @@ public class Excavator extends HarvestTool
         }
         return super.getStrVsBlock(stack, block, meta);
     }
+    
+    @Override
+	public boolean willAllowOffhandWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean willAllowShield() {
+		return false;
+	}
+
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean sheatheOnBack() {
+		return true;
+	}
 }

--- a/src/tconstruct/items/tools/Hammer.java
+++ b/src/tconstruct/items/tools/Hammer.java
@@ -399,4 +399,24 @@ public class Hammer extends HarvestTool
     {
         return new String[] { "weapon", "harvest", "melee", "bludgeoning" };
     }
+    
+    @Override
+	public boolean willAllowOffhandWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean willAllowShield() {
+		return false;
+	}
+
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean sheatheOnBack() {
+		return true;
+	}
 }

--- a/src/tconstruct/items/tools/Hatchet.java
+++ b/src/tconstruct/items/tools/Hatchet.java
@@ -104,4 +104,9 @@ public class Hatchet extends HarvestTool
     {
         return "axe";
     }
+    
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
 }

--- a/src/tconstruct/items/tools/Longsword.java
+++ b/src/tconstruct/items/tools/Longsword.java
@@ -10,6 +10,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -140,4 +141,9 @@ public class Longsword extends Weapon
     {
         return "longsword";
     }
+    
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
 }

--- a/src/tconstruct/items/tools/LumberAxe.java
+++ b/src/tconstruct/items/tools/LumberAxe.java
@@ -400,4 +400,24 @@ public class LumberAxe extends HarvestTool
     {
         return 1;
     }
+    
+    @Override
+	public boolean willAllowOffhandWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean willAllowShield() {
+		return false;
+	}
+
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean sheatheOnBack() {
+		return true;
+	}
 }

--- a/src/tconstruct/items/tools/Mattock.java
+++ b/src/tconstruct/items/tools/Mattock.java
@@ -140,4 +140,24 @@ public class Mattock extends DualHarvestTool
         }
         return true;
     }
+    
+    @Override
+	public boolean willAllowOffhandWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean willAllowShield() {
+		return false;
+	}
+
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean sheatheOnBack() {
+		return true;
+	}
 }

--- a/src/tconstruct/items/tools/Pickaxe.java
+++ b/src/tconstruct/items/tools/Pickaxe.java
@@ -68,4 +68,9 @@ public class Pickaxe extends HarvestTool
     {
         return "pickaxe";
     }
+    
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
 }

--- a/src/tconstruct/items/tools/Scythe.java
+++ b/src/tconstruct/items/tools/Scythe.java
@@ -218,4 +218,23 @@ public class Scythe extends Weapon
         return true;
     }
 
+    @Override
+	public boolean willAllowOffhandWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean willAllowShield() {
+		return false;
+	}
+
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean sheatheOnBack() {
+		return true;
+	}
 }

--- a/src/tconstruct/items/tools/Shortbow.java
+++ b/src/tconstruct/items/tools/Shortbow.java
@@ -191,4 +191,24 @@ public class Shortbow extends BowBase
         }
         //return TConstructRegistry.getMaterial(type).ability();
     }
+    
+    @Override
+	public boolean willAllowOffhandWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean willAllowShield() {
+		return false;
+	}
+
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
+
+	@Override
+	public boolean sheatheOnBack() {
+		return true;
+	}
 }

--- a/src/tconstruct/items/tools/Shovel.java
+++ b/src/tconstruct/items/tools/Shovel.java
@@ -89,6 +89,11 @@ public class Shovel extends HarvestTool
     {
         return "shovel";
     }
+    
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return false;
+	}
 
     /*@Override
     public Icon getIcon (ItemStack stack, int renderPass)

--- a/src/tconstruct/library/tools/ToolCore.java
+++ b/src/tconstruct/library/tools/ToolCore.java
@@ -13,6 +13,8 @@ import tconstruct.library.ActiveToolMod;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.ToolBuilder;
 
+import mods.battlegear2.api.weapons.IBattlegearWeapon;
+import mods.battlegear2.api.weapons.OffhandAttackEvent;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.creativetab.CreativeTabs;
@@ -26,6 +28,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.Icon;
 import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -55,7 +58,7 @@ import cpw.mods.fml.relauncher.SideOnly;
  * @see ToolMod
  */
 
-public abstract class ToolCore extends Item implements ICustomElectricItem, IBoxable
+public abstract class ToolCore extends Item implements ICustomElectricItem, IBoxable, IBattlegearWeapon
 {
     protected Random random = new Random();
     protected int damageVsEntity;
@@ -937,4 +940,47 @@ public abstract class ToolCore extends Item implements ICustomElectricItem, IBox
         return tags.getCompoundTag("InfiTool").getInteger("Damage");
     }
 
+
+	@Override
+	public boolean willAllowOffhandWeapon() {
+		return true;
+	}
+
+	@Override
+	public boolean willAllowShield() {
+		return true;
+	}
+
+	@Override
+	public boolean isOffhandHandDualWeapon() {
+		return true;
+	}
+
+	@Override
+	public boolean sheatheOnBack() {
+		return false;
+	}
+
+	@Override
+	public boolean offhandAttackEntity(OffhandAttackEvent event,
+			ItemStack mainhandItem, ItemStack offhandItem) {
+		return true;
+	}
+
+	@Override
+	public boolean offhandClickAir(PlayerInteractEvent event,
+			ItemStack mainhandItem, ItemStack offhandItem) {
+		return true;
+	}
+
+	@Override
+	public boolean offhandClickBlock(PlayerInteractEvent event,
+			ItemStack mainhandItem, ItemStack offhandItem) {
+		return true;
+	}
+
+	@Override
+	public void performPassiveEffects(Side effectiveSide,
+			ItemStack mainhandItem, ItemStack offhandItem) {		
+	}
 }

--- a/src/tconstruct/library/tools/Weapon.java
+++ b/src/tconstruct/library/tools/Weapon.java
@@ -125,4 +125,6 @@ public abstract class Weapon extends ToolCore
 
     public static Material[] web = new Material[] { Material.web };
     public static Material[] none = new Material[0];
+    
+    
 }


### PR DESCRIPTION
"Tools" can only go into the right hand slot. Longswords, due to encumbrance from size, can only go into the main hand. Bows, Chisels, Mattocks, and all Tier-2 tools are considered "two-handed"; they cannot have a sub weapon and must be equipped into the main hand. Bows because arrows+realism ho! Chisels and Mattocks because they only operate on right-click as tool. Also realism. Hard to chisel prettyness with a sword in your other hand, right? Also, hoeing the ground with one hand is hard. Tier 2 are two-handed because they're all "larger" than your average tool

Still needs a bit of tweaking, and there's a bug where using a tinkertool in the
left hand shifts the selected battlegear slot over by 3. Attached is an example of said bug
![2013-09-10_09 29 28](https://f.cloud.github.com/assets/2984910/1115068/e45b68a2-1a24-11e3-93cf-9e21ca2e0469.png)
