### PR TITLE
Fix breaking animation on racks

### DIFF
--- a/resources/assets/tconstruct/blockstates/rack.json
+++ b/resources/assets/tconstruct/blockstates/rack.json
@@ -9,13 +9,13 @@
     "variants": {
         "facing": {
             "down_z": { "model": "tconstruct:rack_down" },
-            "down_x": { "model": "tconstruct:rack_down" },
+            "down_x": { "model": "tconstruct:rack_down", "y": 90 },
             "up_z":   {},
-            "up_x":   {},
-            "north":  { "model": "tconstruct:rack_side" },
+            "up_x":   { "y": 90 },
+            "north":  { "model": "tconstruct:rack_side", "y": 180 },
             "south":  { "model": "tconstruct:rack_side" },
-            "east":   { "model": "tconstruct:rack_side" },
-            "west":   { "model": "tconstruct:rack_side" }
+            "east":   { "model": "tconstruct:rack_side", "y": 270 },
+            "west":   { "model": "tconstruct:rack_side", "y": 90 }
         },
         "drying": {
             "true": {},


### PR DESCRIPTION
Apparently the breaking animation is generated when the model is loaded,
but before the baked table model is loaded, so the animation appears offset at most states. Rotating the models before they are replaced seems to fix it without any later side effects