### PR TITLE
Hide SlotAccessory id 0

### DIFF
--- a/src/main/java/tconstruct/armor/inventory/ArmorExtendedContainer.java
+++ b/src/main/java/tconstruct/armor/inventory/ArmorExtendedContainer.java
@@ -16,7 +16,7 @@ public class ArmorExtendedContainer extends ActiveContainer
         invPlayer = inventoryplayer;
         this.armor = armor;
 
-        this.addSlotToContainer(new SlotAccessory(armor, 0, 80, 17, 1));
+        //this.addSlotToContainer(new SlotAccessory(armor, 0, 80, 17, 1));
         this.addSlotToContainer(new SlotAccessory(armor, 1, 80, 35, 1));
         this.addSlotToContainer(new SlotAccessory(armor, 2, 116, 17, 1));
         this.addSlotToContainer(new SlotAccessory(armor, 3, 116, 35, 1));


### PR DESCRIPTION
Hide the SlotAccessory with id 0, as users get confused wondering what goes there, and nothing as of yet is implemented to go into that slot.