### PR TITLE
Fixed scythe head icon on the 2nd manual

### DIFF
--- a/resources/assets/tinker/manuals/materials.xml
+++ b/resources/assets/tinker/manuals/materials.xml
@@ -360,7 +360,7 @@ Class: Broad Melee Weapon</text>
 <icon>scytheicon</icon>
 <item>
  <text>Scythe Head</text>
- <icon>excavatorhead</icon>
+ <icon>scythehead</icon>
 </item>
 <item>
  <text>Tough Rod</text>


### PR DESCRIPTION
http://www.minecraftforum.net/topic/1659892-164tinkers-construct/page__st__6700

RichardJCox:

Second (minor): That isn't a scythe part in book 2:
