### PR TITLE
Fix battle sign shielding causing issues (#2038) and remove sweep attack

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tools/item/BattleSign.java
+++ b/src/main/java/slimeknights/tconstruct/tools/item/BattleSign.java
@@ -27,12 +27,13 @@ import java.util.List;
 import slimeknights.tconstruct.common.TinkerNetwork;
 import slimeknights.tconstruct.library.materials.Material;
 import slimeknights.tconstruct.library.tinkering.PartMaterialType;
+import slimeknights.tconstruct.library.tools.ToolCore;
 import slimeknights.tconstruct.library.utils.ToolHelper;
 import slimeknights.tconstruct.tools.TinkerTools;
 import slimeknights.tconstruct.tools.network.EntityMovementChangePacket;
 
 // BattleSign Ability: Blocks more damage and can reflect projectiles. The ultimate defensive weapon.
-public class BattleSign extends BroadSword {
+public class BattleSign extends ToolCore {
 
   public BattleSign() {
     super(PartMaterialType.handle(TinkerTools.toolRod),
@@ -124,7 +125,7 @@ public class BattleSign extends BroadSword {
     }
 
     EntityPlayer player = (EntityPlayer) event.getEntityLiving();
-    ItemStack battlesign = player.getHeldItemMainhand();
+    ItemStack battlesign = player.getActiveItemStack();
 
     // ensure the player is looking at the projectile (aka not getting shot into the back)
     Entity projectile = event.getSource().getSourceOfDamage();
@@ -184,7 +185,7 @@ public class BattleSign extends BroadSword {
     }
 
     // broken battlesign.
-    return !ToolHelper.isBroken(player.getHeldItemMainhand());
+    return !ToolHelper.isBroken(player.getActiveItemStack());
 
   }
 


### PR DESCRIPTION
Battle sign shielding was referencing the main item stack rather than the active one in a few places

Battle signs also inherited the sweep attack from broadswords, which are supposed to be a broadsword thing only