### PR TITLE
Unify harvestlevel strings through the library.

### DIFF
--- a/src/main/java/tconstruct/client/pages/MaterialPage.java
+++ b/src/main/java/tconstruct/client/pages/MaterialPage.java
@@ -14,6 +14,7 @@ import org.w3c.dom.NodeList;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.PatternBuilder;
 import tconstruct.library.tools.ToolMaterial;
+import tconstruct.library.util.HarvestLevels;
 import tconstruct.tools.gui.PartCrafterGui;
 
 public class MaterialPage extends BookPage
@@ -144,7 +145,7 @@ public class MaterialPage extends BookPage
         manual.fonts.drawString(fullToolDurability + ": " + (int) (material.durability() * material.handleDurability()), localWidth, localHeight + 60, 0);
 
         manual.fonts.drawString(miningSpeed + ": " + material.toolSpeed() / 100f, localWidth, localHeight + 80, 0);
-        manual.fonts.drawString(miningLevel + ": " + material.harvestLevel() + " (" + PartCrafterGui.getHarvestLevelName(material.harvestLevel()) + ")", localWidth, localHeight + 90, 0);
+        manual.fonts.drawString(miningLevel + ": " + material.harvestLevel() + " (" + HarvestLevels.getHarvestLevelName(material.harvestLevel()) + ")", localWidth, localHeight + 90, 0);
         int attack = material.attack();
         String heart = attack == 2 ? " " + heart_ : " " + hearts;
         if (attack % 2 == 0)

--- a/src/main/java/tconstruct/library/util/HarvestLevels.java
+++ b/src/main/java/tconstruct/library/util/HarvestLevels.java
@@ -1,0 +1,29 @@
+package tconstruct.library.util;
+
+import net.minecraft.util.StatCollector;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Lookup for the name of each harvest level. Use this clientside only for display purposes.
+ */
+public final class HarvestLevels {
+    private HarvestLevels() {} // non-instantiable
+
+    public static final Map<Integer, String> harvestLevelNames = new HashMap<Integer, String>();
+
+    public static String getHarvestLevelName (int num) {
+        return harvestLevelNames.containsKey(num) ? harvestLevelNames.get(num) : String.valueOf(num);
+    }
+
+    // initialization
+    static{
+        String base = "gui.partcrafter.mining";
+        int i = 0;
+        while(StatCollector.canTranslate(String.format("%s%d", base, i+1))) {
+            harvestLevelNames.put(i, StatCollector.translateToLocal(String.format("%s%d", base, i + 1)));
+            i++;
+        }
+    }
+}

--- a/src/main/java/tconstruct/tools/gui/PartCrafterGui.java
+++ b/src/main/java/tconstruct/tools/gui/PartCrafterGui.java
@@ -16,6 +16,7 @@ import tconstruct.client.gui.NewContainerGui;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.PatternBuilder;
 import tconstruct.library.tools.ToolMaterial;
+import tconstruct.library.util.HarvestLevels;
 import tconstruct.smeltery.inventory.ActiveContainer;
 import tconstruct.tools.inventory.PartCrafterChestContainer;
 import tconstruct.tools.logic.PartBuilderLogic;
@@ -99,7 +100,7 @@ public class PartCrafterGui extends NewContainerGui
             this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter4") + topEnum.durability(), xSize + 8, offset + 16, 16777215);
             this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter5") + topEnum.handleDurability() + "x", xSize + 8, offset + 27, 16777215);
             this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter6") + topEnum.toolSpeed() / 100f, xSize + 8, offset + 38, 16777215);
-            this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter7") + getHarvestLevelName(topEnum.harvestLevel()), xSize + 8, offset + 49, 16777215);
+            this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter7") + HarvestLevels.getHarvestLevelName(topEnum.harvestLevel()), xSize + 8, offset + 49, 16777215);
 
             int attack = topEnum.attack();
             String heart = attack == 2 ? StatCollector.translateToLocal("gui.partcrafter8") : StatCollector.translateToLocal("gui.partcrafter9");
@@ -116,7 +117,7 @@ public class PartCrafterGui extends NewContainerGui
             this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter4") + bottomEnum.durability(), xSize + 8, offset + 16, 16777215);
             this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter5") + bottomEnum.handleDurability() + "x", xSize + 8, offset + 27, 16777215);
             this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter6") + bottomEnum.toolSpeed() / 100f, xSize + 8, offset + 38, 16777215);
-            this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter7") + getHarvestLevelName(bottomEnum.harvestLevel()), xSize + 8, offset + 49, 16777215);
+            this.fontRendererObj.drawString(StatCollector.translateToLocal("gui.partcrafter7") + HarvestLevels.getHarvestLevelName(bottomEnum.harvestLevel()), xSize + 8, offset + 49, 16777215);
             int attack = bottomEnum.attack();
             String heart = attack == 2 ? StatCollector.translateToLocal("gui.partcrafter8") : StatCollector.translateToLocal("gui.partcrafter9");
             if (attack % 2 == 0)
@@ -127,27 +128,6 @@ public class PartCrafterGui extends NewContainerGui
 
         if (!hasTop && !hasBottom)
             drawDefaultInformation();
-    }
-
-    public static String getHarvestLevelName (int num)
-    {
-        switch (num)
-        {
-        case 0:
-            return (StatCollector.translateToLocal("gui.partcrafter.mining1"));
-        case 1:
-            return (StatCollector.translateToLocal("gui.partcrafter.mining2"));
-        case 2:
-            return (StatCollector.translateToLocal("gui.partcrafter.mining3"));
-        case 3:
-            return (StatCollector.translateToLocal("gui.partcrafter.mining4"));
-        case 4:
-            return (StatCollector.translateToLocal("gui.partcrafter.mining5"));
-        case 5:
-            return (StatCollector.translateToLocal("gui.partcrafter.mining6"));
-        default:
-            return String.valueOf(num);
-        }
     }
 
     private static final ResourceLocation background = new ResourceLocation("tinker", "textures/gui/toolparts.png");

--- a/src/main/java/tconstruct/tools/gui/ToolStationGui.java
+++ b/src/main/java/tconstruct/tools/gui/ToolStationGui.java
@@ -22,6 +22,7 @@ import tconstruct.TConstruct;
 import tconstruct.library.client.TConstructClientRegistry;
 import tconstruct.library.client.ToolGuiElement;
 import tconstruct.library.tools.ToolCore;
+import tconstruct.library.util.HarvestLevels;
 import tconstruct.smeltery.inventory.ActiveContainer;
 import tconstruct.tools.inventory.ToolStationContainer;
 import tconstruct.tools.logic.ToolStationLogic;
@@ -316,7 +317,7 @@ public class ToolStationGui extends GuiContainer
             offset++;
             fontRendererObj.drawString(StatCollector.translateToLocal("gui.toolstation13"), 294, base + offset * 10, 0xffffff);
             offset++;
-            fontRendererObj.drawString("- " + getHarvestLevelName(tags.getInteger("HarvestLevel")) + ", " + getHarvestLevelName(tags.getInteger("HarvestLevel2")), 294, base + offset * 10, 0xffffff);
+            fontRendererObj.drawString("- " + HarvestLevels.getHarvestLevelName(tags.getInteger("HarvestLevel")) + ", " + HarvestLevels.getHarvestLevelName(tags.getInteger("HarvestLevel2")), 294, base + offset * 10, 0xffffff);
             offset++;
             offset++;
         }
@@ -359,7 +360,7 @@ public class ToolStationGui extends GuiContainer
                 fontRendererObj.drawString(bloss + df.format(stoneboundSpeed), 294, base + offset * 10, 0xffffff);
                 offset++;
             }
-            fontRendererObj.drawString(StatCollector.translateToLocal("gui.toolstation15") + getHarvestLevelName(tags.getInteger("HarvestLevel")), 294, base + offset * 10, 0xffffff);
+            fontRendererObj.drawString(StatCollector.translateToLocal("gui.toolstation15") + HarvestLevels.getHarvestLevelName(tags.getInteger("HarvestLevel")), 294, base + offset * 10, 0xffffff);
             offset++;
             offset++;
         }
@@ -403,27 +404,6 @@ public class ToolStationGui extends GuiContainer
     {
         this.drawCenteredString(fontRendererObj, title, 349, 8, 0xffffff);
         fontRendererObj.drawSplitString(body, 294, 24, 115, 0xffffff);
-    }
-
-    protected String getHarvestLevelName (int num)
-    {
-        switch (num)
-        {
-        case 0:
-            return StatCollector.translateToLocal("gui.partcrafter.mining1");
-        case 1:
-            return StatCollector.translateToLocal("gui.partcrafter.mining2");
-        case 2:
-            return StatCollector.translateToLocal("gui.partcrafter.mining3");
-        case 3:
-            return StatCollector.translateToLocal("gui.partcrafter.mining4"); // Mithril
-        case 4:
-            return StatCollector.translateToLocal("gui.partcrafter.mining5");
-        case 5:
-            return StatCollector.translateToLocal("gui.partcrafter.mining6");
-        default:
-            return String.valueOf(num);
-        }
     }
 
     private static final ResourceLocation background = new ResourceLocation("tinker", "textures/gui/toolstation.png");


### PR DESCRIPTION
Also allows iguana tinker tweaks to natively change harvestlevel names, and creates native compatibility between it and TicTooltips... natively!
