### PR TITLE
Traveler's Boots Fix (for #802)

### DIFF
--- a/src/main/java/tconstruct/armor/ArmorAbilities.java
+++ b/src/main/java/tconstruct/armor/ArmorAbilities.java
@@ -1,5 +1,8 @@
 package tconstruct.armor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -16,7 +19,8 @@ public class ArmorAbilities
     boolean morphed;
     boolean morphLoaded = Loader.isModLoaded("Morph");
 
-    ItemStack prevFeet;
+    public static List<String> stepBoostedPlayers = new ArrayList();
+    //ItemStack prevFeet;
     double prevMotionY;
 
     @SubscribeEvent
@@ -53,6 +57,7 @@ public class ArmorAbilities
             }
             prevMotionY = player.motionY;
         }
+        /* Former step height boost handling 
         if (feet != prevFeet)
         {
             if (prevFeet != null && prevFeet.getItem() instanceof TravelGear)
@@ -60,6 +65,18 @@ public class ArmorAbilities
             if (feet != null && feet.getItem() instanceof TravelGear)
                 player.stepHeight += 0.6f;
             prevFeet = feet;
+        }*/
+        boolean stepBoosted = stepBoostedPlayers.contains(player.getGameProfile().getName());
+        if(stepBoosted)
+        	player.stepHeight = 1.1f;
+        if(!stepBoosted && feet!=null && feet.getItem() instanceof TravelGear)
+        {
+        	stepBoostedPlayers.add(player.getGameProfile().getName());
+        }
+        else if(stepBoosted && (feet==null || !(feet.getItem() instanceof TravelGear)))
+        {
+        	stepBoostedPlayers.remove(player.getGameProfile().getName());
+        	player.stepHeight -= 0.6f;
         }
         //TODO: Proper minimap support
         /*ItemStack stack = player.inventory.getStackInSlot(8);


### PR DESCRIPTION
Added tracking of players wearing Traveler's Boots and constant setting
of boosted stepHeight.  The former prevents cross-player stepHeight
issues in Multiplayer, and the latter compensates for the resetting of
stepHeight on login and when changing dimension.
