### PR TITLE
Changed Chisel action animation to be 'bow' instead of 'eat'

### DIFF
--- a/src/main/java/tconstruct/items/tools/Chisel.java
+++ b/src/main/java/tconstruct/items/tools/Chisel.java
@@ -154,7 +154,7 @@ public class Chisel extends ToolCore
     @Override
     public EnumAction getItemUseAction (ItemStack itemstack)
     {
-        return EnumAction.eat;
+        return EnumAction.bow;
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
This used to be like this before, but was changed for some reason. If it is actually supposed to be 'eat', please ignore this. It just seems a bit weird to me the way it is right now.
