### PR TITLE
Fix brownstone interaction with water

### DIFF
--- a/src/main/java/slimeknights/tconstruct/gadgets/block/BlockBrownstone.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/block/BlockBrownstone.java
@@ -27,8 +27,14 @@ public class BlockBrownstone extends EnumBlock<BlockBrownstone.BrownstoneType> {
 
   @Override
   public void onEntityWalk(World worldIn, BlockPos pos, Entity entity) {
-    entity.motionX *= 1.25;
-    entity.motionZ *= 1.25;
+    if(entity.isInWater()) {
+      entity.motionX *= 1.20;
+      entity.motionZ *= 1.20;
+    }
+    else {
+      entity.motionX *= 1.25;
+      entity.motionZ *= 1.25;
+    }
   }
 
   public enum BrownstoneType implements IStringSerializable, EnumBlock.IEnumMeta {

--- a/src/main/java/slimeknights/tconstruct/gadgets/block/BlockBrownstoneSlab.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/block/BlockBrownstoneSlab.java
@@ -30,8 +30,14 @@ public class BlockBrownstoneSlab extends EnumBlockSlab<BlockBrownstoneSlab.Brown
 
   @Override
   public void onEntityWalk(World worldIn, BlockPos pos, Entity entity) {
-    entity.motionX *= 1.25;
-    entity.motionZ *= 1.25;
+    if(entity.isInWater()) {
+      entity.motionX *= 1.20;
+      entity.motionZ *= 1.20;
+    }
+    else {
+      entity.motionX *= 1.25;
+      entity.motionZ *= 1.25;
+    }
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/gadgets/block/BlockBrownstoneSlab2.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/block/BlockBrownstoneSlab2.java
@@ -30,8 +30,14 @@ public class BlockBrownstoneSlab2 extends EnumBlockSlab<BlockBrownstoneSlab2.Bro
   
   @Override
   public void onEntityWalk(World worldIn, BlockPos pos, Entity entity) {
-    entity.motionX *= 1.25;
-    entity.motionZ *= 1.25;
+    if(entity.isInWater()) {
+      entity.motionX *= 1.20;
+      entity.motionZ *= 1.20;
+    }
+    else {
+      entity.motionX *= 1.25;
+      entity.motionZ *= 1.25;
+    }
   }
   
   @Override


### PR DESCRIPTION
Basically, the speed boost from brownstone was canceling out the deceleration from the water, leading to some strange behavior including excessive max speeds

The issue is quite a bit easier to produce using slime channels as they are not pushing you off the brownstone, thus why I did not notice it until now