### PR TITLE
Fix a crash with dynamically generated tool parts (bolts) trying to get a material name shorter than 9 characters.

### DIFF
--- a/src/main/java/tconstruct/library/tools/DynamicToolPart.java
+++ b/src/main/java/tconstruct/library/tools/DynamicToolPart.java
@@ -19,6 +19,7 @@ import tconstruct.tools.TinkerTools;
 import tconstruct.util.config.PHConstruct;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class DynamicToolPart extends CraftingItem implements IToolPart
@@ -85,7 +86,7 @@ public class DynamicToolPart extends CraftingItem implements IToolPart
             if(toolmat == null)
                 return super.getItemStackDisplayName(stack);
 
-            material = toolmat.localizationString.substring(9); // :(
+            material = toolmat.localizationString.toLowerCase(Locale.ENGLISH).startsWith("material.") ? toolmat.localizationString.substring(9) : toolmat.localizationString; // :(
             matName = toolmat.prefixName();
         }
         else


### PR DESCRIPTION
Bolts appear to be dynamically generated for every registered tool material. If the localized material name is shorter than 9 characters, the game will crash trying to display that ItemStack in the Creative Search tab.

The check should ensure compatibility with existing materials consists.