### PR TITLE
Fixes the hammer mining level of adjacent blocks

### DIFF
--- a/src/main/java/tconstruct/items/tools/Hammer.java
+++ b/src/main/java/tconstruct/items/tools/Hammer.java
@@ -294,7 +294,7 @@ public class Hammer extends HarvestTool
                         int localblockID = world.getBlockId(xPos, yPos, zPos);
                         Block localBlock = Block.blocksList[localblockID];
                         int localMeta = world.getBlockMetadata(xPos, yPos, zPos);
-                        int hlvl = MinecraftForge.getBlockHarvestLevel(localBlock, meta, getHarvestType());
+                        int hlvl = MinecraftForge.getBlockHarvestLevel(localBlock, localMeta, getHarvestType());
                         float localHardness = localBlock == null ? Float.MAX_VALUE : localBlock.getBlockHardness(world, xPos, yPos, zPos);
 
                         if (hlvl <= toolLevel && localHardness - 1.5 <= blockHardness)


### PR DESCRIPTION
Fixed the hammer mining levels and tested with Metallurgy 3.3.2

Screenshots :)

![2014-02-16_02 06 19](https://f.cloud.github.com/assets/5352172/2179206/02b82f16-9698-11e3-980d-3b0a9c25d3d2.png)
![2014-02-16_02 06 37](https://f.cloud.github.com/assets/5352172/2179207/02eb74b6-9698-11e3-826a-9b1cd1a9759a.png)
