### PR TITLE
Fixed leaf fletching dup

### DIFF
--- a/src/tconstruct/blocks/logic/PartBuilderLogic.java
+++ b/src/tconstruct/blocks/logic/PartBuilderLogic.java
@@ -61,8 +61,6 @@ public class PartBuilderLogic extends InventoryLogic implements ISidedInventory
             if (!craftedTop && inventory[0] != null)
             {
                 int value = PatternBuilder.instance.getPartValue(inventory[2]);
-                if (value == 0) /* hack to plug up future dups */
-                    value = 2;
                 IPattern item = (IPattern) inventory[0].getItem();
                 int cost = item != null ? item.getPatternCost(inventory[0]) : 0;
                 if (value > 0 && cost > 0)


### PR DESCRIPTION
The Issue was that only vanilla oak leaves were registered. I used a for loop to register all four vanilla leaves.
If you want to use leaves from other mods, try some kind of leaf dictionary.

There's a little hack that could prevent future dupes. You can remove it if you want.

https://github.com/mDiyo/TinkersConstruct/issues/110

Fixes the above
