### PR TITLE
Fixed tooltip modifier proper names defaulting to X+ when they should start at I

### DIFF
--- a/src/main/java/tconstruct/library/tools/ToolMod.java
+++ b/src/main/java/tconstruct/library/tools/ToolMod.java
@@ -176,7 +176,10 @@ public abstract class ToolMod
 
     protected String getProperName (String tooltip, String tag)
     {
-        if (tag.equals(tooltip))
+        if (tag.isEmpty())
+            return tooltip + " I";
+
+        if (tag.equals(tooltip) || tag.equals(tooltip + " I"))
             return tooltip + " II";
 
         if (tag.equals(tooltip + " II"))


### PR DESCRIPTION
(the Reinforced modifier is the one affected)

Currently, if you add reinforced to a tool using an obsidian plate, the modifier tooltip will get set to Reinforced X+ no matter what. This fixes that, and sets it to Reinforced I instead (for the first level, and then Reinforced II, etc for subsequent levels).

See [this line](https://github.com/SlimeKnights/TinkersConstruct/blob/b6ba8700ad000cd626796612b1b98cdfa77d5e0b/src/main/java/tconstruct/modifiers/tools/ModReinforced.java#L54) compared to [this one](https://github.com/SlimeKnights/TinkersConstruct/blob/b6ba8700ad000cd626796612b1b98cdfa77d5e0b/src/main/java/tconstruct/library/tools/ToolMod.java#L168) for why this only affects Reinforced.
