### PR TITLE
Fixed ArrayIndexOutOfBoundsException on DiamondApple getUnlocalizedName()

### DIFF
--- a/src/main/java/tconstruct/armor/items/DiamondApple.java
+++ b/src/main/java/tconstruct/armor/items/DiamondApple.java
@@ -76,15 +76,11 @@ public class DiamondApple extends ItemFood
     public String getUnlocalizedName (ItemStack itemstack)
     {
         int damage = itemstack.getItemDamage();
-        int name_index = 0;
+        int name_index = damage;
 
-        if( damage < 0 )
+        if( name_index < 0 || name_index >= itemNames.length )
         {
             name_index = 0;
-        }
-        else if( damage >= itemNames.length )
-        {
-            name_index = itemNames.length-1;
         }
 
         return (new StringBuilder()).append("item.food.").append(itemNames[name_index]).toString();

--- a/src/main/java/tconstruct/armor/items/DiamondApple.java
+++ b/src/main/java/tconstruct/armor/items/DiamondApple.java
@@ -75,6 +75,18 @@ public class DiamondApple extends ItemFood
     @Override
     public String getUnlocalizedName (ItemStack itemstack)
     {
-        return (new StringBuilder()).append("item.food.").append(itemNames[itemstack.getItemDamage()]).toString();
+        int damage = itemstack.getItemDamage();
+        int name_index = 0;
+
+        if( damage < 0 )
+        {
+            name_index = 0;
+        }
+        else if( damage >= itemNames.length )
+        {
+            name_index = itemNames.length-1;
+        }
+
+        return (new StringBuilder()).append("item.food.").append(itemNames[name_index]).toString();
     }
 }


### PR DESCRIPTION
This makes the DiamondApple's getUnlocalizedName() method more robust by disallowing any possibility of invalid array indices.  I have also added the tweaks boni wanted.