### PR TITLE
Fix Tinker Tank bounding box not including the full liquid and the lighting location being offset in the wrong direction

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/client/TinkerTankRenderer.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/client/TinkerTankRenderer.java
@@ -90,7 +90,7 @@ public class TinkerTankRenderer extends SmelteryTankRenderer<TileTinkerTank> {
     }
 
     // draw the fluids inside
-    // we offset the minPos for lighting since its possible to have a solid block (always light 0) where the liquid starts
-    renderFluids(tank, tilePos, minPos.add(-1, 0, -1), maxPos.add(1, 0, 1), x, y, z, 0.0625f, minPos.add(2, 0, 2));
+    // we don't offset the minPos for lighting since its possible to have a solid block (always light 0) where the liquid starts
+    renderFluids(tank, tilePos, minPos.add(-1, 0, -1), maxPos.add(1, 0, 1), x, y, z, 0.0625f, minPos);
   }
 }

--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileTinkerTank.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileTinkerTank.java
@@ -107,15 +107,15 @@ public class TileTinkerTank extends TileMultiblock<MultiblockTinkerTank> impleme
     if(minPos == null || maxPos == null) {
       return super.getRenderBoundingBox();
     }
-    // we need to include the controller's position for Y value as we render a face there
-    // we also include additional positions for the sake of the fluids
+    // we stretch the bounding on the X and Z since the liquids show in the full structure rather than just the inside
+    // we also need to include the controller's position for Y value as we render a face there (but X/Z is covered above)
     return new AxisAlignedBB(
-        minPos.getX(),
+        minPos.getX() - 1,
         Math.min(minPos.getY(), pos.getY()),
-        minPos.getZ(),
-        maxPos.getX() + 1,
+        minPos.getZ() - 1,
+        maxPos.getX() + 2,
         Math.max(maxPos.getY(), pos.getY()) + 1,
-        maxPos.getZ() + 1
+        maxPos.getZ() + 2
       );
   }
 


### PR DESCRIPTION
Fixes issues caused by the multiblock code extraction as the stored position was changed from the liquid start to the inside start.

Also fixes the liquid lighting location as it was offset in the opposite direction during 9466eba