### PR TITLE
Basic structure block support for smeltery (#2315)

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSmeltery.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSmeltery.java
@@ -108,6 +108,13 @@ public class TileSmeltery extends TileHeatingStructureFuelTank implements IMaste
       // this also updates the needsFuel flag, which causes us to consume fuel at the end.
       // This way fuel is only consumed if it's actually needed
 
+      // if the smeltry is cloned using a structure block, smeltery is considered active but this.info is null. Try to rebuild the smeltery in this case.
+      if(info == null) {
+        checkSmelteryStructure();
+        // if the rebuild doesn't work (ie. the slave blocks still refers to an existing smeltery), skip the update to prevent a server crash.
+        if(info == null) return;
+      }
+      
       if(tick == 0) {
         interactWithEntitiesInside();
       }


### PR DESCRIPTION
When the smeltery is copied using a structure block, the state is broken which can be identified by the smeltery being "active" while the variable this.info is null. This, by the way, causes the server the crash during the update.

This PR add a check to prevent the update if the state is identified as broken, and try to rebuild the smeltery if possible. The rebuild will work if the former smeltery is gone. If the former smeltery still exists, new loaded smeltery will not be valid and skip the tick updates, but at least won't crash the server anymore.

This PR completely allows smelteries to be moved or spawned as reward with capsules as well (see #2315), since the original smeltery will never exist anymore when the content is placed in the world.