### PR TITLE
Fix NPE for some (at least Mekanism) pipes

### DIFF
--- a/src/main/java/tconstruct/smeltery/logic/SmelteryDrainLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryDrainLogic.java
@@ -72,6 +72,9 @@ public class SmelteryDrainLogic extends MultiServantLogic implements IFluidHandl
     {
         // Check that the drain is coming from the from the front of the block
         // and that the fluid to be drained is in the smeltery.
+        if(!hasValidMaster())
+            return false;
+            
         boolean containsFluid = fluid == null;
         if (fluid != null)
         {


### PR DESCRIPTION
Happens when you try connecting some types of pipes (tested with Mekanism pipes) - NPEs and crashes upon chunk loading WHEN the smeltery was not finished.

(Crash log here: http://nopaste.info/f0940b534e.html)
I have rather created a direct fix than just opening an issue since we had to fix it on a live server ASAP.
