### PR TITLE
Fixed mod sounds not playing

### DIFF
--- a/resources/assets/tinker/sounds.json
+++ b/resources/assets/tinker/sounds.json
@@ -11,7 +11,7 @@
        "little_saw"
      ]
    },
-   "frypan_hit": {
+   "launcher_clank": {
      "category": "neutral",
      "sounds": [
        "launcher_clank"


### PR DESCRIPTION
This fixes the mod's sounds that weren't playing. These include the frying pan hit sound and the tool station sawing sound.
