### PR TITLE
Fixed tool rendering breaking scoreboard and player list rendering

### DIFF
--- a/src/main/java/tconstruct/client/ToolCoreRenderer.java
+++ b/src/main/java/tconstruct/client/ToolCoreRenderer.java
@@ -164,7 +164,6 @@ public class ToolCoreRenderer implements IItemRenderer
 
             GL11.glDisable(GL11.GL_LIGHTING);
             GL11.glEnable(GL11.GL_ALPHA_TEST);
-            GL11.glAlphaFunc(GL11.GL_GREATER, 0.5F);
             GL11.glDisable(GL11.GL_BLEND);
 
             tess.startDrawingQuads();


### PR DESCRIPTION
This removes an unneeded OpenGL call from ToolCoreRenderer. This call caused parts of the online player list to not render, and caused scoreboards in the sidebar position to not draw at all.
