### PR TITLE
Fix server-side crash with Manuals

### DIFF
--- a/src/main/java/tconstruct/items/Manual.java
+++ b/src/main/java/tconstruct/items/Manual.java
@@ -31,14 +31,13 @@ public class Manual extends CraftingItem
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public ItemStack onItemRightClick (ItemStack stack, World world, EntityPlayer player)
     {
         player.addStat(TAchievements.achievements.get("tconstruct.beginner"), 1);
         player.openGui(TConstruct.instance, mantle.client.MProxyClient.manualGuiID, world, 0, 0, 0);
-         Side side = FMLCommonHandler.instance().getEffectiveSide(); 
-         if (side.isClient())
-        	 FMLClientHandler.instance().displayGuiScreen(player, new GuiManual(stack, getData(stack)));
-         return stack;
+        FMLClientHandler.instance().displayGuiScreen(player, new GuiManual(stack, getData(stack)));
+        return stack;
     }
 
     private BookData getData(ItemStack stack) {


### PR DESCRIPTION
I'm not sure how far implemented books are, but this code doesn't crash on the server, and the client can open the book. The book GUI does not have any navigation buttons, however.
