### PR TITLE
Adds foliage colors to slime based blocks

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,4 +4,4 @@ forge_version=12.16.0.1811-1.9
 mappings=snapshot_20160324
 
 mantle_version=0.9.2.jenkins104
-jei_version=3.0.+
+jei_version=3.1.+

--- a/src/main/java/slimeknights/tconstruct/world/WorldClientProxy.java
+++ b/src/main/java/slimeknights/tconstruct/world/WorldClientProxy.java
@@ -1,25 +1,29 @@
 package slimeknights.tconstruct.world;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.BlockSapling;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.client.renderer.block.statemap.DefaultStateMapper;
 import net.minecraft.client.renderer.block.statemap.IStateMapper;
 import net.minecraft.client.renderer.block.statemap.StateMap;
+import net.minecraft.client.renderer.color.BlockColors;
+import net.minecraft.client.renderer.color.IBlockColor;
+import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.client.resources.IReloadableResourceManager;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
-
-import java.util.Map;
 
 import slimeknights.tconstruct.common.ClientProxy;
 import slimeknights.tconstruct.library.client.renderer.RenderTinkerSlime;
 import slimeknights.tconstruct.world.block.BlockSlimeGrass;
-import slimeknights.tconstruct.world.block.BlockSlimeLeaves;
+import slimeknights.tconstruct.world.block.BlockSlimeGrass.FoliageType;
 import slimeknights.tconstruct.world.block.BlockSlimeSapling;
 import slimeknights.tconstruct.world.block.BlockTallSlimeGrass;
 import slimeknights.tconstruct.world.client.CustomStateMap;
@@ -28,14 +32,74 @@ import slimeknights.tconstruct.world.entity.EntityBlueSlime;
 
 public class WorldClientProxy extends ClientProxy {
   public static SlimeColorizer slimeColorizer = new SlimeColorizer();
+  public static Minecraft minecraft = Minecraft.getMinecraft();
 
   @Override
   public void preInit() {
-    ((IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager()).registerReloadListener(slimeColorizer);
+    ((IReloadableResourceManager) minecraft.getResourceManager()).registerReloadListener(slimeColorizer);
+	  
+	  
     // Entities
     RenderingRegistry.registerEntityRenderingHandler(EntityBlueSlime.class, RenderTinkerSlime.FACTORY_BlueSlime);
 
     super.preInit();
+  }
+  
+  @Override
+  public void init() {
+    final BlockColors blockColors = minecraft.getBlockColors();
+ 
+    // slime grass, slime tall grass, and slime leaves
+    blockColors.registerBlockColorHandler(
+    	new IBlockColor() {
+    		public int colorMultiplier(IBlockState state, IBlockAccess access, BlockPos pos, int tintIndex) {
+    			FoliageType type = state.getValue(BlockSlimeGrass.FOLIAGE);
+    			if ( pos == null )
+    				return SlimeColorizer.getColorStatic(type);
+    				
+    			return SlimeColorizer.getColorForPos(pos, type);
+    		}
+        }, new Block[] { TinkerWorld.slimeGrass, TinkerWorld.slimeGrassTall, TinkerWorld.slimeLeaves }
+    );
+    
+    // slime vines don't use a foliage color state, so color them directly
+    blockColors.registerBlockColorHandler(
+    	new IBlockColor() {
+    		public int colorMultiplier(IBlockState state, IBlockAccess access, BlockPos pos, int tintIndex) {
+    			if ( pos == null )
+    				return SlimeColorizer.getColorStatic(BlockSlimeGrass.FoliageType.BLUE);
+    				
+    			return SlimeColorizer.getColorForPos(pos, BlockSlimeGrass.FoliageType.BLUE);
+    		}
+        }, new Block[] { TinkerWorld.slimeVineBlue1, TinkerWorld.slimeVineBlue2, TinkerWorld.slimeVineBlue3 }
+    );
+    blockColors.registerBlockColorHandler(
+    	new IBlockColor() {
+    		public int colorMultiplier(IBlockState state, IBlockAccess access, BlockPos pos, int tintIndex) {
+    			if ( pos == null )
+    				return SlimeColorizer.getColorStatic(BlockSlimeGrass.FoliageType.PURPLE);
+    				
+    			return SlimeColorizer.getColorForPos(pos, BlockSlimeGrass.FoliageType.PURPLE);
+    		}
+        }, new Block[] { TinkerWorld.slimeVinePurple1, TinkerWorld.slimeVinePurple2, TinkerWorld.slimeVinePurple3 }
+    );
+    
+    // item models simply pull the data from the block models, to make things easier for each separate type
+    minecraft.getItemColors().registerItemColorHandler(
+    	new IItemColor() {
+    		public int getColorFromItemstack(ItemStack stack, int tintIndex)
+    		{
+    			IBlockState iblockstate = ((ItemBlock)stack.getItem()).getBlock().getStateFromMeta(stack.getMetadata());
+    			return blockColors.colorMultiplier(iblockstate, (IBlockAccess)null, (BlockPos)null, tintIndex);
+    		}
+    	}, new Block[] {
+    		TinkerWorld.slimeGrass, TinkerWorld.slimeGrassTall, TinkerWorld.slimeLeaves,
+    		TinkerWorld.slimeVineBlue1, TinkerWorld.slimeVineBlue2, TinkerWorld.slimeVineBlue3,
+    		TinkerWorld.slimeVinePurple1, TinkerWorld.slimeVinePurple2, TinkerWorld.slimeVinePurple3
+    	}
+    );
+    
+    super.init();
   }
 
   @Override


### PR DESCRIPTION
Fixes #1974, see [here for a picture of the result](https://cloud.githubusercontent.com/assets/12155288/14097100/68bc5390-f533-11e5-8cce-39a56e3294b4.png) and [here for a picture with vines](https://cloud.githubusercontent.com/assets/12155288/14096991/a1c96b1a-f532-11e5-830b-7c3b8bab0dd9.png) (the missing model issue existed before I made any changes, so I reported it at #1981)

Also updates the JEI version, since the 3.0.+ versions are not compatible with the latest Forge (which blocks the launching of Minecraft)