### PR TITLE
fixes #1468

### DIFF
--- a/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
+++ b/src/main/java/tconstruct/smeltery/gui/SmelteryGui.java
@@ -506,6 +506,7 @@ public class SmelteryGui extends ActiveContainerGui
 
             this.zLevel = 0.0F;
             itemRender.zLevel = 0.0F;
+            RenderHelper.enableGUIStandardItemLighting();
         }
     }
 


### PR DESCRIPTION
This is the issue where all block lighting is broken in the NEI as shown here
![](http://puu.sh/iTXw7/a6daef36ce.png)

By just cleaning up the flags after drawing the tooltip this is fixed
![](http://puu.sh/iTXyU/19d9483116.png)