### PR TITLE
Render Tank in 2 passes

### DIFF
--- a/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/LavaTankBlock.java
@@ -101,6 +101,12 @@ public class LavaTankBlock extends BlockContainer
     }
 
     @Override
+    public boolean canRenderInPass(int pass) {
+        TankRender.renderPass = pass;
+        return true;
+    }
+
+    @Override
     public int getLightValue (IBlockAccess world, int x, int y, int z)
     {
         TileEntity logic = world.getTileEntity(x, y, z);

--- a/src/main/java/tconstruct/smeltery/model/TankRender.java
+++ b/src/main/java/tconstruct/smeltery/model/TankRender.java
@@ -19,6 +19,7 @@ import cpw.mods.fml.client.registry.RenderingRegistry;
 public class TankRender implements ISimpleBlockRenderingHandler
 {
     public static int tankModelID = RenderingRegistry.getNextAvailableRenderId();
+    public static int renderPass = 0;
 
     @Override
     public void renderInventoryBlock (Block block, int metadata, int modelID, RenderBlocks renderer)
@@ -40,29 +41,30 @@ public class TankRender implements ISimpleBlockRenderingHandler
         if (modelID == tankModelID)
         {
             //Liquid
-            LavaTankLogic logic = (LavaTankLogic) world.getTileEntity(x, y, z);
-            if (logic.containsFluid())
-            {
-                FluidStack liquid = logic.tank.getFluid();
-                renderer.setRenderBounds(0.001, 0.001, 0.001, 0.999, logic.getFluidAmountScaled(), 0.999);
-                Fluid fluid = liquid.getFluid();
-                if (fluid.canBePlacedInWorld())
-                    BlockSkinRenderHelper.renderMetadataBlock(fluid.getBlock(), 0, x, y, z, renderer, world);
-                else
-                    BlockSkinRenderHelper.renderLiquidBlock(fluid.getStillIcon(), fluid.getFlowingIcon(), x, y, z, renderer, world);
+            if(renderPass == 0) {
+                LavaTankLogic logic = (LavaTankLogic) world.getTileEntity(x, y, z);
+                if (logic.containsFluid()) {
+                    FluidStack liquid = logic.tank.getFluid();
+                    renderer.setRenderBounds(0.001, 0.001, 0.001, 0.999, logic.getFluidAmountScaled(), 0.999);
+                    Fluid fluid = liquid.getFluid();
+                    if (fluid.canBePlacedInWorld())
+                        BlockSkinRenderHelper.renderMetadataBlock(fluid.getBlock(), 0, x, y, z, renderer, world);
+                    else
+                        BlockSkinRenderHelper.renderLiquidBlock(fluid.getStillIcon(), fluid.getFlowingIcon(), x, y, z, renderer, world);
 
-                renderer.setRenderBounds(00, 0.001, 0.001, 0.999, logic.getFluidAmountScaled(), 0.999);
+                    renderer.setRenderBounds(00, 0.001, 0.001, 0.999, logic.getFluidAmountScaled(), 0.999);
+                }
             }
-
             //Block
-            int meta = world.getBlockMetadata(x, y, z);
-            if (meta == 0 && world.getBlock(x, y + 1, z) == Blocks.air)
-            {
-                renderer.setRenderBounds(0.1875, 0, 0.1875, 0.8125, 0.125, 0.8125);
-                renderer.renderStandardBlock(block, x, y + 1, z);
+            else {
+                int meta = world.getBlockMetadata(x, y, z);
+                if (meta == 0 && world.getBlock(x, y + 1, z) == Blocks.air) {
+                    renderer.setRenderBounds(0.1875, 0, 0.1875, 0.8125, 0.125, 0.8125);
+                    renderer.renderStandardBlock(block, x, y + 1, z);
+                }
+                renderer.setRenderBounds(0, 0, 0, 1, 1, 1);
+                renderer.renderStandardBlock(block, x, y, z);
             }
-            renderer.setRenderBounds(0, 0, 0, 1, 1, 1);
-            renderer.renderStandardBlock(block, x, y, z);
         }
         return true;
     }


### PR DESCRIPTION
Fixes the lava-over-tank-rendered deripness.
This works because canRenderInPass is called directly before the draw call.
