### PR TITLE
Update ANT script so that TCon 1.6.4 will build properly.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -18,8 +18,8 @@
     <property name="mcpsrc.dir" value="${mcp.dir}/src"/>
 
     <property name="mc.version" value="1.6.4"/>
-    <property name="forge.version" value="9.11.0.880"/>
-    <property name="forge.name" value="minecraftforge-src-${mc.version}-${forge.version}.zip"/>
+    <property name="forge.version" value="9.11.1.953"/>
+    <property name="forge.name" value="forge-${mc.version}-${forge.version}-src.zip"/>
 
     <available property="forge-exists" file="${download.dir}/${forge.name}"/>
     <available file=".git" type="dir" property="git.present"/>
@@ -39,11 +39,11 @@
     <property name="build.dependencies.file" value="${build.dir}/dependencies.properties" />
     <property name="ccl.version" value="1.0.0.36" />
     <property name="fmp.version" value="1.0.0.182" />
-    <property name="nei.version" value="1.6.1.5_d1" />
+    <property name="nei.version" value="1.6.1.7" />
 
     <property name="ccl.name" value="CodeChickenLib-dev-${mc.version}-${ccl.version}.jar" />
     <property name="fmp.name" value="ForgeMultipart-dev-${mc.version}-${fmp.version}.jar" />
-    <property name="nei.name" value="NotEnoughItems-dev%20${nei.version}.jar" />
+    <property name="nei.name" value="NotEnoughItems%20${nei.version}.jar" />
     <available property="fmp-downloaded" file="${download.dir}/${fmp.name}" />
     <available property="ccl-downloaded" file="${download.dir}/${ccl.name}" />
     <available property="nei-downloaded" file="${download.dir}/${nei.name}" />
@@ -158,7 +158,7 @@
 
     <!-- Download forge (if it doesn't exist) -->
     <target name="download-forge" unless="forge-exists">
-        <get src="http://files.minecraftforge.net/${forge.name}" dest="${download.dir}" usetimestamp="True"/>
+        <get src="http://files.minecraftforge.net/maven/net/minecraftforge/forge/${mc.version}-${forge.version}/${forge.name}" dest="${download.dir}" usetimestamp="True"/>
     </target>
 
     <!-- Setup mcp and forge -->


### PR DESCRIPTION
Updated to build with Forge #953, which has fixed the library download issues and is the last recommended build for 1.6.4.
Also update NEI building to 1.6.1.7, as it has an actual download link up, unlike the past version.

There are a lot of warnings about deprecated code when building, probably having to do with the code between 880 and 953, that's 73 builds after all!
