### PR TITLE
Molten Electrum Localization

### DIFF
--- a/resources/assets/tinker/lang/en_US.lang
+++ b/resources/assets/tinker/lang/en_US.lang
@@ -437,7 +437,7 @@ tile.metal.molten.silver.name=Molten Silver
 tile.metal.molten.lead.name=Molten Lead
 tile.metal.molten.shiny.name=Molten Shiny
 tile.metal.molten.invar.name=Molten Invar
-tile.metal.molten.Electrum.name=Molten Electrum
+tile.metal.molten.electrum.name=Molten Electrum
 tile.fluid.ender.name=Liquified Ender
 tile.liquid.slime.name=Liquified Slime
 
@@ -562,6 +562,7 @@ fluid.lead.molten=Molten Lead
 fluid.silver.molten=Molten Silver
 fluid.platinum.molten=Molten Platinum
 fluid.invar=Molten Invar
+fluid.electrum.molten=Molten Electrum
 fluid.shiny=Molten Shiny
 fluid.ender=Liquid Ender
 fluid.slime.blue=Liquid Blueslime


### PR DESCRIPTION
Added localiztion for "fluid.electrum.molten", which I think it missed because it was confused with "fluid.platinum.molten" (it's the only localization for Molten Platinum, while electrum is the only missing) and i would deleat it if you give me the permision.
Also changed tile.metal.molten.electrum.name
