### PR TITLE
[Bug] "SkullOwner" tag on player heads (Fix included)

### DIFF
--- a/src/main/java/tconstruct/util/TEventHandler.java
+++ b/src/main/java/tconstruct/util/TEventHandler.java
@@ -414,6 +414,7 @@ public class TEventHandler
                 ItemStack dropStack = new ItemStack(Item.skull.itemID, 1, 3);
                 NBTTagCompound nametag = new NBTTagCompound();
                 nametag.setString("SkullOwner", player.username);
+                dropStack.setTagCompound(nametag);
                 addDrops(event, dropStack);
             }
 
@@ -431,6 +432,7 @@ public class TEventHandler
                         ItemStack dropStack = new ItemStack(Item.skull.itemID, 1, 3);
                         NBTTagCompound nametag = new NBTTagCompound();
                         nametag.setString("SkullOwner", player.username);
+                        dropStack.setTagCompound(nametag);
                         addDrops(event, dropStack);
                     }
                 }


### PR DESCRIPTION
The "SkullOwner" NBT tag was getting created but never actached to the itemstack.
