### PR TITLE
Add a method for registering a block with no item and use it on glow

### DIFF
--- a/src/main/java/slimeknights/tconstruct/TConstruct.java
+++ b/src/main/java/slimeknights/tconstruct/TConstruct.java
@@ -149,7 +149,9 @@ public class TConstruct {
   public void onMissingMapping(FMLMissingMappingsEvent event) {
     for(FMLMissingMappingsEvent.MissingMapping mapping : event.get()) {
       // old universal bucket, got moved into Forge
-      if(mapping.type == GameRegistry.Type.ITEM && mapping.name.equals(Util.resource("bucket"))) {
+      // glow is the leftover itemblock form which was removed
+      if(mapping.type == GameRegistry.Type.ITEM
+          && (mapping.name.equals(Util.resource("bucket")) || mapping.name.equals(Util.resource("glow")))) {
         mapping.ignore();
       }
     }

--- a/src/main/java/slimeknights/tconstruct/common/TinkerPulse.java
+++ b/src/main/java/slimeknights/tconstruct/common/TinkerPulse.java
@@ -111,6 +111,18 @@ public abstract class TinkerPulse {
     register(itemBlock, name);
     return block;
   }
+  
+  protected static <T extends Block> T registerBlockNoItem(T block, String name) {
+    if(!name.equals(name.toLowerCase(Locale.US))) {
+      throw new IllegalArgumentException(String.format("Unlocalized names need to be all lowercase! Block: %s", name));
+    }
+    
+    String prefixedName = Util.prefix(name);
+    block.setUnlocalizedName(prefixedName);
+
+    register(block, name);
+    return block;
+  }
 
   protected static <T extends IForgeRegistryEntry<?>> T register(T thing, String name) {
     thing.setRegistryName(Util.getResource(name));

--- a/src/main/java/slimeknights/tconstruct/shared/TinkerCommons.java
+++ b/src/main/java/slimeknights/tconstruct/shared/TinkerCommons.java
@@ -308,7 +308,7 @@ public class TinkerCommons extends TinkerPulse {
     }
 
     if(isToolsLoaded() || isGadgetsLoaded()) {
-      blockGlow = registerBlock(new BlockGlow(), "glow");
+      blockGlow = registerBlockNoItem(new BlockGlow(), "glow");
     }
 
     proxy.preInit();


### PR DESCRIPTION
Basically, if it is not intended to be available as an item it shouldn't have an item form, to be consistent with vanilla.