### PR TITLE
fix for blockbreaking issues with area harvesting tools

### DIFF
--- a/src/main/java/tconstruct/items/tools/Battleaxe.java
+++ b/src/main/java/tconstruct/items/tools/Battleaxe.java
@@ -249,18 +249,16 @@ public class Battleaxe extends HarvestTool
             return false;
 
         World world = player.worldObj;
-        final Block wood = world.getBlock(x, y, z);
+        final Block block = world.getBlock(x, y, z);
         NBTTagCompound tags = stack.getTagCompound().getCompoundTag("InfiTool");
         final int meta = world.getBlockMetadata(x, y, z);
-        final int fortune = EnchantmentHelper.getFortuneModifier(player);
         for (int yPos = y + 1; yPos < y + 9; yPos++)
         {
-            Block block = world.getBlock(x, yPos, z);
-            if (!(tags.getBoolean("Broken")) && block != null && block.getMaterial() == Material.wood)
+            Block localBlock = world.getBlock(x, yPos, z);
+            if (!(tags.getBoolean("Broken")) && localBlock != null && localBlock.getMaterial() == Material.wood)
             {
-                Block localblock = world.getBlock(x, yPos, z);
                 int localMeta = world.getBlockMetadata(x, yPos, z);
-                int hlvl = block.getHarvestLevel(meta);
+                int hlvl = localBlock.getHarvestLevel(localMeta);
 
                 if (hlvl <= tags.getInteger("HarvestLevel"))
                 {
@@ -273,23 +271,12 @@ public class Battleaxe extends HarvestTool
 
                     if (!cancelHarvest)
                     {
-                        if (block != null && block.getMaterial() == Material.wood)
+                        if (localBlock != null && localBlock.getMaterial() == Material.wood)
                         {
-                            localMeta = world.getBlockMetadata(x, yPos, z);
                             if (!player.capabilities.isCreativeMode)
                             {
-                                if (block.removedByPlayer(world, player, x, yPos, z))
-                                {
-                                    block.onBlockDestroyedByPlayer(world, x, yPos, z, localMeta);
-                                }
-
-                                // Workaround for dropping experience
-                                int exp = block.getExpDrop(world, localMeta, fortune);
-                                block.dropXpOnBlockBreak(world, x, y, z, exp);
-
-                                block.harvestBlock(world, player, x, yPos, z, localMeta);
-                                block.onBlockHarvested(world, x, yPos, z, localMeta, player);
-                                onBlockDestroyed(stack, world, block, x, yPos, z, player);
+                                mineBlock(world, x, yPos, z, localMeta, player, localBlock);
+                                onBlockDestroyed(stack, world, localBlock, x, yPos, z, player);
                             }
                             else
                             {
@@ -303,7 +290,7 @@ public class Battleaxe extends HarvestTool
                 break;
         }
         if (!world.isRemote)
-            world.playAuxSFX(2001, x, y, z, Block.getIdFromBlock(wood) + (meta << 12));
+            world.playAuxSFX(2001, x, y, z, Block.getIdFromBlock(block) + (meta << 12));
         return super.onBlockStartBreak(stack, x, y, z, player);
     }
 }

--- a/src/main/java/tconstruct/items/tools/Excavator.java
+++ b/src/main/java/tconstruct/items/tools/Excavator.java
@@ -185,7 +185,6 @@ public class Excavator extends HarvestTool
             break;
         }
         NBTTagCompound tags = stack.getTagCompound().getCompoundTag("InfiTool");
-        int fortune = EnchantmentHelper.getFortuneModifier(player);
         for (int xPos = x - xRange; xPos <= x + xRange; xPos++)
         {
             for (int yPos = y - yRange; yPos <= y + yRange; yPos++)
@@ -194,11 +193,10 @@ public class Excavator extends HarvestTool
                 {
                     if (!(tags.getBoolean("Broken")))
                     {
-                        Block localblock = world.getBlock(xPos, yPos, zPos);
-                        block = localblock;
+                        Block localBlock = world.getBlock(xPos, yPos, zPos);
                         int localMeta = world.getBlockMetadata(xPos, yPos, zPos);
-                        int hlvl = block.getHarvestLevel(meta);
-                        float localHardness = block == null ? Float.MAX_VALUE : block.getBlockHardness(world, xPos, yPos, zPos);
+                        int hlvl = localBlock.getHarvestLevel(localMeta);
+                        float localHardness = localBlock == null ? Float.MAX_VALUE : localBlock.getBlockHardness(world, xPos, yPos, zPos);
 
                         if (hlvl <= tags.getInteger("HarvestLevel") && localHardness - 1.5 <= blockHardness)
                         {
@@ -211,27 +209,17 @@ public class Excavator extends HarvestTool
 
                             if (!cancelHarvest)
                             {
-                                if (block != null && !(localHardness < 0))
+                                if (localBlock != null && !(localHardness < 0))
                                 {
                                     for (int iter = 0; iter < materials.length; iter++)
                                     {
-                                        if (materials[iter] == block.getMaterial())
+                                        if (materials[iter] == localBlock.getMaterial())
                                         {
                                             if (!player.capabilities.isCreativeMode)
                                             {
-                                                if (block.removedByPlayer(world, player, xPos, yPos, zPos))
-                                                {
-                                                    block.onBlockDestroyedByPlayer(world, xPos, yPos, zPos, localMeta);
-                                                }
-
-                                                // Workaround for dropping experience
-                                                int exp = block.getExpDrop(world, localMeta, fortune);
-                                                block.dropXpOnBlockBreak(world, xPos, yPos, zPos, exp);
-
-                                                block.harvestBlock(world, player, xPos, yPos, zPos, localMeta);
-                                                block.onBlockHarvested(world, xPos, yPos, zPos, localMeta, player);
-                                                if (blockHardness > 0f)
-                                                    onBlockDestroyed(stack, world, localblock, xPos, yPos, zPos, player);
+                                                mineBlock(world, xPos, yPos, zPos, localMeta, player, localBlock);
+                                                if (localHardness > 0f)
+                                                    onBlockDestroyed(stack, world, localBlock, xPos, yPos, zPos, player);
                                             }
                                             else
                                             {

--- a/src/main/java/tconstruct/items/tools/Hammer.java
+++ b/src/main/java/tconstruct/items/tools/Hammer.java
@@ -284,7 +284,6 @@ public class Hammer extends HarvestTool
 
         NBTTagCompound tags = stack.getTagCompound().getCompoundTag("InfiTool");
         int toolLevel = tags.getInteger("HarvestLevel");
-        int fortune = EnchantmentHelper.getFortuneModifier(player);
         for (int xPos = x - xRange; xPos <= x + xRange; xPos++)
         {
             for (int yPos = y - yRange; yPos <= y + yRange; yPos++)
@@ -300,6 +299,7 @@ public class Hammer extends HarvestTool
                             hlvl = localBlock.getHarvestLevel(localMeta);
                         float localHardness = localBlock == null ? Float.MAX_VALUE : localBlock.getBlockHardness(world, xPos, yPos, zPos);
 
+                        //Choose blocks that aren't too much harder than the first block. Stone: 2.0, Ores: 3.0
                         if (hlvl <= toolLevel && localHardness - 1.5 <= blockHardness)
                         {
                             boolean cancelHarvest = false;
@@ -319,17 +319,8 @@ public class Hammer extends HarvestTool
                                         {
                                             if (!player.capabilities.isCreativeMode)
                                             {
-                                                if (localBlock.removedByPlayer(world, player, xPos, yPos, zPos))
-                                                {
-                                                    localBlock.onBlockDestroyedByPlayer(world, xPos, yPos, zPos, localMeta);
-                                                }
+                                                mineBlock(world, xPos, yPos, zPos, localMeta, player, localBlock);
 
-                                                // Workaround for dropping experience
-                                                int exp = localBlock.getExpDrop(world, localMeta, fortune);
-                                                localBlock.dropXpOnBlockBreak(world, xPos, yPos, zPos, exp);
-
-                                                localBlock.harvestBlock(world, player, xPos, yPos, zPos, localMeta);
-                                                localBlock.onBlockHarvested(world, xPos, yPos, zPos, localMeta, player);
                                                 if (blockHardness > 0f)
                                                     onBlockDestroyed(stack, world, localBlock, xPos, yPos, zPos, player);
                                                 world.func_147479_m(x, y, z);

--- a/src/main/java/tconstruct/items/tools/LumberAxe.java
+++ b/src/main/java/tconstruct/items/tools/LumberAxe.java
@@ -198,9 +198,6 @@ public class LumberAxe extends HarvestTool
 
     void breakTree (World world, int x, int y, int z, ItemStack stack, NBTTagCompound tags, Block bID, int meta, EntityPlayer player)
     {
-        Block block;
-        final int fortune = EnchantmentHelper.getFortuneModifier(player);
-
         for (int xPos = x - 1; xPos <= x + 1; xPos++)
         {
             for (int yPos = y; yPos <= y + 1; yPos++)
@@ -209,12 +206,11 @@ public class LumberAxe extends HarvestTool
                 {
                     if (!(tags.getBoolean("Broken")))
                     {
-                        Block localblock = world.getBlock(xPos, yPos, zPos);
-                        if (bID == localblock)
+                        Block localBlock = world.getBlock(xPos, yPos, zPos);
+                        if (bID == localBlock)
                         {
-                            block = localblock;
-                            meta = world.getBlockMetadata(xPos, yPos, zPos);
-                            int hlvl = block.getHarvestLevel(meta);
+                            int localMeta = world.getBlockMetadata(xPos, yPos, zPos);
+                            int hlvl = localBlock.getHarvestLevel(localMeta);
 
                             if (hlvl <= tags.getInteger("HarvestLevel"))
                             {
@@ -231,7 +227,7 @@ public class LumberAxe extends HarvestTool
                                 }
                                 else
                                 {
-                                    if (localblock == bID && world.getBlockMetadata(xPos, yPos, zPos) % 4 == meta % 4)
+                                    if (localBlock == bID && localMeta % 4 == meta % 4)
                                     {
                                         /*
                                          * world.setBlock(xPos, yPos, zPos, 0,
@@ -245,24 +241,15 @@ public class LumberAxe extends HarvestTool
                                          */
                                         if (!player.capabilities.isCreativeMode)
                                         {
-                                            if (block.removedByPlayer(world, player, xPos, yPos, zPos))
-                                            {
-                                                block.onBlockDestroyedByPlayer(world, xPos, yPos, zPos, meta);
-                                            }
-
-                                            // Workaround for dropping experience
-                                            int exp = localblock.getExpDrop(world, meta, fortune);
-                                            localblock.dropXpOnBlockBreak(world, xPos, yPos, zPos, exp);
-
-                                            block.harvestBlock(world, player, xPos, yPos, zPos, meta);
-                                            block.onBlockHarvested(world, xPos, yPos, zPos, meta, player);
-                                            onBlockDestroyed(stack, world, localblock, xPos, yPos, zPos, player);
+                                            mineBlock(world, xPos, yPos, zPos, localMeta, player, localBlock);
+                                            onBlockDestroyed(stack, world, localBlock, xPos, yPos, zPos, player);
                                         }
                                         else
                                         {
                                             WorldHelper.setBlockToAir(world, xPos, yPos, zPos);
                                         }
-                                        breakTree(world, xPos, yPos, zPos, stack, tags, bID, meta, player);
+                                        if (!world.isRemote)
+                                            breakTree(world, xPos, yPos, zPos, stack, tags, bID, meta, player);
                                     }
                                     /*
                                      * else { Block leaves =
@@ -288,8 +275,6 @@ public class LumberAxe extends HarvestTool
 
     void destroyWood (World world, int x, int y, int z, ItemStack stack, NBTTagCompound tags, EntityPlayer player)
     {
-        final int fortune = EnchantmentHelper.getFortuneModifier(player);
-
         for (int xPos = x - 1; xPos <= x + 1; xPos++)
         {
             for (int yPos = y - 1; yPos <= y + 1; yPos++)
@@ -298,11 +283,11 @@ public class LumberAxe extends HarvestTool
                 {
                     if (!(tags.getBoolean("Broken")))
                     {
-                        Block block = world.getBlock(xPos, yPos, zPos);
-                        int meta = world.getBlockMetadata(xPos, yPos, zPos);
-                        int hlvl = block.getHarvestLevel(meta);
+                        Block localBlock = world.getBlock(xPos, yPos, zPos);
+                        int localMeta = world.getBlockMetadata(xPos, yPos, zPos);
+                        int hlvl = localBlock.getHarvestLevel(localMeta);
 
-                        if (block != null && block.getMaterial() == Material.wood)
+                        if (localBlock != null && localBlock.getMaterial() == Material.wood)
                         {
                             if (hlvl <= tags.getInteger("HarvestLevel"))
                             {
@@ -317,12 +302,8 @@ public class LumberAxe extends HarvestTool
                                 {
                                     if (!player.capabilities.isCreativeMode)
                                     {
-                                        // TODO harvestBlock
-                                        int exp = block.getExpDrop(world, meta, fortune);
-                                        block.dropXpOnBlockBreak(world, xPos, yPos, zPos, exp);
-
-                                        block.harvestBlock(world, player, xPos, yPos, zPos, meta);
-                                        onBlockDestroyed(stack, world, block, xPos, yPos, zPos, player);
+                                        mineBlock(world, xPos, yPos, zPos, localMeta, player, localBlock);
+                                        onBlockDestroyed(stack, world, localBlock, xPos, yPos, zPos, player);
                                     }
                                     WorldHelper.setBlockToAir(world, xPos, yPos, zPos);
                                     world.func_147479_m(xPos, yPos, zPos);

--- a/src/main/java/tconstruct/items/tools/Scythe.java
+++ b/src/main/java/tconstruct/items/tools/Scythe.java
@@ -169,6 +169,7 @@ public class Scythe extends Weapon
             return false;
         NBTTagCompound tags = stack.getTagCompound().getCompoundTag("InfiTool");
         boolean butter = EnchantmentHelper.getEnchantmentLevel(Enchantment.silkTouch.effectId, stack) > 0;
+        int fortune = EnchantmentHelper.getFortuneModifier(player);
         for (int xPos = x - 1; xPos <= x + 1; xPos++)
         {
             for (int yPos = y - 1; yPos <= y + 1; yPos++)
@@ -222,12 +223,26 @@ public class Scythe extends Weapon
                                             }
                                             else
                                             {
-                                                if (localBlock.removedByPlayer(world, player, xPos, yPos, zPos))
+                                                if (!world.isRemote)
+                                                {
+                                                    // Workaround for dropping experience
+                                                    int exp = localBlock.getExpDrop(world, localMeta, fortune);
+
+                                                    localBlock.onBlockHarvested(world, xPos, yPos, zPos, localMeta, player);
+                                                    if (localBlock.removedByPlayer(world, player, xPos, yPos, zPos, true))
+                                                    {
+                                                        localBlock.onBlockDestroyedByPlayer(world, xPos, yPos, zPos, localMeta);
+                                                        localBlock.harvestBlock(world, player, xPos, yPos, zPos, localMeta);
+                                                        // Workaround for dropping experience
+                                                        if (!butter)
+                                                            localBlock.dropXpOnBlockBreak(world, xPos, yPos, zPos, exp);
+                                                    }
+                                                }
+                                                else
                                                 {
                                                     localBlock.onBlockDestroyedByPlayer(world, xPos, yPos, zPos, localMeta);
                                                 }
-                                                localBlock.harvestBlock(world, player, xPos, yPos, zPos, localMeta);
-                                                localBlock.onBlockHarvested(world, xPos, yPos, zPos, localMeta, player);
+
                                                 if (localHardness > 0f)
                                                     onBlockDestroyed(stack, world, localBlock, xPos, yPos, zPos, player);
                                             }


### PR DESCRIPTION
unified use of block / localBlock like it is in Hammer.
block harvesting is in own method in HarvestTool except the scythe.
fix for some blocks drop nothing or not breaking at all.
fix for dropping exp with silktouch.
