### PR TITLE
Use left_height from GuiInGameForge for compat

### DIFF
--- a/src/tconstruct/client/TClientEvents.java
+++ b/src/tconstruct/client/TClientEvents.java
@@ -88,8 +88,6 @@ public class TClientEvents
 
     private static final ResourceLocation hearts = new ResourceLocation("tinker", "textures/gui/newhearts.png");
     private static final ResourceLocation icons = new ResourceLocation("textures/gui/icons.png");
-    public static int left_height = 39;
-    public static int right_height = 39;
     Random rand = new Random();
     int updateCounter = 0;
 
@@ -131,7 +129,7 @@ public class TClientEvents
                 this.rand.setSeed((long) (updateCounter * 312871));
 
                 int left = scaledWidth / 2 - 91;
-                int top = scaledHeight - left_height;
+                int top = scaledHeight - GuiIngameForge.left_height;
 
                 int regen = -1;
                 if (mc.thePlayer.isPotionActive(Potion.regeneration))


### PR DESCRIPTION
Just changing the health bar rendering code to use the left_height from GuiInGameForge, so that if a custom left height is used, it is compatible.  Rather than declaring and using a private version.  The variable is static, so no reason not to use it.  
