### PR TITLE
Add CraftingTweaks Support

### DIFF
--- a/src/main/java/slimeknights/tconstruct/TConstruct.java
+++ b/src/main/java/slimeknights/tconstruct/TConstruct.java
@@ -30,6 +30,7 @@ import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.library.tinkering.IndestructibleEntityItem;
 import slimeknights.tconstruct.library.utils.HarvestLevels;
 import slimeknights.tconstruct.plugin.ChiselAndBits;
+import slimeknights.tconstruct.plugin.CraftingTweaks;
 import slimeknights.tconstruct.plugin.TinkerVintageCraft;
 import slimeknights.tconstruct.shared.TinkerCommons;
 import slimeknights.tconstruct.shared.TinkerFluids;
@@ -81,6 +82,7 @@ public class TConstruct {
     // Plugins/Integration
     //pulseManager.registerPulse(new TinkerVintageCraft());
     pulseManager.registerPulse(new ChiselAndBits());
+    pulseManager.registerPulse(new CraftingTweaks());
 
     pulseManager.registerPulse(new TinkerDebug());
   }

--- a/src/main/java/slimeknights/tconstruct/plugin/CraftingTweaks.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/CraftingTweaks.java
@@ -1,0 +1,25 @@
+package slimeknights.tconstruct.plugin;
+
+import com.google.common.eventbus.Subscribe;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+import slimeknights.mantle.pulsar.pulse.Pulse;
+import slimeknights.tconstruct.tools.inventory.ContainerCraftingStation;
+
+@Pulse(id = CraftingTweaks.PulseId, modsRequired = CraftingTweaks.modid, defaultEnable = true)
+public class CraftingTweaks {
+
+  public static final String modid = "craftingtweaks";
+  public static final String PulseId = modid + "Integration";
+
+  @Subscribe
+  public void init(FMLInitializationEvent event) {
+    NBTTagCompound tagCompound = new NBTTagCompound();
+    tagCompound.setString("ContainerClass", ContainerCraftingStation.class.getName());
+    tagCompound.setInteger("ButtonOffsetX", 10);
+    tagCompound.setInteger("ButtonOffsetY", 49);
+    FMLInterModComms.sendMessage(modid, "RegisterProvider", tagCompound);
+  }
+
+}


### PR DESCRIPTION
Adds support for [Crafting Tweaks](http://minecraft.curseforge.com/projects/crafting-tweaks), which adds rotate/balance/clear buttons to supported crafting GUIs.

If you'd like to test it, you can grab the latest build on my [Jenkins](http://jenkins.blay09.net/job/Crafting%20Tweaks%201.8.9/).