### PR TITLE
Defer ore dictionary smeltery recipes to postInit

### DIFF
--- a/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/tconstruct/smeltery/TinkerSmeltery.java
@@ -754,12 +754,12 @@ public class TinkerSmeltery
         addRecipesForSmeltery();
         addRecipesForTableCasting();
         addRecipesForBasinCasting();
-        addOreDictionarySmelteryRecipes();
     }
 
     @Handler
     public void postInit (FMLPostInitializationEvent evt)
     {
+        addOreDictionarySmelteryRecipes();
         modIntegration();
     }
 


### PR DESCRIPTION
We can't be sure the ore dictionary has been fully registered by other mods due to load order as most mods register ore dictionary items in init, so we should wait until postInit to ensure it has all registrations, otherwise some ore dictionary items may not get registered.
