### PR TITLE
No more furious item swapping when adding modifiers

### DIFF
--- a/src/main/java/tconstruct/smeltery/blocks/SearedBlock.java
+++ b/src/main/java/tconstruct/smeltery/blocks/SearedBlock.java
@@ -2,6 +2,9 @@ package tconstruct.smeltery.blocks;
 
 import cpw.mods.fml.relauncher.*;
 import java.util.List;
+
+import com.sun.istack.internal.logging.Logger;
+
 import mantle.blocks.abstracts.InventoryBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -278,20 +281,17 @@ public class SearedBlock extends InventoryBlock
         return world.getBlockMetadata(x, y, z) == 1;
     }
 
-    private boolean wasPowered = false;
-
     @Override
-    public void onNeighborBlockChange (World world, int x, int y, int z, Block neighborBlockID)
+    public void onNeighborBlockChange (World world, int x, int y, int z, Block neighborBlock)
     {
         if (world.getBlockMetadata(x, y, z) == 1)
         {
             boolean isPowered = world.isBlockIndirectlyGettingPowered(x, y, z);
-            if (!wasPowered && isPowered)
+            if (isPowered)
             {
                 FaucetLogic logic = (FaucetLogic) world.getTileEntity(x, y, z);
                 logic.setActive(true);
             }
-            wasPowered = isPowered;
         }
     }
 

--- a/src/main/java/tconstruct/smeltery/logic/FaucetLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/FaucetLogic.java
@@ -203,7 +203,6 @@ public class FaucetLogic extends TileEntity implements IFacingLogic, IActiveLogi
     	if(active == flag) {
     		return; // if there would be no change
     	}
-    	Logger.getAnonymousLogger().info(flag+" "+active);
         active = flag;
         active = activateFaucet(); // same as if(!activateFaucet()) active = false;
     }

--- a/src/main/java/tconstruct/smeltery/logic/FaucetLogic.java
+++ b/src/main/java/tconstruct/smeltery/logic/FaucetLogic.java
@@ -1,13 +1,20 @@
 package tconstruct.smeltery.logic;
 
-import mantle.blocks.iface.*;
+import java.util.logging.Logger;
+
+import mantle.blocks.iface.IActiveLogic;
+import mantle.blocks.iface.IFacingLogic;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.network.*;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
-import net.minecraftforge.fluids.*;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidTankInfo;
+import net.minecraftforge.fluids.IFluidHandler;
 import tconstruct.TConstruct;
 
 public class FaucetLogic extends TileEntity implements IFacingLogic, IActiveLogic, IFluidHandler
@@ -193,16 +200,12 @@ public class FaucetLogic extends TileEntity implements IFacingLogic, IActiveLogi
     @Override
     public void setActive (boolean flag)
     {
-        if (!active)
-        {
-            active = true;
-            if (!activateFaucet())
-                active = false;
-        }
-        else
-        {
-            active = false;
-        }
+    	if(active == flag) {
+    		return; // if there would be no change
+    	}
+    	Logger.getAnonymousLogger().info(flag+" "+active);
+        active = flag;
+        active = activateFaucet(); // same as if(!activateFaucet()) active = false;
     }
 
     @Override

--- a/src/main/java/tconstruct/tools/inventory/SlotTool.java
+++ b/src/main/java/tconstruct/tools/inventory/SlotTool.java
@@ -1,15 +1,15 @@
 package tconstruct.tools.inventory;
 
 import java.util.Random;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
-import net.minecraft.inventory.*;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.MinecraftForge;
 import tconstruct.library.event.ToolCraftedEvent;
 import tconstruct.library.modifier.IModifyable;
-import tconstruct.tools.logic.ToolStationLogic;
 
 public class SlotTool extends Slot
 {
@@ -37,6 +37,13 @@ public class SlotTool extends Slot
         this.onCrafting(stack);
         //stack.setUnlocalizedName("\u00A7f" + toolName);
         super.onPickupFromSlot(par1EntityPlayer, stack);
+        inventory.setInventorySlotContents(1, stack);
+    }
+    
+    public boolean canTakeStack(EntityPlayer p_82869_1_)
+    {
+    	this.onPickupFromSlot(p_82869_1_, getStack());
+        return false;
     }
 
     /**
@@ -56,13 +63,13 @@ public class SlotTool extends Slot
     {
         if (stack.getItem() instanceof IModifyable)
         {
-            NBTTagCompound tags = stack.getTagCompound().getCompoundTag(((IModifyable) stack.getItem()).getBaseTagName());
+            //NBTTagCompound tags = stack.getTagCompound().getCompoundTag(((IModifyable) stack.getItem()).getBaseTagName());
             Boolean full = (inventory.getStackInSlot(2) != null || inventory.getStackInSlot(3) != null);
             for (int i = 2; i <= 3; i++)
                 inventory.decrStackSize(i, 1);
-            ItemStack compare = inventory.getStackInSlot(1);
-            int amount = compare.getItem() instanceof IModifyable ? compare.stackSize : 1;
-            inventory.decrStackSize(1, amount);
+            //ItemStack compare = inventory.getStackInSlot(1);
+            //int amount = compare.getItem() instanceof IModifyable ? compare.stackSize : 1;
+            //inventory.decrStackSize(1, amount);
             if (!player.worldObj.isRemote && full)
                 player.worldObj.playSoundEffect(player.posX, player.posY, player.posZ, "tinker:little_saw", 1.0F, (random.nextFloat() - random.nextFloat()) * 0.2F + 1.0F);
             MinecraftForge.EVENT_BUS.post(new ToolCraftedEvent(this.inventory, player, stack));

--- a/src/main/java/tconstruct/tools/inventory/SlotToolForge.java
+++ b/src/main/java/tconstruct/tools/inventory/SlotToolForge.java
@@ -24,15 +24,15 @@ public class SlotToolForge extends SlotTool
     {
         if (stack.getItem() instanceof IModifyable)
         {
-            NBTTagCompound tags = stack.getTagCompound().getCompoundTag(((IModifyable) stack.getItem()).getBaseTagName());
+            //NBTTagCompound tags = stack.getTagCompound().getCompoundTag(((IModifyable) stack.getItem()).getBaseTagName());
             Boolean full = (inventory.getStackInSlot(2) != null || inventory.getStackInSlot(3) != null || inventory.getStackInSlot(4) != null);
             for (int i = 2; i <= 4; i++)
                 inventory.decrStackSize(i, 1);
-            ItemStack compare = inventory.getStackInSlot(1);
-            int amount = compare.getItem() instanceof IModifyable ? compare.stackSize : 1;
-            inventory.decrStackSize(1, amount);
+            //ItemStack compare = inventory.getStackInSlot(1);
+            //int amount = compare.getItem() instanceof IModifyable ? compare.stackSize : 1;
+            //inventory.decrStackSize(1, amount);
             if (!player.worldObj.isRemote && full)
-                player.worldObj.playAuxSFX(1021, (int) player.posX, (int) player.posY, (int) player.posZ, 0);
+            	player.worldObj.playSoundEffect(player.posX, player.posY, player.posZ, "random.anvil_use", 1.0F, (random.nextFloat() - random.nextFloat()) * 0.2F + 1.0F);
             MinecraftForge.EVENT_BUS.post(new ToolCraftedEvent(this.inventory, player, stack));
         }
         else

--- a/src/main/java/tconstruct/tools/inventory/ToolForgeContainer.java
+++ b/src/main/java/tconstruct/tools/inventory/ToolForgeContainer.java
@@ -1,16 +1,16 @@
 package tconstruct.tools.inventory;
 
 import net.minecraft.block.Block;
-import net.minecraft.entity.player.*;
-import net.minecraft.init.Items;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.MinecraftForge;
 import tconstruct.library.event.ToolCraftedEvent;
 import tconstruct.library.modifier.IModifyable;
 import tconstruct.tools.TinkerTools;
-import tconstruct.tools.logic.*;
+import tconstruct.tools.logic.ToolForgeLogic;
+import tconstruct.tools.logic.ToolStationLogic;
 
 public class ToolForgeContainer extends ToolStationContainer
 {
@@ -24,7 +24,7 @@ public class ToolForgeContainer extends ToolStationContainer
     public void initializeContainer (InventoryPlayer inventoryplayer, ToolStationLogic builderlogic)
     {
         invPlayer = inventoryplayer;
-        this.logic = builderlogic;
+        logic = builderlogic;
 
         toolSlot = new SlotToolForge(inventoryplayer.player, logic, 0, 225, 38);
         this.addSlotToContainer(toolSlot);
@@ -81,33 +81,11 @@ public class ToolForgeContainer extends ToolStationContainer
     {
         if (stack.getItem() instanceof IModifyable)
         {
-            NBTTagCompound tags = stack.getTagCompound().getCompoundTag(((IModifyable) stack.getItem()).getBaseTagName());
             Boolean full = (logic.getStackInSlot(2) != null || logic.getStackInSlot(3) != null || logic.getStackInSlot(4) != null);
-            for (int i = 2; i <= 4; i++)
-                logic.decrStackSize(i, 1);
-            ItemStack compare = logic.getStackInSlot(1);
-            int amount = compare.getItem() instanceof IModifyable ? compare.stackSize : 1;
-            logic.decrStackSize(1, amount);
             EntityPlayer player = invPlayer.player;
             if (!player.worldObj.isRemote && full)
-                player.worldObj.playAuxSFX(1021, (int) player.posX, (int) player.posY, (int) player.posZ, 0);
+            	player.worldObj.playSoundEffect(player.posX, player.posY, player.posZ, "random.anvil_use", 1.0F, (random.nextFloat() - random.nextFloat()) * 0.2F + 1.0F);
             MinecraftForge.EVENT_BUS.post(new ToolCraftedEvent(this.logic, player, stack));
-        }
-        else
-        //Simply naming items
-        {
-            ItemStack stack2 = logic.getStackInSlot(1);
-            int amount = logic.getStackInSlot(1).stackSize;
-            logic.decrStackSize(1, amount);
-
-            if(!ToolStationLogic.canRename(stack2.getTagCompound(), stack2)) {
-                for(int i = 0; i < logic.getSizeInventory(); i++) {
-                    if(logic.getStackInSlot(i) != null && logic.getStackInSlot(i).getItem() == Items.name_tag) {
-                        logic.decrStackSize(i, 1);
-                        break;
-                    }
-                }
-            }
         }
     }
 

--- a/src/main/java/tconstruct/tools/inventory/ToolStationContainer.java
+++ b/src/main/java/tconstruct/tools/inventory/ToolStationContainer.java
@@ -1,12 +1,12 @@
 package tconstruct.tools.inventory;
 
 import java.util.Random;
+
 import net.minecraft.block.Block;
-import net.minecraft.entity.player.*;
-import net.minecraft.init.Items;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.MinecraftForge;
 import tconstruct.library.event.ToolCraftedEvent;
 import tconstruct.library.modifier.IModifyable;
@@ -138,33 +138,11 @@ public class ToolStationContainer extends ActiveContainer
     {
         if (stack.getItem() instanceof IModifyable)
         {
-            NBTTagCompound tags = stack.getTagCompound().getCompoundTag(((IModifyable) stack.getItem()).getBaseTagName());
             Boolean full = (logic.getStackInSlot(2) != null || logic.getStackInSlot(3) != null);
-            for (int i = 2; i <= 3; i++)
-                logic.decrStackSize(i, 1);
-            ItemStack compare = logic.getStackInSlot(1);
-            int amount = compare.getItem() instanceof IModifyable ? compare.stackSize : 1;
-            logic.decrStackSize(1, amount);
             EntityPlayer player = invPlayer.player;
             if (!player.worldObj.isRemote && full)
                 player.worldObj.playSoundEffect(logic.xCoord, logic.yCoord, logic.zCoord, "tinker:little_saw", 1.0F, (random.nextFloat() - random.nextFloat()) * 0.2F + 1.0F);
             MinecraftForge.EVENT_BUS.post(new ToolCraftedEvent(this.logic, player, stack));
-        }
-        else
-        //Simply naming items        
-        {
-            ItemStack stack2 = logic.getStackInSlot(1);
-            int amount = logic.getStackInSlot(1).stackSize;
-            logic.decrStackSize(1, amount);
-
-            if(!ToolStationLogic.canRename(stack2.getTagCompound(), stack2)) {
-                for(int i = 0; i < logic.getSizeInventory(); i++) {
-                    if(logic.getStackInSlot(i) != null && logic.getStackInSlot(i).getItem() == Items.name_tag) {
-                        logic.decrStackSize(i, 1);
-                        break;
-                    }
-                }
-            }
         }
     }
 

--- a/src/main/java/tconstruct/tools/logic/ToolForgeLogic.java
+++ b/src/main/java/tconstruct/tools/logic/ToolForgeLogic.java
@@ -11,11 +11,8 @@ import tconstruct.tools.inventory.ToolForgeContainer;
 /* Simple class for storing items in the block
  */
 
-public class ToolForgeLogic extends ToolStationLogic implements ISidedInventory
+public class ToolForgeLogic extends ToolStationLogic
 {
-    ItemStack previousTool;
-    String toolName;
-
     public ToolForgeLogic()
     {
         super(6);
@@ -70,19 +67,4 @@ public class ToolForgeLogic extends ToolStationLogic implements ISidedInventory
         }
         inventory[0] = output;
     }
-    /*public void buildTool (String name)
-    {
-        toolName = name;
-        ItemStack tool = ToolBuilder.instance.buildTool(inventory[1], inventory[2], inventory[3], inventory[4], name);
-        if (inventory[0] == null)
-            inventory[0] = tool;
-        else
-        {
-            NBTTagCompound tags = inventory[0].getTagCompound();
-            if (!tags.getCompoundTag("InfiTool").hasKey("Built"))
-            {
-                inventory[0] = tool;
-            }
-        }
-    }*/
 }

--- a/src/main/java/tconstruct/tools/logic/ToolStationLogic.java
+++ b/src/main/java/tconstruct/tools/logic/ToolStationLogic.java
@@ -3,14 +3,14 @@ package tconstruct.tools.logic;
 import mantle.blocks.abstracts.InventoryLogic;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Items;
-import net.minecraft.inventory.*;
-import net.minecraft.item.Item;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
-import tconstruct.library.crafting.*;
+import tconstruct.library.crafting.ModifyBuilder;
+import tconstruct.library.crafting.ToolBuilder;
 import tconstruct.library.modifier.IModifyable;
-import tconstruct.library.tools.ToolCore;
 import tconstruct.tools.inventory.ToolStationContainer;
 
 /* Simple class for storing items in the block
@@ -93,11 +93,11 @@ public class ToolStationLogic extends InventoryLogic implements ISidedInventory
                     output = tool;
                 else if (tool != null)
                 {
-                    NBTTagCompound tags = tool.getTagCompound();
-                    if (!tags.getCompoundTag(((IModifyable) tool.getItem()).getBaseTagName()).hasKey("Built"))
-                    {
+                    //NBTTagCompound tags = tool.getTagCompound();
+                    //if (!tags.getCompoundTag(((IModifyable) tool.getItem()).getBaseTagName()).hasKey("Built"))
+                    //{
                         output = tool;
-                    }
+                    //}
                 }
             }
             if (!name.equals("")) //Name item


### PR DESCRIPTION
Made it so you can just click on the result slot on tool station/forge to apply modifiers or build a tool.
I personally hate how you have to move the tool back to the slot on the right every time you apply a modifier.
Other fixes too, apparently.