### PR TITLE
Fix bug with opening/closing GUI speeding smeltery up...

### DIFF
--- a/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/SmelteryLogic.java
@@ -701,9 +701,6 @@ public class SmelteryLogic extends InventoryLogic implements IActiveLogic, IFaci
     @Override
     public void markDirty ()
     {
-        updateTemperatures();
-        updateEntity();
-
         super.markDirty();
         needsUpdate = true;
         // worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);


### PR DESCRIPTION
... and other possible hidden and related bugs.

markDirty called updateEntity that called heatItems which called markDirty ---

markDirty should definitely not update the entity to begin with.