### PR TITLE
Fixed Localizations in Smeltery Tooltip and WAILA

### DIFF
--- a/resources/assets/tinker/lang/en_US.lang
+++ b/resources/assets/tinker/lang/en_US.lang
@@ -717,6 +717,7 @@ gui.smeltery.glass.block=Blocks:
 gui.smeltery.glass.pannel=Pannels: 
 gui.smeltery.metal.ingot=Ingots: 
 gui.smeltery.metal.nugget=Nuggets: 
+gui.smeltery.molten.check=Molten
 gui.landmine=Landmine
 gui.partcrafter1=Tool Part Crafting
 gui.partcrafter2=Tool Part Building

--- a/resources/assets/tinker/lang/it_IT.lang
+++ b/resources/assets/tinker/lang/it_IT.lang
@@ -719,6 +719,7 @@ gui.smeltery.glass.block=Blocchi:
 gui.smeltery.glass.pannel=Pannelli: 
 gui.smeltery.metal.ingot=Lingotti: 
 gui.smeltery.metal.nugget=Pepite:
+gui.smeltery.molten.check=fuso,fusa
 gui.landmine=Mina
 gui.partcrafter1=Costruire parti
 gui.partcrafter2=Costruire parti

--- a/returning_eventually/plugins/waila/WailaRegistrar.java
+++ b/returning_eventually/plugins/waila/WailaRegistrar.java
@@ -39,7 +39,7 @@ public class WailaRegistrar
 
     public static String fluidNameHelper (FluidStack f)
     {
-        return StatCollector.translateToLocal(FluidRegistry.getFluidName(f));
+        return f.getFluid().getLocalizedName();
     }
 
 }

--- a/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
+++ b/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
@@ -284,13 +284,13 @@ public class SmelteryGui extends NewContainerGui
         }
         else
         {
-            String name = StatCollector.translateToLocal("fluid." + FluidRegistry.getFluidName(liquid));
+            String name = liquid.getFluid().getLocalizedName();
             list.add("\u00A7f" + name);
-            if (name.equals("Liquified Emerald"))
+            if (name.equals(StatCollector.translateToLocal("fluid.emerald.liquid")))
             {
                 list.add(StatCollector.translateToLocal("gui.smeltery.emerald") + liquid.amount / 640f);
             }
-            else if (name.equals("Molten Glass"))
+            else if (name.equals(StatCollector.translateToLocal("fluid.glass.molten")))
             {
                 int blocks = liquid.amount / 1000;
                 if (blocks > 0)
@@ -302,7 +302,16 @@ public class SmelteryGui extends NewContainerGui
                 if (mB > 0)
                     list.add("mB: " + mB);
             }
-            else if (name.contains("Molten"))
+            else if (name.equals(StatCollector.translateToLocal("fluid.stone.seared")))
+            {
+                int ingots = liquid.amount / TConstruct.ingotLiquidValue;
+                if (ingots > 0)
+                    list.add(StatCollector.translateToLocal("gui.smeltery.glass.block") + ingots);
+                int mB = liquid.amount % TConstruct.ingotLiquidValue;
+                if (mB > 0)
+                    list.add("mB: " + mB);
+            }
+            else if (isMolten(name))
             {
                 int ingots = liquid.amount / TConstruct.ingotLiquidValue;
                 if (ingots > 0)
@@ -318,21 +327,29 @@ public class SmelteryGui extends NewContainerGui
                         list.add("mB: " + junk);
                 }
             }
-            else if (name.equals("Seared Stone"))
-            {
-                int ingots = liquid.amount / TConstruct.ingotLiquidValue;
-                if (ingots > 0)
-                    list.add(StatCollector.translateToLocal("gui.smeltery.glass.block") + ingots);
-                int mB = liquid.amount % TConstruct.ingotLiquidValue;
-                if (mB > 0)
-                    list.add("mB: " + mB);
-            }
             else
             {
                 list.add("mB: " + liquid.amount);
             }
         }
         return list;
+    }
+
+    private boolean isMolten (String fluidName)
+    {
+        boolean molten = false;
+        String[] moltenNames = StatCollector.translateToLocal("gui.smeltery.molten.check").split(",");
+
+        for (int i = 0; i< moltenNames.length; i++)
+        {
+            if (fluidName.contains(moltenNames[i].trim()))
+            {
+                molten = true;
+                break;
+            }
+        }
+
+        return molten;
     }
 
     protected void drawToolTip (List par1List, int par2, int par3)


### PR DESCRIPTION
Fixes Fluid localization, and amounts in Smeltery tooltip and WAILA

Note for translators: 
gui.smeltery.molten.check have been added to list localized words for Molten, the words should be separated by a comma ",".
kindly check the en_US.lang for a single word example, and it_IT.lang for multiple words example.
