### PR TITLE
Add FlenixCities Food support to Jerky

### DIFF
--- a/src/main/java/tconstruct/common/TContent.java
+++ b/src/main/java/tconstruct/common/TContent.java
@@ -648,8 +648,13 @@ public class TContent implements IFuelHandler
         GameRegistry.registerItem(TRepo.diamondApple, "diamondApple");
         GameRegistry.registerItem(TRepo.strangeFood, "strangeFood");
         GameRegistry.registerItem(TRepo.oreBerries, "oreBerries");
-
-        TRepo.jerky = new Jerky(Loader.isModLoaded("HungerOverhaul")).setUnlocalizedName("tconstruct.jerky");
+        
+        boolean foodOverhaul;
+        if (Loader.isModLoaded("HungerOverhaul") || Loader.isModLoaded("fc_food")) {
+        	foodOverhaul = true;
+        }
+        
+        TRepo.jerky = new Jerky(foodOverhaul).setUnlocalizedName("tconstruct.jerky");
         GameRegistry.registerItem(TRepo.jerky, "jerky");
 
         //Wearables


### PR DESCRIPTION
Very minor tweak. Simply changed it so that if FlenixCitiesFood is found, it'll do exactly the same thing it does if Hunger Overhaul is found.
