### PR TITLE
config option for invulnerability of dropped tools

### DIFF
--- a/src/main/java/tconstruct/TConstruct.java
+++ b/src/main/java/tconstruct/TConstruct.java
@@ -7,6 +7,7 @@ import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.*;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.network.NetworkCheckHandler;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -14,9 +15,11 @@ import cpw.mods.fml.common.registry.VillagerRegistry;
 import cpw.mods.fml.relauncher.Side;
 import mantle.pulsar.config.ForgeCFG;
 import mantle.pulsar.control.PulseManager;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.world.gen.structure.MapGenStructureIO;
 import net.minecraftforge.common.MinecraftForge;
 
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -181,6 +184,9 @@ public class TConstruct
         MinecraftForge.EVENT_BUS.register(playerTracker);
         NetworkRegistry.INSTANCE.registerGuiHandler(TConstruct.instance, proxy);
 
+        if (PHConstruct.globalDespawn != 6000)
+            MinecraftForge.EVENT_BUS.register(new Spawntercepter());
+
         pulsar.preInit(event);
 
         if (PHConstruct.achievementsEnabled)
@@ -278,6 +284,20 @@ public class TConstruct
         for(FMLMissingMappingsEvent.MissingMapping mapping : event.get()) {
             if(mapping.name.equals("TConstruct:TankAir"))
                 mapping.ignore();
+        }
+    }
+
+    public static class Spawntercepter {
+        @SubscribeEvent
+        public void onEntitySpawn(EntityJoinWorldEvent event)
+        {
+            if(event.entity instanceof EntityItem)
+            {
+                EntityItem ourGuy = (EntityItem)event.entity;
+                if (ourGuy.lifespan == 6000) {
+                    ourGuy.lifespan = PHConstruct.globalDespawn;
+                }
+            }
         }
     }
 }

--- a/src/main/java/tconstruct/tools/entity/FancyEntityItem.java
+++ b/src/main/java/tconstruct/tools/entity/FancyEntityItem.java
@@ -5,14 +5,17 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
+import tconstruct.util.config.PHConstruct;
 
 public class FancyEntityItem extends EntityItem
 {
     public FancyEntityItem(World par1World, double par2, double par4, double par6)
     {
         super(par1World, par2, par4, par6);
-        this.isImmuneToFire = true;
-        this.lifespan = 72000;
+        if (PHConstruct.indestructible) {
+            this.isImmuneToFire = true;
+            this.lifespan = 72000;
+        }
     }
 
     public FancyEntityItem(World par1World, double par2, double par4, double par6, ItemStack par8ItemStack)
@@ -25,8 +28,10 @@ public class FancyEntityItem extends EntityItem
     public FancyEntityItem(World par1World)
     {
         super(par1World);
-        this.isImmuneToFire = true;
-        this.lifespan = 72000;
+        if (PHConstruct.indestructible) {
+            this.isImmuneToFire = true;
+            this.lifespan = 72000;
+        }
     }
 
     public FancyEntityItem(World world, Entity original, ItemStack stack)
@@ -41,8 +46,12 @@ public class FancyEntityItem extends EntityItem
 
     public boolean attackEntityFrom (DamageSource par1DamageSource, float par2)
     {
-        if (par1DamageSource.getDamageType().equals("outOfWorld"))
-            return true;
-        return false;
+        if (PHConstruct.indestructible) {
+            if (par1DamageSource.getDamageType().equals("outOfWorld"))
+                return true;
+            return false;
+        } else {
+            return super.attackEntityFrom(par1DamageSource, par2);
+        }
     }
 }

--- a/src/main/java/tconstruct/util/config/PHConstruct.java
+++ b/src/main/java/tconstruct/util/config/PHConstruct.java
@@ -66,6 +66,8 @@ public class PHConstruct
         denyMattock = config.get("Difficulty Changes", "Deny creation of non-metal mattocks", false).getBoolean(false);
         craftEndstone = config.get("Difficulty Changes", "Allow creation of endstone", true).getBoolean(true);
         alternativeBoltRecipe = config.get("Difficulty Changes", "Add alternative recipe for bolt parts: arrowhead + toolrod in a crafting grid", false).getBoolean(false);
+        indestructible = config.get("Difficulty Changes", "Dropped tools are indestructible", true).getBoolean(true);
+        globalDespawn = config.get("Difficulty Changes", "Global item despawn time", 6000).getInt(6000);
 
         naturalSlimeSpawn = config.get("Mobs", "Blue Slime spawn chance", 1, "Set to 0 to disable").getInt(1);
 
@@ -346,6 +348,8 @@ public class PHConstruct
     public static boolean miningLevelIncrease;
     public static boolean denyMattock;
     public static boolean alternativeBoltRecipe;
+    public static boolean indestructible;
+    public static int globalDespawn;
 
     // Smeltery Output Modification
     public static double ingotsPerOre;


### PR DESCRIPTION
Two new config options, which both default to the current behavior, for:
- dropped tools being immune to lava and having a much longer despawn timer
- global item despawn timer for all items, not just tcon tools (only affects tcon tools if the previous option is turned off)

On my server I like to make tinker's construct tools not special, but instead give all items a 15 minute despawn.