### PR TITLE
New system for preventing certain modifiers from being combined

### DIFF
--- a/src/main/java/tconstruct/library/crafting/ModifyBuilder.java
+++ b/src/main/java/tconstruct/library/crafting/ModifyBuilder.java
@@ -4,6 +4,8 @@ import java.util.*;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import tconstruct.library.modifier.*;
+import net.minecraftforge.common.MinecraftForge;
+import cpw.mods.fml.common.eventhandler.Event;
 
 public class ModifyBuilder
 {
@@ -13,23 +15,44 @@ public class ModifyBuilder
     public ItemStack modifyItem (ItemStack input, ItemStack[] modifiers)
     {
         ItemStack copy = input.copy(); //Prevent modifying the original
-        if (copy.getItem() instanceof IModifyable)
-        {
-            IModifyable item = (IModifyable) copy.getItem();
+        if (!(copy.getItem() instanceof IModifyable))
+            return null;
 
-            boolean built = false;
-            for (ItemModifier mod : itemModifiers)
-            {
-                if (mod.matches(modifiers, copy) && mod.validType(item))
-                {
-                    built = true;
-                    mod.addMatchingEffect(copy); //Order matters here
-                    mod.modify(modifiers, copy);
-                }
-            }
-            if (built)
-                return copy;
+        IModifyable item = (IModifyable) copy.getItem();
+
+        List<ItemModifier> currentModifiers = new ArrayList<ItemModifier>();
+        ItemModifier newMod = null;
+
+        NBTTagCompound tags = copy.getTagCompound().getCompoundTag(item.getBaseTagName());
+
+        for (ItemModifier mod : itemModifiers)
+        {
+            if (mod.matches(modifiers, copy) && mod.validType(item))
+                newMod = mod;
+
+            if (tags.hasKey(mod.key))
+                currentModifiers.add(mod);
         }
+
+        if (newMod == null)
+            return null;
+
+        for (ItemModifier mod : currentModifiers)
+        {
+            if (!mod.canModifyWith(newMod) || !newMod.canModifyWith(mod))
+                return null;
+        }
+
+        newMod.addMatchingEffect(copy);
+        newMod.modify(modifiers, copy);
+        return copy;
+    }
+
+    public ItemModifier getModifierByKey (String modKey)
+    {
+        for (ItemModifier mod : itemModifiers)
+            if (mod.key == modKey)
+                return mod;
         return null;
     }
 
@@ -38,5 +61,18 @@ public class ModifyBuilder
         if (mod == null)
             throw new NullPointerException("Modifier cannot be null.");
         instance.itemModifiers.add(mod);
+        MinecraftForge.EVENT_BUS.post(new RegisterModifierEvent(mod.key, mod));
+    }
+
+    public static class RegisterModifierEvent extends Event
+    {
+        public final String key;
+        public final ItemModifier modifier;
+
+        RegisterModifierEvent (String key, ItemModifier modifier)
+        {
+            this.key = key;
+            this.modifier = modifier;
+        }
     }
 }

--- a/src/main/java/tconstruct/library/modifier/ItemModifier.java
+++ b/src/main/java/tconstruct/library/modifier/ItemModifier.java
@@ -8,6 +8,7 @@ public abstract class ItemModifier
 {
     public final String key;
     public final List stacks;
+    protected final List modifierBlacklist;
     public final int effectIndex;
     public static Random random = new Random();
 
@@ -26,6 +27,7 @@ public abstract class ItemModifier
         stacks = itemstacks;
         effectIndex = effect;
         key = dataKey;
+        modifierBlacklist = new ArrayList<ItemModifier>();
     }
 
     /** Checks to see if the inputs match the stored items
@@ -93,6 +95,36 @@ public abstract class ItemModifier
     {
         NBTTagCompound tags = input.getTagCompound().getCompoundTag(getTagName(input));
         return tags.getInteger("Modifiers") > 0;
+    }
+
+    /**
+     * @param modifier Modifier to check for incompatibility.
+     * @return Whether this modifier considers itself compatibility with the argument.
+     */
+
+    public boolean canModifyWith (ItemModifier modifier)
+    {
+        if(modifierBlacklist.contains(modifier))
+            return false;
+        return true;
+    }
+
+    /**
+     * @param modifier Modifier to set as incompatible with this one.
+     */
+
+    public void addModifierIncompatibility (ItemModifier modifier)
+    {
+        this.modifierBlacklist.add(modifier);
+    }
+
+    /**
+     * @return A List of ItemModifiers that are incompatible with this one.
+     */
+
+    public List getBlacklist()
+    {
+        return this.modifierBlacklist;
     }
 
     /** Modifies the tool. Adds nbttags, changes existing ones, ticks down modification counter, etc

--- a/src/main/java/tconstruct/modifiers/tools/ModAutoSmelt.java
+++ b/src/main/java/tconstruct/modifiers/tools/ModAutoSmelt.java
@@ -15,8 +15,6 @@ public class ModAutoSmelt extends ModBoolean
     protected boolean canModify (ItemStack tool, ItemStack[] input)
     {
         NBTTagCompound tags = tool.getTagCompound().getCompoundTag("InfiTool");
-        if (tags.getBoolean("Silk Touch"))
-            return false;
         return tags.getInteger("Modifiers") > 0 && !tags.getBoolean(key); //Will fail if the modifier is false or the tag doesn't exist
     }
 

--- a/src/main/java/tconstruct/modifiers/tools/ModButtertouch.java
+++ b/src/main/java/tconstruct/modifiers/tools/ModButtertouch.java
@@ -24,10 +24,7 @@ public class ModButtertouch extends ModBoolean
                 return false;
 
             NBTTagCompound tags = tool.getTagCompound().getCompoundTag("InfiTool");
-            if (!tags.getBoolean("Lava") && !tags.hasKey("Lapis"))
-            {
-                return tags.getInteger("Modifiers") > 0 && !tags.getBoolean(key);
-            }
+            return tags.getInteger("Modifiers") > 0 && !tags.getBoolean(key);
         }
         return false;
     }

--- a/src/main/java/tconstruct/modifiers/tools/ModLapis.java
+++ b/src/main/java/tconstruct/modifiers/tools/ModLapis.java
@@ -31,9 +31,6 @@ public class ModLapis extends ItemModTypeFilter
 
             NBTTagCompound tags = tool.getTagCompound().getCompoundTag("InfiTool");
 
-            if (tags.getBoolean("Silk Touch"))
-                return false;
-
             if (!tags.hasKey(key))
                 return tags.getInteger("Modifiers") > 0 && matchingAmount(input) <= max;
 

--- a/src/main/java/tconstruct/tools/TinkerTools.java
+++ b/src/main/java/tconstruct/tools/TinkerTools.java
@@ -335,6 +335,7 @@ public class TinkerTools
     {
         addPartMapping();
         addRecipesForToolBuilder();
+        addModifierIncompatibilities();
         addRecipesForChisel();
         craftingTableRecipes();
         setupToolTabs();
@@ -464,6 +465,12 @@ public class TinkerTools
         ModifyBuilder.registerModifier(new ModReinforced(new ItemStack[] { obsidianPlate }, 16, 1));
 
         TConstructRegistry.registerActiveToolMod(new TActiveOmniMod());
+    }
+
+    private void addModifierIncompatibilities()
+    {
+        ModifyBuilder.instance.getModifierByKey("Silk Touch").addModifierIncompatibility(ModifyBuilder.instance.getModifierByKey("Lava"));
+        ModifyBuilder.instance.getModifierByKey("Silk Touch").addModifierIncompatibility(ModifyBuilder.instance.getModifierByKey("Lapis"));
     }
 
     private void addRecipesForChisel ()


### PR DESCRIPTION
ItemModifiers now use a new, blacklist-based, system for checking incompatibilities.
Registering an incompatibility between two modifiers can now be done by calling ItemModifier.addIncompatibility(<key>) on either end where <key> is the ItemModifier.key from the modifier it should be incompatible with.
Added the RegisterModifierEvent, which fires on MinecraftForge.EVENT_BUS whenever a new modifier is registered to the ModifyBuilder.