### PR TITLE
Fix arrow shaft name / add CustomMaterial support to DynamicToolPart

### DIFF
--- a/resources/assets/tinker/lang/en_US.lang
+++ b/resources/assets/tinker/lang/en_US.lang
@@ -587,6 +587,7 @@ toolpart.CrossbowLimb=%%material Crossbow Limb
 toolpart.CrossbowBody=%%material Crossbow Body
 toolpart.BowLimb=%%material Bow Limb
 toolpart.Bolt=%%material Bolt
+toolpart.Shaft=%%material Arrow Shaft
 
 # Now with translations of specific material and part combinations:
 #toolpart.ToolRod.wood=Wooden Tool Rod

--- a/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
+++ b/src/main/java/tconstruct/weaponry/TinkerWeaponry.java
@@ -144,7 +144,7 @@ public class TinkerWeaponry {
         TinkerTools.arrowhead = arrowhead = new DynamicToolPart("_arrowhead", "ArrowHead");
         TinkerTools.fletching = fletching = new Fletching().setUnlocalizedName("tconstruct.Fletching");
         partShuriken = new DynamicToolPart("_shuriken", "Shuriken");
-        partArrowShaft = new DynamicToolPart("_arrow_shaft", "Shaft");
+        partArrowShaft = new DynamicToolPart("_arrow_shaft", "Shaft", ArrowShaftMaterial.class);
         partBowLimb = new DynamicToolPart("_bow_limb", "BowLimb");
         partCrossbowLimb = new DynamicToolPart("_crossbow_limb", "CrossbowLimb");
         partCrossbowBody = new DynamicToolPart("_crossbow_body", "CrossbowBody");


### PR DESCRIPTION
 * Fixes #1275

#### Prioritized list of how the name gets resolved for custom materials:

##### If CustomMaterial.input is not null:
  1. `"toolpart." + partName + "." + (CustomMaterial.input.getUnlocalizedName() with the part before the first period removed)`
  2. `"toolpart." + partName` with %%material replaced by `"toolpart.material." + (CustomMaterial.input.getUnlocalizedName() with the part before the first period removed)`
  3. `"toolpart." + partName` with %%material replaced by `CustomMaterial.input.getDisplayName()`

Example with Blaze Rod:
  1. `toolpart.Shaft.blazeRod`
  2. %%material = `toolpart.material.blazeRod`
  3. %%material = `"Blaze Rod"` (the localized name of a blaze rod ItemStack)

##### If CustomMaterial.input is null:
  1. `"toolpart." + partName + "." + customMaterial.oredict`
  2. `"toolpart." + partName` with %%material replaced by `"toolpart.material." + customMaterial.oredict`
  3. `"toolpart." + partName` with %%material replaced by `customMaterial.oredict`

Example with stickWood (note: this isn't currently how it works; the ArrowShaftMaterial is added using a Items.stick ItemStack):
  1. `toolpart.Shaft.stickWood`
  2. %%material = `toolpart.material.stickWood`
  3. %%material = `"stickWood"` (the oredict string)