### PR TITLE
Fix metadata for block->render mapping in smeltery.

### DIFF
--- a/src/main/java/tconstruct/library/crafting/Smeltery.java
+++ b/src/main/java/tconstruct/library/crafting/Smeltery.java
@@ -204,7 +204,7 @@ public class Smeltery
             temp = type.baseTemperature;
 
         if (input.getItem() instanceof ItemBlock)
-            addMelting(input, ((ItemBlock) input.getItem()).field_150939_a, type.renderMeta, type.baseTemperature + temperatureDifference, new FluidStack(type.fluid, fluidAmount));
+            addMelting(input, ((ItemBlock) input.getItem()).field_150939_a, input.getItemDamage(), type.baseTemperature + temperatureDifference, new FluidStack(type.fluid, fluidAmount));
         else
             addMelting(input, type.renderBlock, type.renderMeta, type.baseTemperature + temperatureDifference, new FluidStack(type.fluid, fluidAmount));
     }


### PR DESCRIPTION
You want to use the metadata value of the block, not the meta value of the fluid.
