### PR TITLE
TabRegistry - fix issues on switching back to vanilla inventory tab from TConstruct tab

### DIFF
--- a/src/main/java/tconstruct/client/tabs/TabRegistry.java
+++ b/src/main/java/tconstruct/client/tabs/TabRegistry.java
@@ -40,6 +40,7 @@ public class TabRegistry
 
     public static void openInventoryGui ()
     {
+        mc.thePlayer.closeScreen();
         GuiInventory inventory = new GuiInventory(mc.thePlayer);
         mc.displayGuiScreen(inventory);
         TabRegistry.addTabsToInventory(inventory);


### PR DESCRIPTION
Without this change, if you open the player's inventory, click to the Tinker's Construct inventory tab, then click _back_ to the vanilla inventory tab, any changes then made to the player inventory (e.g. crafting, or moving an item from a slot to a different slot) do not register on the server.

For further info please see the issue reported here https://github.com/micdoodle8/Galacticraft/issues/782
I hope you already knew we are making use of your TabRegistry code for Galacticraft's inventory tab as well - for compatibility reasons :)
