### PR TITLE
Fix Tinkers Issues: #2249, #2244: Slimy Grass Crash

### DIFF
--- a/src/main/java/slimeknights/tconstruct/world/block/BlockSlimeGrass.java
+++ b/src/main/java/slimeknights/tconstruct/world/block/BlockSlimeGrass.java
@@ -104,12 +104,17 @@ public class BlockSlimeGrass extends BlockGrass {
     // spread to surrounding blocks
     if(worldIn.getLightFromNeighbors(pos.up()) >= 9) {
       for(int i = 0; i < 4; ++i) {
-        BlockPos pos1 = pos.add(rand.nextInt(3) - 1, rand.nextInt(5) - 3, rand.nextInt(3) - 1);
-        Block block = worldIn.getBlockState(pos1.up()).getBlock();
-        IBlockState state1 = worldIn.getBlockState(pos1);
+        BlockPos blockpos = pos.add(rand.nextInt(3) - 1, rand.nextInt(5) - 3, rand.nextInt(3) - 1);
 
-        if(worldIn.getLightFromNeighbors(pos1.up()) >= 4 && block.getLightOpacity(state, worldIn, pos1.up()) <= 2) {
-          convert(worldIn, pos1, state1, state.getValue(FOLIAGE));
+        if(blockpos.getY() >= 0 && blockpos.getY() < 256 && !worldIn.isBlockLoaded(blockpos)) {
+          return;
+        }
+
+        IBlockState iblockstate = worldIn.getBlockState(blockpos.up());
+        IBlockState iblockstate1 = worldIn.getBlockState(blockpos);
+
+        if(iblockstate1.getBlock() == TinkerWorld.slimeDirt && worldIn.getLightFromNeighbors(blockpos.up()) >= 4 && iblockstate.getLightOpacity(worldIn, pos.up()) <= 2) {
+          convert(worldIn, blockpos, iblockstate1, state.getValue(FOLIAGE));
         }
       }
     }


### PR DESCRIPTION
Fix Tinkers Issues: #2249, #2244: Chisel or any block that is placed on top of Slimy Grass will now not crash the server when the grass tries to spread.