### PR TITLE
Fix unsafe getCompoundTag call in PotionLauncher.getItemUseAction

### DIFF
--- a/src/main/java/tconstruct/items/tools/PotionLauncher.java
+++ b/src/main/java/tconstruct/items/tools/PotionLauncher.java
@@ -86,7 +86,7 @@ public class PotionLauncher extends Item
     @Override
     public EnumAction getItemUseAction (ItemStack stack)
     {
-        if (!stack.getTagCompound().getCompoundTag("InfiTool").getBoolean("Loaded"))
+        if (stack != null && stack.hasTagCompound() && !stack.getTagCompound().getCompoundTag("InfiTool").getBoolean("Loaded"))
             return EnumAction.bow;
         else
             return EnumAction.none;


### PR DESCRIPTION
- See squeek502/AppleCore#9
