### PR TITLE
Add Localizations for Dusts

### DIFF
--- a/resources/assets/tinker/lang/en_US.lang
+++ b/resources/assets/tinker/lang/en_US.lang
@@ -811,4 +811,4 @@ materialtraits.thaumic=Thaumic
 
 creativeModLock.tooltip=Target Lock: 
 
-attribute.generic.ammo.attackDamage=Average Shot Damage
+attribute.name.ammo.attackDamage=Average Shot Damage


### PR DESCRIPTION
Ardite Dust, Cobalt Dust, Aluminum Dust, Manyullyn Dust, and Aluminum Brass Dust, all did not have localizations.
