### PR TITLE
Add ItemStack displays to JEI recipe categories

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,4 +4,4 @@ forge_version=12.16.0.1865-1.9
 mappings=snapshot_20160418
 
 mantle_version=0.9.4.jenkins130
-jei_version=3.2.+
+jei_version=3.3.+

--- a/src/main/java/slimeknights/tconstruct/gadgets/block/BlockRack.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/block/BlockRack.java
@@ -63,8 +63,8 @@ public class BlockRack extends BlockTable {
   @SideOnly(Side.CLIENT)
   @Override
   public void getSubBlocks(Item itemIn, CreativeTabs tab, List<ItemStack> list) {
-    list.add(createItemstack(this, 0, Blocks.PLANKS, 0));
-    list.add(createItemstack(this, 1, Blocks.PLANKS, 0));
+    list.add(createItemstack(this, 0, Blocks.WOODEN_SLAB, 0));
+    list.add(createItemstack(this, 1, Blocks.WOODEN_SLAB, 0));
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/CastingRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/CastingRecipeCategory.java
@@ -87,7 +87,7 @@ public class CastingRecipeCategory implements IRecipeCategory {
       // no cast, bigger fluid
       int h = 11;
       if(recipe.getInputs().isEmpty()) {
-        h += 15;
+        h += 16;
       }
       fluids.init(1, true, 64, 15, 6, h, cap, false, null);
       fluids.set(1, recipe.getFluidInputs());

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
@@ -18,13 +19,17 @@ import mezz.jei.api.IJeiHelpers;
 import mezz.jei.api.IJeiRuntime;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
+import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.gadgets.TinkerGadgets;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.smeltery.Cast;
 import slimeknights.tconstruct.library.smeltery.CastingRecipe;
+import slimeknights.tconstruct.shared.block.BlockTable;
 import slimeknights.tconstruct.smeltery.TinkerSmeltery;
+import slimeknights.tconstruct.smeltery.block.BlockCasting;
 import slimeknights.tconstruct.tools.TinkerTools;
+import slimeknights.tconstruct.tools.block.BlockToolTable;
 
 @mezz.jei.api.JEIPlugin
 public class JEIPlugin implements IModPlugin {
@@ -39,6 +44,10 @@ public class JEIPlugin implements IModPlugin {
     if(TConstruct.pulseManager.isPulseLoaded(TinkerTools.PulseId)) {
       // crafting table shiftclicking
       registry.getRecipeTransferRegistry().addRecipeTransferHandler(new CraftingStationRecipeTransferInfo());
+      
+      // add our crafting table to the list with the vanilla crafting table
+      registry.addRecipeCategoryCraftingItem(new ItemStack(TinkerTools.toolTables, 1, BlockToolTable.TableTypes.CraftingStation.meta),
+                                             VanillaRecipeCategoryUid.CRAFTING);
     }
 
     // Smeltery
@@ -53,6 +62,13 @@ public class JEIPlugin implements IModPlugin {
                                  new AlloyRecipeHandler(),
                                  new CastingRecipeHandler());
 
+      registry.addRecipeCategoryCraftingItem(new ItemStack(TinkerSmeltery.smelteryController),
+                                             SmeltingRecipeCategory.CATEGORY,
+                                             AlloyRecipeCategory.CATEGORY);
+      registry.addRecipeCategoryCraftingItem(new ItemStack(TinkerSmeltery.castingBlock, 1, BlockCasting.CastingType.TABLE.meta),
+                                             CastingRecipeCategory.CATEGORY);
+      registry.addRecipeCategoryCraftingItem(new ItemStack(TinkerSmeltery.castingBlock, 1, BlockCasting.CastingType.BASIN.meta),
+                                             CastingRecipeCategory.CATEGORY);
 
       // melting recipes
       registry.addRecipes(TinkerRegistry.getAllMeltingRecipies());
@@ -88,11 +104,12 @@ public class JEIPlugin implements IModPlugin {
       registry.addRecipeCategories(new DryingRecipeCategory(guiHelper));
       registry.addRecipeHandlers(new DryingRecipeHandler());
       registry.addRecipes(TinkerRegistry.getAllDryingRecipes());
+      registry.addRecipeCategoryCraftingItem(BlockTable.createItemstack(TinkerGadgets.rack, 1, Blocks.WOODEN_SLAB, 0),
+                                             DryingRecipeCategory.CATEGORY);
     }
   }
 
   @Override
   public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
-
   }
 }


### PR DESCRIPTION
Adds the smeltery controller to smeltery melting and alloying, the drying rack to drying recipes, the casting table and basin to casting recipes, and the crafting station to vanilla crafting.

Also fixes the casting recipe category's liquid being 1 pixel too high when there is no cast, and the racks in JEI not showing their recipe when right clicked