### PR TITLE
Fix player heads dropping with the wrong metadata

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tools/modifiers/ModBeheading.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modifiers/ModBeheading.java
@@ -105,7 +105,7 @@ public class ModBeheading extends ToolModifier {
     }
     // meta 3: player
     else if(entity instanceof EntityPlayer) {
-      ItemStack head = new ItemStack(Items.SKULL, 1, 4);
+      ItemStack head = new ItemStack(Items.SKULL, 1, 3);
       NBTTagCompound nametag = new NBTTagCompound();
       nametag.setString("SkullOwner", entity.getDisplayName().getFormattedText());
       head.setTagCompound(nametag);


### PR DESCRIPTION
Also, can we get something so I can hook [Headcrumbs](http://minecraft.curseforge.com/projects/headcrumbs) into this withoug much hassle? <3

I saw the TODO on the top of the class and I must say that a Class->ItemStack registry would not suffice at all. Some entities have more than one head (like the vanilla Skeletons). It would be better if there was an actual fired Event, or some sort of registry for head drop handlers of some sort (a simple class with a ```ItemStack getHead(Entity entity)``` method).

If I get an "official" answer on what would be preferred I'd be more than willing to make the PR myself