### PR TITLE
Fix JEI recipe transferring in the Crafting Station

### DIFF
--- a/src/main/java/slimeknights/tconstruct/plugin/jei/CraftingStationRecipeTransferInfo.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/CraftingStationRecipeTransferInfo.java
@@ -1,0 +1,44 @@
+package slimeknights.tconstruct.plugin.jei;
+
+import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
+import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import slimeknights.tconstruct.tools.inventory.ContainerCraftingStation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author shadowfacts
+ */
+public class CraftingStationRecipeTransferInfo implements IRecipeTransferInfo {
+
+	@Override
+	public Class<? extends Container> getContainerClass() {
+		return ContainerCraftingStation.class;
+	}
+
+	@Override
+	public String getRecipeCategoryUid() {
+		return VanillaRecipeCategoryUid.CRAFTING;
+	}
+
+	@Override
+	public List<Slot> getRecipeSlots(Container container) {
+		List<Slot> slots = new ArrayList<Slot>();
+		for (int i = 1; i < 10; i++) {
+			slots.add(container.getSlot(i));
+		}
+		return slots;
+	}
+
+	@Override
+	public List<Slot> getInventorySlots(Container container) {
+		List<Slot> slots = new ArrayList<Slot>();
+		for (int i = 10; i < container.inventorySlots.size(); i++) {
+			slots.add(container.getSlot(i));
+		}
+		return slots;
+	}
+}

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
@@ -46,7 +46,7 @@ public class JEIPlugin implements IModPlugin {
 
     if(TConstruct.pulseManager.isPulseLoaded(TinkerTools.PulseId)) {
       // crafting table shiftclicking
-      registry.getRecipeTransferRegistry().addRecipeTransferHandler(ContainerCraftingStation.class, VanillaRecipeCategoryUid.CRAFTING, 1, 9, 10, 36);
+      registry.getRecipeTransferRegistry().addRecipeTransferHandler(new CraftingStationRecipeTransferInfo());
     }
 
     // Smeltery


### PR DESCRIPTION
Previously, (if a side chest was present) only the chest slots would be used, and the player inventory slots would be ignored.

Fixes mezz/JustEnoughItems#128