### PR TITLE
Fix capability serializer running on capabilities from other mods, causing a crash

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/capability/TinkerPiggybackSerializer.java
+++ b/src/main/java/slimeknights/tconstruct/library/capability/TinkerPiggybackSerializer.java
@@ -33,12 +33,15 @@ public class TinkerPiggybackSerializer implements ICapabilitySerializable<NBTTag
 
   @Override
   public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
-    return true;
+    return capability == CapabilityTinkerPiggyback.PIGGYBACK;
   }
 
   @Override
   public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
-    return (T)piggyback;
+    if(capability == CapabilityTinkerPiggyback.PIGGYBACK) {
+      return (T)piggyback;
+    }
+    return null;
   }
 
   @Override


### PR DESCRIPTION
Basically, the methods from ICapabilitySerializable are called by any mod requesting their capability, and if we return our ours it crashes due to invalid casting. This fixes it to make sure we are using ours before returning the casted version