### PR TITLE
Fixed TinkerTools.modIntegration not being called

### DIFF
--- a/src/main/java/tconstruct/tools/TinkerTools.java
+++ b/src/main/java/tconstruct/tools/TinkerTools.java
@@ -410,6 +410,7 @@ public class TinkerTools
     public void postInit (FMLPostInitializationEvent evt)
     {
         vanillaToolRecipes();
+        modIntegration();
     }
 
     private void addPartMapping ()


### PR DESCRIPTION
Fixes SlimeKnights/TinkersConstruct#734
