### PR TITLE
Lets try this again...

### DIFF
--- a/src/main/java/tconstruct/common/TContent.java
+++ b/src/main/java/tconstruct/common/TContent.java
@@ -967,7 +967,12 @@ public class TContent implements IFuelHandler
         GameRegistry.registerItem(strangeFood, "strangeFood");
         GameRegistry.registerItem(oreBerries, "oreBerries");
 
-        jerky = new Jerky(PHConstruct.jerky, Loader.isModLoaded("HungerOverhaul")).setUnlocalizedName("tconstruct.jerky");
+        boolean foodOverhaul = false;
+        if (Loader.isModLoaded("HungerOverhaul") || Loader.isModLoaded("fc_food")) {
+            foodOverhaul = true;
+        }
+        
+        jerky = new Jerky(PHConstruct.jerky, foodOverhaul).setUnlocalizedName("tconstruct.jerky");
         GameRegistry.registerItem(jerky, "jerky");
 
         //Wearables


### PR DESCRIPTION
Figured out what went wrong. 1.6 had an ID declared for Jerky whereas 1.7 didn't (obviously), so I'd accidentally removed it with my nooby copy-paste of 1.7 to 1.6.
Should compile OK this time. Also fixed the foodOverhaul to default to false so if the mods aren't detected, Jerky works as normal.
