### PR TITLE
Fixed goofy fluid rendering, affecting the Smeltery GUI.

### DIFF
--- a/src/main/java/tconstruct/client/gui/SmelteryGui.java
+++ b/src/main/java/tconstruct/client/gui/SmelteryGui.java
@@ -411,14 +411,18 @@ public class SmelteryGui extends NewContainerGui
         }
     }
 
-    public void drawLiquidRect (int startU, int startV, Icon par3Icon, int endU, int endV)
+    public void drawLiquidRect (int startU, int startV, Icon icon, int endU, int endV)
     {
-        Tessellator tessellator = Tessellator.instance;
+    	float top = icon.getInterpolatedV(16 - endV);
+    	float bottom = icon.getMaxV();
+    	float left = icon.getMinU();
+    	float right = icon.getInterpolatedU(endU);
+    	Tessellator tessellator = Tessellator.instance;
         tessellator.startDrawingQuads();
-        tessellator.addVertexWithUV(startU + 0, startV + endV, this.zLevel, par3Icon.getMinU(), par3Icon.getMaxV());//Bottom left
-        tessellator.addVertexWithUV(startU + endU, startV + endV, this.zLevel, par3Icon.getMaxU(), par3Icon.getMaxV());//Bottom right
-        tessellator.addVertexWithUV(startU + endU, startV + 0, this.zLevel, par3Icon.getMaxU(), par3Icon.getMinV());//Top right
-        tessellator.addVertexWithUV(startU + 0, startV + 0, this.zLevel, par3Icon.getMinU(), par3Icon.getMinV()); //Top left
+        tessellator.addVertexWithUV(startU + 0, startV + endV, this.zLevel, left, bottom);//Bottom left
+        tessellator.addVertexWithUV(startU + endU, startV + endV, this.zLevel, right, bottom);//Bottom right
+        tessellator.addVertexWithUV(startU + endU, startV + 0, this.zLevel, right, top);//Top right
+        tessellator.addVertexWithUV(startU + 0, startV + 0, this.zLevel, left, top); //Top left
         tessellator.draw();
     }
 


### PR DESCRIPTION
I could probably have avoided those 4 new vars, but I've messed a lot with code until I got to that solution, and ended up not cleaning the vars up. I'm the kind of person who'd rather store a value in a var and use it than call a getter twice. In the case of the interpolations it's not a simple getter, as there's a bit f math involved.

before:
![before](http://puu.sh/9AJx1/4a9e3ea4cb.png)

after:
![after](http://puu.sh/9AJEM/653214a341.png)

These are both images of the same smeltery with the same amount of molten platinum from TE3,
All that changed was the GUI code.
