### PR TITLE
Add the ability for comparators to check the fluid level in tanks, drying racks, and casting tables/basins

### DIFF
--- a/src/main/java/slimeknights/tconstruct/gadgets/block/BlockRack.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/block/BlockRack.java
@@ -332,4 +332,20 @@ public class BlockRack extends BlockTable {
   public RayTraceResult collisionRayTrace(IBlockState blockState, @Nonnull World worldIn, @Nonnull BlockPos pos, @Nonnull Vec3d start, @Nonnull Vec3d end) {
     return this.rayTrace(pos, start, end, blockState.getBoundingBox(worldIn, pos));
   }
+
+  @Override
+  public boolean hasComparatorInputOverride(IBlockState state) {
+    return state.getValue(DRYING) == Boolean.TRUE;
+  }
+
+  // comparator stuffs
+  @Override
+  public int getComparatorInputOverride(IBlockState blockState, World world, BlockPos pos) {
+    TileEntity te = world.getTileEntity(pos);
+    if(!(te instanceof TileDryingRack)) {
+      return 0;
+    }
+
+    return ((TileDryingRack) te).comparatorStrength();
+  }
 }

--- a/src/main/java/slimeknights/tconstruct/gadgets/tileentity/TileDryingRack.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/tileentity/TileDryingRack.java
@@ -35,21 +35,28 @@ public class TileDryingRack extends TileItemRack implements ITickable, ISidedInv
         // add the result to slot 1 and remove the original from slot 0
         setInventorySlotContents(1, TinkerRegistry.getDryingResult(getStackInSlot(0)));
         setInventorySlotContents(0, null);
-        //updateDryingTime(); drying time updated in setInventorySlotContents
+        //drying time updated in setInventorySlotContents
+
+        // comparator update
+        this.worldObj.notifyNeighborsOfStateChange(this.pos, this.getBlockType());
       }
     }
   }
 
   @Override
-  public void setInventorySlotContents(int slot, ItemStack itemstack) {
+  public void setInventorySlotContents(int slot, ItemStack stack) {
     // if there is no drying recipe, just place the item directly into the output slot for item output and tick efficiency
-    if(slot == 0 && itemstack != null && !isStackInSlot(1) && TinkerRegistry.getDryingResult(itemstack) == null) {
+    if(slot == 0 && !isStackInSlot(1) && stack != null && TinkerRegistry.getDryingResult(stack) == null) {
       slot = 1;
     }
 
-    super.setInventorySlotContents(slot, itemstack);
+    super.setInventorySlotContents(slot, stack);
     if(slot == 0) {
       updateDryingTime();
+    }
+    else {
+      // comparator update
+      this.worldObj.notifyNeighborsOfStateChange(this.pos, this.getBlockType());
     }
   }
 
@@ -74,21 +81,6 @@ public class TileDryingRack extends TileItemRack implements ITickable, ISidedInv
     //worldObj.scheduleUpdate(pos, blockType, 0);
   }
 
-  @Override
-  public void readFromNBT(NBTTagCompound tags) {
-    currentTime = tags.getInteger("Time");
-    maxTime = tags.getInteger("MaxTime");
-    super.readFromNBT(tags);
-  }
-
-  @Nonnull
-  @Override
-  public NBTTagCompound writeToNBT(NBTTagCompound tags) {
-    tags.setInteger("Time", currentTime);
-    tags.setInteger("MaxTime", maxTime);
-    return super.writeToNBT(tags);
-  }
-
   @Nonnull
   @Override
   @SideOnly(Side.CLIENT)
@@ -105,11 +97,35 @@ public class TileDryingRack extends TileItemRack implements ITickable, ISidedInv
   @Override
   public boolean canInsertItem(int index, @Nonnull ItemStack itemStackIn, @Nonnull EnumFacing direction) {
     // Only allow inserting if there is no stack in the result slot
-    return !isStackInSlot(1) && index == 0;
+    return index == 0 && !isStackInSlot(1);
   }
 
   @Override
   public boolean canExtractItem(int index, @Nonnull ItemStack stack, @Nonnull EnumFacing direction) {
     return index == 1;
+  }
+
+  /**
+   * @return The current comparator strength based on if an output exists
+   */
+  public int comparatorStrength() {
+    return isStackInSlot(1) ? 15 : 0;
+  }
+
+  /* Saving and Loading */
+
+  @Override
+  public void readFromNBT(NBTTagCompound tags) {
+    currentTime = tags.getInteger("Time");
+    maxTime = tags.getInteger("MaxTime");
+    super.readFromNBT(tags);
+  }
+
+  @Nonnull
+  @Override
+  public NBTTagCompound writeToNBT(NBTTagCompound tags) {
+    tags.setInteger("Time", currentTime);
+    tags.setInteger("MaxTime", maxTime);
+    return super.writeToNBT(tags);
   }
 }

--- a/src/main/java/slimeknights/tconstruct/library/fluid/FluidTankAnimated.java
+++ b/src/main/java/slimeknights/tconstruct/library/fluid/FluidTankAnimated.java
@@ -55,4 +55,12 @@ public class FluidTankAnimated extends FluidTank {
       }
     }
   }
+
+  @Override
+  protected void onContentsChanged() {
+    // updates the tile entity for the sake of things that detect when contents change (such as comparators)
+    if(parent instanceof IFluidTankUpdater) {
+      ((IFluidTankUpdater) parent).onTankContentsChanged();
+    }
+  }
 }

--- a/src/main/java/slimeknights/tconstruct/library/fluid/IFluidTankUpdater.java
+++ b/src/main/java/slimeknights/tconstruct/library/fluid/IFluidTankUpdater.java
@@ -1,0 +1,13 @@
+package slimeknights.tconstruct.library.fluid;
+
+/**
+ * Allows a tile entity containing an instance of FluidTankAnimated to perform action whenever the tank's contents change
+ */
+public interface IFluidTankUpdater {
+  /**
+   * Called when the contained fluid tank changes its contents
+   * <p>
+   * This does not contain the actual changes, the class containing this needs to manually store the data it wants to check
+   */
+  public abstract void onTankContentsChanged();
+}

--- a/src/main/java/slimeknights/tconstruct/smeltery/block/BlockCasting.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/BlockCasting.java
@@ -180,9 +180,23 @@ public class BlockCasting extends BlockInventory {
   @Nonnull
   @Override
   @SideOnly(Side.CLIENT)
-  public BlockRenderLayer getBlockLayer()
-  {
+  public BlockRenderLayer getBlockLayer() {
     return BlockRenderLayer.CUTOUT;
+  }
+
+  @Override
+  public boolean hasComparatorInputOverride(IBlockState state) {
+    return true;
+  }
+
+  @Override
+  public int getComparatorInputOverride(IBlockState blockState, World world, BlockPos pos) {
+    TileEntity te = world.getTileEntity(pos);
+    if(!(te instanceof TileCasting)) {
+      return 0;
+    }
+
+    return ((TileCasting) te).comparatorStrength();
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/smeltery/block/BlockTank.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/BlockTank.java
@@ -156,8 +156,7 @@ public class BlockTank extends BlockEnumSmeltery<BlockTank.TankType> {
   @Nonnull
   @Override
   @SideOnly(Side.CLIENT)
-  public BlockRenderLayer getBlockLayer()
-  {
+  public BlockRenderLayer getBlockLayer() {
     return BlockRenderLayer.CUTOUT;
   }
 
@@ -169,6 +168,21 @@ public class BlockTank extends BlockEnumSmeltery<BlockTank.TankType> {
   @Override
   public boolean isOpaqueCube(IBlockState state) {
     return false;
+  }
+
+  @Override
+  public boolean hasComparatorInputOverride(IBlockState state) {
+    return true;
+  }
+
+  @Override
+  public int getComparatorInputOverride(IBlockState blockState, World world, BlockPos pos) {
+    TileEntity te = world.getTileEntity(pos);
+    if(!(te instanceof TileTank)) {
+      return 0;
+    }
+
+    return ((TileTank) te).comparatorStrength();
   }
 
   public enum TankType implements IStringSerializable, EnumBlock.IEnumMeta {

--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileCasting.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileCasting.java
@@ -1,5 +1,8 @@
 package slimeknights.tconstruct.smeltery.tileentity;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.SoundEvents;
@@ -20,10 +23,6 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.wrapper.SidedInvWrapper;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import slimeknights.tconstruct.common.TinkerNetwork;
 import slimeknights.tconstruct.library.fluid.FluidHandlerCasting;
 import slimeknights.tconstruct.library.fluid.FluidTankAnimated;
@@ -96,6 +95,11 @@ public abstract class TileCasting extends TileTable implements ITickable, ISided
       }
       ItemHandlerHelper.giveItemToPlayer(player, stack);
       setInventorySlotContents(slot, null);
+
+      // send a block update for the comparator, needs to be done after the stack is removed
+      if(slot == 1) {
+        this.worldObj.notifyNeighborsOfStateChange(this.pos, this.getBlockType());
+      }
     }
   }
 
@@ -155,8 +159,10 @@ public abstract class TileCasting extends TileTable implements ITickable, ISided
           else {
             setInventorySlotContents(1, event.output);
           }
-
           worldObj.playSound(null, pos, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.AMBIENT, 0.07f, 4f);
+
+          // comparator update
+          worldObj.notifyNeighborsOfStateChange(this.pos, this.getBlockType());
 
           // reset state
           reset();
@@ -236,6 +242,13 @@ public abstract class TileCasting extends TileTable implements ITickable, ISided
     }
 
     tank.renderOffset += tank.getFluidAmount() - oldAmount;
+  }
+
+  /**
+   * @return The current comparator strength based on if an output exists
+   */
+  public int comparatorStrength() {
+    return isStackInSlot(1) ? 15 : 0;
   }
 
   /* Saving and Loading */

--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileTank.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileTank.java
@@ -13,15 +13,20 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import slimeknights.tconstruct.library.fluid.FluidTankAnimated;
+import slimeknights.tconstruct.library.fluid.IFluidTankUpdater;
 
-public class TileTank extends TileSmelteryComponent {
+public class TileTank extends TileSmelteryComponent implements IFluidTankUpdater {
 
   public static final int CAPACITY = Fluid.BUCKET_VOLUME * 4;
 
   protected FluidTankAnimated tank;
 
+  // used to only run block updates if the value actually changes
+  private int lastStrength;
+
   public TileTank() {
     this.tank = new FluidTankAnimated(CAPACITY, this);
+    this.lastStrength = -1;
   }
 
   @Override
@@ -89,8 +94,20 @@ public class TileTank extends TileSmelteryComponent {
     tank.writeToNBT(tags);
   }
 
-
+  /**
+   * @return The current comparator strength based on the tank's capicity
+   */
   public int comparatorStrength() {
     return 15 * tank.getFluidAmount() / tank.getCapacity();
   }
+
+  @Override
+  public void onTankContentsChanged() {
+    int newStrength = this.comparatorStrength();
+    if(newStrength != lastStrength) {
+      this.worldObj.notifyNeighborsOfStateChange(this.pos, this.getBlockType());
+      this.lastStrength = newStrength;
+    }
+  }
+
 }


### PR DESCRIPTION
Tanks return a number from 0 to 15 based on how full they are

Drying racks, casting tables, and casting basins return 0 if there is no output, and 15 if one exists