### PR TITLE
When creating a cast, move it to input slot for direct use.

### DIFF
--- a/src/main/java/tconstruct/smeltery/logic/CastingTableLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/CastingTableLogic.java
@@ -346,6 +346,14 @@ public class CastingTableLogic extends InventoryLogic implements IFluidTank, IFl
             inventory[1] = event.output;
             if (event.consumeCast)
                 inventory[0] = null;
+
+            // if we just created a cast, move it to the first slot so we can use it directly afterwards
+            if(event.output != null && event.output.getItem() instanceof IPattern)
+            {
+                inventory[1] = inventory[0];
+                inventory[0] = event.output;
+            }
+
             liquid = null;
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
         }


### PR DESCRIPTION
Basically this means that when you create a new cast, the first rightclick takes the item out instead of the cast, and you can use the cast without having to take it out and reinserting it again.
Coincidentally also fixes exactly that with iguana tweaks "burn material used to create cast" feature. ;)
