### PR TITLE
Have the IToolPart implementations actually respect the IToolPart API.

### DIFF
--- a/src/main/java/tconstruct/tools/items/Bowstring.java
+++ b/src/main/java/tconstruct/tools/items/Bowstring.java
@@ -40,6 +40,8 @@ public class Bowstring extends CraftingItem implements IToolPart
     @Override
     public int getMaterialID (ItemStack stack)
     {
+        if(stack.getItemDamage() >= toolMaterialNames.length)
+            return -1;
         return stack.getItemDamage();
     }
 

--- a/src/main/java/tconstruct/tools/items/Fletching.java
+++ b/src/main/java/tconstruct/tools/items/Fletching.java
@@ -34,6 +34,8 @@ public class Fletching extends CraftingItem implements IToolPart
     @Override
     public int getMaterialID (ItemStack stack)
     {
+        if(stack.getItemDamage() >= toolMaterialNames.length)
+            return -1;
         return stack.getItemDamage();
     }
 }

--- a/src/main/java/tconstruct/tools/items/ToolPart.java
+++ b/src/main/java/tconstruct/tools/items/ToolPart.java
@@ -81,6 +81,8 @@ public class ToolPart extends CraftingItem implements IToolPart
     @Override
     public int getMaterialID (ItemStack stack)
     {
+        if(stack.getItemDamage() >= toolMaterialNames.length)
+            return -1;
         return stack.getItemDamage();
     }
 }


### PR DESCRIPTION
None of the Toolparts actually return -1 on invalid material, but return invalid materials.
