### PR TITLE
Use the input item object hashcode for determining SmelteryInput's hashcode

### DIFF
--- a/src/main/java/tconstruct/library/crafting/Smeltery.java
+++ b/src/main/java/tconstruct/library/crafting/Smeltery.java
@@ -243,7 +243,7 @@ public class Smeltery
         @Override
         public int hashCode ()
         {
-            return Item.getIdFromItem(this.input) << 16 | this.meta;
+            return this.input.hashCode() << 16 | this.meta;
         }
 
         @Override


### PR DESCRIPTION
Just a small 'fix' for my last pull request. This makes sure the SmelteryInput lookup isn't affected by the live item id, which in turn could be affected by id remapping issues.
