### PR TITLE
Fix OpenGL blend state causing dark inventory slots.

### DIFF
--- a/src/main/java/tconstruct/client/tabs/AbstractTab.java
+++ b/src/main/java/tconstruct/client/tabs/AbstractTab.java
@@ -42,6 +42,7 @@ public abstract class AbstractTab extends GuiButton
             this.itemRenderer.renderItemAndEffectIntoGUI(mc.fontRenderer, mc.renderEngine, renderStack, xPosition + 6, yPosition + 8);
             this.itemRenderer.renderItemOverlayIntoGUI(mc.fontRenderer, mc.renderEngine, renderStack, xPosition + 6, yPosition + 8);
             GL11.glDisable(GL11.GL_LIGHTING);
+            GL11.glEnable(GL11.GL_BLEND);
             this.itemRenderer.zLevel = 0.0F;
             this.zLevel = 0.0F;
             RenderHelper.disableStandardItemLighting();


### PR DESCRIPTION
Small fix, see https://github.com/micdoodle8/Galacticraft/issues/790.

Simply enables OpenGL blending to fix issues with dark vanilla armor slots.
