### PR TITLE
Fix faucet item and fancy frames appearing invisible

### DIFF
--- a/resources/assets/tconstruct/blockstates/fancy_frame.json
+++ b/resources/assets/tconstruct/blockstates/fancy_frame.json
@@ -1,29 +1,14 @@
 {
     "forge_marker": 1,
     "defaults": {
-        "model": "item_frame",
+        "model": "tconstruct:fancy_frame",
         "textures": {
             "particle": "#wood",
             "wood": "tconstruct:blocks/block_ardite",
             "back": "tconstruct:blocks/itemframe_background"
         },
         "transform": {
-            "firstperson_righthand": {
-                "rotation": [ {"x": -20}, {"y": 90}, {"z": 0} ],
-                "translation": [ -0.25, 0.05, 0 ]
-            },
-            "firstperson_lefthand": {
-                "rotation": [ {"x": -20}, {"y": 90}, {"z": 0} ],
-                "translation": [ -0.25, 0.05, 0 ]
-            },
-            "thirdperson_righthand": {
-                "translation": [ 0, 0.18, -0.175 ],
-                "scale": [ 0.5, 0.5, 0.5 ]
-            },
-            "thirdperson_lefthand": {
-                "translation": [ 0, 0.18, -0.175 ],
-                "scale": [ 0.5, 0.5, 0.5 ]
-            }
+
         }
     },
     "variants": {

--- a/resources/assets/tconstruct/blockstates/faucet.json
+++ b/resources/assets/tconstruct/blockstates/faucet.json
@@ -12,41 +12,7 @@
             "west":  { "y": 90 }
         },
         "inventory": {
-            "model": "tconstruct:faucet",
-            "transform": {
-                "gui": {
-                    "rotation": [ {"x": 30}, {"y": 225} ],
-                    "translation": [0.1875, -0.125, 0],
-                    "scale": [0.9375, 0.9375, 0.9375]
-                },
-                "ground": {
-                    "translation": [ 0, 0.1875, 0],
-                    "scale":[ 0.25, 0.25, 0.25 ]
-                },
-                "fixed": {
-                    "scale":[ 0.5, 0.5, 0.5 ]
-                },
-                "thirdperson_righthand": {
-                    "rotation": [ {"x": 75}, {"y": 45} ],
-                    "translation": [ 0, 0.15625, 0],
-                    "scale": [ 0.375, 0.375, 0.375 ]
-                },
-                "thirdperson_lefthand": {
-                    "rotation": [ {"x": 75}, {"y": 45} ],
-                    "translation": [ 0, 0.15625, 0],
-                    "scale": [ 0.375, 0.375, 0.375 ]
-                },
-                "firstperson_righthand": {
-                    "rotation": [ {"y": 135} ],
-                    "translation": [ -0.1875, 0.15625, 0.1875],
-                    "scale": [ 0.40, 0.40, 0.40 ]
-                },
-                "firstperson_lefthand": {
-                    "rotation": [ {"y": 135} ],
-                    "translation": [ -0.1875, 0.15625, 0.1875],
-                    "scale": [ 0.40, 0.40, 0.40 ]
-                }
-            }
+            "model": "tconstruct:faucet"
         }
     }
 }

--- a/resources/assets/tconstruct/models/block/fancy_frame.json
+++ b/resources/assets/tconstruct/models/block/fancy_frame.json
@@ -1,0 +1,31 @@
+{
+    "comment": "Setting display tags for the item form",
+    "parent": "block/item_frame",
+	"display": {
+		"fixed": {
+			"translation": [ 0, 0, -7 ]
+		},
+		"ground": {
+			"translation": [ 0, 0, -2 ],
+			"scale": [ 0.25, 0.25, 0.25 ]
+		},
+		"firstperson_righthand": {
+			"rotation": [ -20, 90, 0 ],
+			"translation": [ -3, 0.5, 0 ]
+		},
+		"firstperson_lefthand": {
+			"rotation": [ -20, 90, 0 ],
+			"translation": [ -3, 0.5, 0 ]
+		},
+		"thirdperson_righthand": {
+			"rotation": [ 0, 180, 0 ],
+			"translation": [ 0, 2, 3.25 ],
+			"scale": [ 0.5, 0.5, 0.5 ]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [ 0, 180, 0 ],
+			"translation": [ 0, 2, 3.25 ],
+			"scale": [ 0.5, 0.5, 0.5 ]
+		}
+	}
+}

--- a/resources/assets/tconstruct/models/block/faucet.json
+++ b/resources/assets/tconstruct/models/block/faucet.json
@@ -4,6 +4,41 @@
         "tex": "tconstruct:blocks/smeltery/faucet",
         "particle": "tconstruct:blocks/smeltery/faucet"
     },
+	"display": {
+		"gui": {
+			"rotation": [ 30, 225, 0 ],
+			"translation": [ 3, -1, 0 ],
+			"scale": [ 0.9375, 0.9375, 0.9375 ]
+		},
+		"ground": {
+			"translation": [ 0, 3, -1 ],
+			"scale": [ 0.25, 0.25, 0.25 ]
+		},
+		"fixed": {
+			"translation": [ 0, 0, -1 ],
+			"scale": [ 0.5, 0.5, 0.5 ]
+		},
+		"thirdperson_righthand": {
+			"rotation": [ 75, 45, 0 ],
+			"translation": [ 0, 3, 0.5 ],
+			"scale": [ 0.4, 0.4, 0.4 ]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [ 75, 45, 0 ],
+			"translation": [ 0, 3, 0.5 ],
+			"scale": [ 0.4, 0.4, 0.4 ]
+		},
+		"firstperson_righthand": {
+			"rotation": [ 0, 135, 0 ],
+			"translation": [ 0, 0.5, 0 ],
+			"scale": [ 0.5, 0.5, 0.5 ]
+		},
+		"firstperson_lefthand": {
+			"rotation": [ 0, 135, 0 ],
+			"translation": [ 0, 0.5, 0 ],
+			"scale": [ 0.5, 0.5, 0.5 ]
+		}
+	},
 	"elements": [
 		{
 		 "from": [  4,  4, 10 ],


### PR DESCRIPTION
It seems something in 1.9.4 broke Forge item blockstate display tags, causing the faucets (as items) and fancy frames to appear invisible (#2127). Switching to a vanilla display tag fixed the issue, and there really is no need to use the Forge blockstate version in this case anyways.