### PR TITLE
Safer tile entity casting in SearedBlock.getCollisionBoundingBoxFromPool

### DIFF
--- a/src/main/java/tconstruct/blocks/SearedBlock.java
+++ b/src/main/java/tconstruct/blocks/SearedBlock.java
@@ -299,9 +299,10 @@ public class SearedBlock extends InventoryBlock
         }
         else
         {
-            FaucetLogic logic = (FaucetLogic) world.getBlockTileEntity(x, y, z);
-            if (logic != null)
+        	TileEntity tile = world.getBlockTileEntity(x, y, z);
+            if (tile != null && tile instanceof FaucetLogic)
             {
+                FaucetLogic logic = (FaucetLogic) tile;
                 float xMin = 0.25F;
                 float xMax = 0.75F;
                 float zMin = 0.25F;


### PR DESCRIPTION
Fixes SlimeKnights/TinkersConstruct#586 and SlimeKnights/TinkersConstruct#557
