### PR TITLE
Allow more creative builder message suppression

### DIFF
--- a/src/tconstruct/items/tools/Arrow.java
+++ b/src/tconstruct/items/tools/Arrow.java
@@ -105,8 +105,11 @@ public class Arrow extends ToolCore
         ItemStack tool = ToolBuilder.instance.buildTool(new ItemStack(getHeadItem(), 1, 3), new ItemStack(getHandleItem(), 1, 0), accessoryStack, extraStack, "");
         if (tool == null)
         {
-            TConstruct.logger.warning("Creative builder failed tool for Vanilla style" + this.getToolName());
-            TConstruct.logger.warning("Make sure you do not have item ID conflicts");
+            if (!TContent.supressMissingToolLogs)
+            {
+	            TConstruct.logger.warning("Creative builder failed tool for Vanilla style" + this.getToolName());
+	            TConstruct.logger.warning("Make sure you do not have item ID conflicts");
+            }
         }
         else
         {
@@ -150,8 +153,11 @@ public class Arrow extends ToolCore
         ItemStack tool = ToolBuilder.instance.buildTool(new ItemStack(getHeadItem(), 1, id), new ItemStack(getHandleItem(), 1, id), accessoryStack, extraStack, name + getToolName());
         if (tool == null)
         {
-            TConstruct.logger.warning("Creative builder failed tool for " + name + this.getToolName());
-            TConstruct.logger.warning("Make sure you do not have item ID conflicts");
+            if (!TContent.supressMissingToolLogs)
+            {
+	            TConstruct.logger.warning("Creative builder failed tool for " + name + this.getToolName());
+	            TConstruct.logger.warning("Make sure you do not have item ID conflicts");
+            }
         }
         else
         {

--- a/src/tconstruct/library/tools/ToolCore.java
+++ b/src/tconstruct/library/tools/ToolCore.java
@@ -579,8 +579,10 @@ public abstract class ToolCore extends Item implements IEnergyContainerItem, ICu
                 e.printStackTrace();
             }
             if (!supress)
+            {
                 TConstructRegistry.logger.severe("Creative builder failed tool for " + name + this.getToolName());
-            TConstructRegistry.logger.severe("Make sure you do not have item ID conflicts");
+                TConstructRegistry.logger.severe("Make sure you do not have item ID conflicts");
+            }
         }
         else
         {


### PR DESCRIPTION
Just put a few more if wrappers around some of the creative builder error messages, so that they can be suppressed
