### PR TITLE
Bad casting recipe, no cookie.

### DIFF
--- a/src/tconstruct/common/TContent.java
+++ b/src/tconstruct/common/TContent.java
@@ -1282,8 +1282,8 @@ public class TContent implements IFuelHandler
 
                 for (int iterTwo = 0; iterTwo < liquids.length; iterTwo++)
                 {
-                    ItemStack metalCast = new ItemStack(patternOutputs[iter], 1, liquidDamage[iterTwo]);
-                    tableCasting.addCastingRecipe(metalCast, new FluidStack(liquids[iterTwo].getFluid(), ((IPattern) metalPattern).getPatternCost(metalCast) * TConstruct.ingotLiquidValue / 2), cast,
+                    ItemStack outputItem = new ItemStack(patternOutputs[iter], 1, liquidDamage[iterTwo]);
+                    tableCasting.addCastingRecipe(outputItem, new FluidStack(liquids[iterTwo].getFluid(), ((IPattern) metalPattern).getPatternCost(cast) * TConstruct.ingotLiquidValue / 2), cast,
                             50);
                 }
             }


### PR DESCRIPTION
When adding the casting recipes for metal tool parts, the liquid metal quantity is produced from the calculation `IPattern.getPatternCost(ItemStack) * ingotInMillibuckets / 2`. However, the ItemStack provided to getPatternCost is supposed to be an ItemStack containing the pattern (in this case, the cast), **not** an ItemStack containing the tool part.

Also, the name "metalCast" for what is obviously the actual output item (e.g. pickaxe head) is kind of silly. Let's fix that.
