### PR TITLE
Allow anything in the top and bottom borders of a seared furnace, decrease stack size and increase smelting time

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/block/BlockSearedStairs.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/BlockSearedStairs.java
@@ -24,17 +24,12 @@ public class BlockSearedStairs extends BlockStairsBase implements ITileEntityPro
     this.isBlockContainer = true; // has TE
   }
 
-  /* BlockContainer TE handling
-   * Not a fan of duplicating the code
-   * but for the sake of mod compat other mods need to know this is stairs
-   */
-
   @Nonnull
   @Override
   public TileEntity createNewTileEntity(@Nonnull World worldIn, int meta) {
     return new TileSmelteryComponent();
   }
-  
+
   /* Pass on the missing code for seared block TE stuff */
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/smeltery/multiblock/MultiblockSearedFurnace.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/multiblock/MultiblockSearedFurnace.java
@@ -86,17 +86,12 @@ public class MultiblockSearedFurnace extends MultiblockCuboid {
       return true;
     }
 
-    // allow stairs and slabs on the ceiling, but need to be the bottom half
-    if(type == EnumFrameType.CEILING) {
-      if(state.getBlock() instanceof BlockSlab && state.getValue(BlockSlab.HALF) == BlockSlab.EnumBlockHalf.TOP) {
-        return false;
-      }
-      if(state.getBlock() instanceof BlockStairs && state.getValue(BlockStairs.HALF) == BlockStairs.EnumHalf.TOP) {
-        return false;
-      }
-
-      return TinkerSmeltery.validSearedFurnaceBlocks.contains(state.getBlock());
+    // anything is allowed on the ceiling and floor of the frame, just the walls matter
+    if(type != EnumFrameType.WALL) {
+      return true;
     }
+
+    // the above also allows slabs and stairs on the ceiling, so no need to add it here
 
     return state.getBlock() == TinkerSmeltery.searedBlock;
   }

--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
@@ -38,7 +38,6 @@ import slimeknights.tconstruct.smeltery.multiblock.MultiblockSearedFurnace;
 public class TileSearedFurnace extends TileHeatingStructureFuelTank implements IMasterLogic, ITickable, IInventoryGui {
 
   public static final Logger log = Util.getLogger("Furnace");
-  private static final double LOG9_2 = 0.31546487678;
 
   protected static final int MAX_SIZE = 9; // because the smeltery max is 9x9, duh
 
@@ -49,7 +48,7 @@ public class TileSearedFurnace extends TileHeatingStructureFuelTank implements I
   protected int tick;
 
   public TileSearedFurnace() {
-    super("gui.searedfurnace.name", 0, 64);
+    super("gui.searedfurnace.name", 0, 16);
 
     multiblock = new MultiblockSearedFurnace(this);
   }
@@ -124,13 +123,11 @@ public class TileSearedFurnace extends TileHeatingStructureFuelTank implements I
    */
   private int getHeatForStack(@Nonnull ItemStack input, @Nonnull ItemStack result) {
     // base stack temp, here in case Forge adds a hook
-    // ends up at 60 by default, since we only actually increment the cooking time every 4 ticks
-    // (240 is the result, though that brings us to 192 due to the temperature calculations)
     int base = 200;
-    float temp = (base * input.stackSize / 20f) + base / 4f;
+    float temp = base * input.stackSize / 4f;
 
     // adjust the speed based on if its a food or not
-    // after adjustment with the base of 200, we get 153 for foods and 192 for non foods 
+    // after adjustment with the base of 200, we get a temp of 160 for foods, though its slightly faster than that due to TileHeatingStructure logic
     if(result.getItem() instanceof ItemFood) {
       temp *= 0.8;
     }


### PR DESCRIPTION
Smelting time now more properly matches vanilla (though is about 4/5 of the speed just due to TileHeatingStructure logic), and stack size was to prevent temperature limits from being reached.

This does remove the stack size boost (meaning 16 items take 16 times the amount of time), though that can easily be added back if requested.