### PR TITLE
Add facing checks (#2024) and pick block to glow

### DIFF
--- a/src/main/java/slimeknights/tconstruct/gadgets/entity/EntityThrowball.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/entity/EntityThrowball.java
@@ -1,5 +1,6 @@
 package slimeknights.tconstruct.gadgets.entity;
 
+import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.util.EnumFacing;
@@ -7,12 +8,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
-
-import io.netty.buffer.ByteBuf;
 import slimeknights.tconstruct.gadgets.Exploder;
 import slimeknights.tconstruct.gadgets.item.ItemThrowball;
 import slimeknights.tconstruct.shared.TinkerCommons;
-import slimeknights.tconstruct.shared.block.BlockGlow;
 
 public class EntityThrowball extends EntityThrowable implements IEntityAdditionalSpawnData {
 
@@ -54,12 +52,15 @@ public class EntityThrowball extends EntityThrowable implements IEntityAdditiona
       if(pos == null && result.entityHit != null) {
         pos = result.entityHit.getPosition();
       }
+
       EnumFacing facing = EnumFacing.DOWN;
       if(result.typeOfHit == RayTraceResult.Type.BLOCK) {
         pos = pos.offset(result.sideHit);
         facing = result.sideHit.getOpposite();
-      }
-      worldObj.setBlockState(pos, TinkerCommons.blockGlow.getDefaultState().withProperty(BlockGlow.FACING, facing));
+      }  
+
+      // add the glow using the special function in BlockGlow so it faces the right way after placing
+      TinkerCommons.blockGlow.addGlow(worldObj, pos, facing);
     }
   }
 

--- a/src/main/java/slimeknights/tconstruct/shared/TinkerCommons.java
+++ b/src/main/java/slimeknights/tconstruct/shared/TinkerCommons.java
@@ -51,7 +51,7 @@ public class TinkerCommons extends TinkerPulse {
   public static BlockOre blockOre;
   public static BlockMetal blockMetal;
   public static Block blockFirewood;
-  public static Block blockGlow;
+  public static BlockGlow blockGlow;
 
   // block itemstacks
   public static ItemStack grout;

--- a/src/main/java/slimeknights/tconstruct/shared/block/BlockGlow.java
+++ b/src/main/java/slimeknights/tconstruct/shared/block/BlockGlow.java
@@ -24,14 +24,12 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.gadgets.TinkerGadgets;
 import slimeknights.tconstruct.gadgets.item.ItemThrowball;
 
 public class BlockGlow extends Block {
 
   public static PropertyDirection FACING = PropertyDirection.create("facing");
-  private static boolean gadgetsLoaded = TConstruct.pulseManager.isPulseLoaded(TinkerGadgets.PulseId);
 
   public BlockGlow() {
     super(Material.CIRCUITS);
@@ -60,8 +58,8 @@ public class BlockGlow extends Block {
   
   @Override
   public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player) {
-    // use the glowball for the pickblock, as it is more useful than the technical block
-    if(gadgetsLoaded) {
+    // only use the glowball for pickblock if it was loaded (which happens when gadgets is loaded)
+    if(TinkerGadgets.throwball != null) {
       return new ItemStack(TinkerGadgets.throwball, 1, ItemThrowball.ThrowballType.GLOW.ordinal());
     }
 


### PR DESCRIPTION
Glow is now dependant on a block, and upon placing if the face it is
placed on is not solid it will automatically find a solid face (or break
if none is found)

Pick block on a glow now returns a glowball if available, otherwise does
nothing