### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,9 +153,16 @@ task libJar(type: Jar) {
     classifier = 'lib'
 }
 
+// Create Maven source jar
+task sourceJar(type: Jar, dependsOn:classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
 artifacts {
     archives deobfJar
     archives libJar
+    archives sourceJar
 }
 // verify the properties exist.. or initialize.
 if (!project.hasProperty("keystore_location")) // keystore location


### PR DESCRIPTION
Add source jar generation as an option.

Useful for Mavenisation, when TCon is just referred to by a Maven dependency. This attaches clean sources without decompiling or checking out from Git.
