### PR TITLE
Fixes #1561

### DIFF
--- a/src/main/java/tconstruct/armor/modelblock/DryingRackSpecialRender.java
+++ b/src/main/java/tconstruct/armor/modelblock/DryingRackSpecialRender.java
@@ -56,9 +56,7 @@ public class DryingRackSpecialRender extends TileEntitySpecialRenderer
                 GL11.glTranslatef(0F, 0F, 0.375F);
             if (meta == 3)
             {
-            	/**
-            	 * Rotate the image as it is flipped, translate to the correct spot.
-            	 */
+            	// Rotate, Flip.
             	GL11.glRotatef(180F, 0F, 1F, 0F);
             	GL11.glTranslatef(0F, 0F, 0.2F);
             	//GL11.glTranslatef(0F, 0F, -0.375F);
@@ -69,9 +67,7 @@ public class DryingRackSpecialRender extends TileEntitySpecialRenderer
             }
             if (meta == 5)
             {
-            	/**
-            	 * Rotate the image as it is flipped, translate to the correct spot.
-            	 */
+            	//Rotate, Flip.
             	GL11.glRotatef(180F, 0F, 1F, 0F);
             	GL11.glTranslatef(0F, 0F, 0.3F);
                 //GL11.glTranslatef(0F, 0F, -0.5F);

--- a/src/main/java/tconstruct/armor/modelblock/DryingRackSpecialRender.java
+++ b/src/main/java/tconstruct/armor/modelblock/DryingRackSpecialRender.java
@@ -55,11 +55,27 @@ public class DryingRackSpecialRender extends TileEntitySpecialRenderer
             if (meta == 2)
                 GL11.glTranslatef(0F, 0F, 0.375F);
             if (meta == 3)
-                GL11.glTranslatef(0F, 0F, -0.375F);
+            {
+            	/**
+            	 * Rotate the image as it is flipped, translate to the correct spot.
+            	 */
+            	GL11.glRotatef(180F, 0F, 1F, 0F);
+            	GL11.glTranslatef(0F, 0F, 0.2F);
+            	//GL11.glTranslatef(0F, 0F, -0.375F);
+            }
             if (meta == 4)
+            {
                 GL11.glTranslatef(0F, 0F, 0.2875F);
+            }
             if (meta == 5)
-                GL11.glTranslatef(0F, 0F, -0.5F);
+            {
+            	/**
+            	 * Rotate the image as it is flipped, translate to the correct spot.
+            	 */
+            	GL11.glRotatef(180F, 0F, 1F, 0F);
+            	GL11.glTranslatef(0F, 0F, 0.3F);
+                //GL11.glTranslatef(0F, 0F, -0.5F);
+            }
         }
         GL11.glScalef(2F, 2F, 2F);
         if (stack.getItem() instanceof ItemBlock)


### PR DESCRIPTION
The item in the drying rack was being rendered on the incorrect side of
the block, rotating to face the correct way then translating it to the
correct spot fixes the issue.