### PR TITLE
Moved the adding to the ore dict to the init and the checking of ore dict to postInit

### DIFF
--- a/src/tconstruct/TConstruct.java
+++ b/src/tconstruct/TConstruct.java
@@ -100,9 +100,7 @@ public class TConstruct
         content = new TContent();
 
         events = new TEventHandler();
-        events.unfuxOreDictionary();
         MinecraftForge.EVENT_BUS.register(events);
-        content.oreRegistry();
 
         proxy.registerRenderer();
         proxy.registerTickHandler();
@@ -138,6 +136,7 @@ public class TConstruct
             MinecraftForge.EVENT_BUS.register(new EventCloakRender());
         }
 
+        content.oreRegistry();
         content.intermodCommunication();
         Tforest.initProps(PHConstruct.cfglocation);
         BOP.initProps(PHConstruct.cfglocation);
@@ -148,6 +147,7 @@ public class TConstruct
     @EventHandler
     public void postInit(FMLPostInitializationEvent evt)
     {
+        events.unfuxOreDictionary();
         Behavior.registerBuiltInBehaviors();
         SpecialStackHandler.registerBuiltInStackHandlers();
         content.modIntegration();


### PR DESCRIPTION
Cause according to http://www.minecraftforge.net/wiki/How_to_use_the_ore_dictionary additions to the ore dict go to init and from that I assume you want to pull the data after every mod has registered everything it has to so the checking is in postInit.
