### PR TITLE
Add right click functionality to tool traits

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/tools/ToolCore.java
+++ b/src/main/java/slimeknights/tconstruct/library/tools/ToolCore.java
@@ -18,6 +18,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
@@ -547,6 +549,21 @@ public abstract class ToolCore extends TinkersItem implements IToolStationDispla
     }
 
     ToolHelper.damageTool(stack, damage, player);
+  }
+
+  @Override
+  public EnumActionResult onItemUse(ItemStack stack, EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
+    NBTTagList list = TagUtil.getTraitsTagList(stack);
+    for(int i = 0; i < list.tagCount(); i++) {
+      ITrait trait = TinkerRegistry.getTrait(list.getStringTagAt(i));
+      if(trait != null) {
+        EnumActionResult result = trait.onToolUse(stack, player, world, pos, hand, facing, hitX, hitY, hitZ);
+        if (result != EnumActionResult.PASS) {
+          return result;
+        }
+      }
+    }
+    return EnumActionResult.PASS;
   }
 
   // elevate to public

--- a/src/main/java/slimeknights/tconstruct/library/traits/AbstractTrait.java
+++ b/src/main/java/slimeknights/tconstruct/library/traits/AbstractTrait.java
@@ -8,6 +8,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
@@ -91,6 +94,11 @@ public abstract class AbstractTrait extends Modifier implements ITrait {
 
   @Override
   public void blockHarvestDrops(ItemStack tool, BlockEvent.HarvestDropsEvent event) {
+  }
+
+  @Override
+  public EnumActionResult onToolUse(ItemStack tool, EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
+      return EnumActionResult.PASS;
   }
 
   /* Attacking */

--- a/src/main/java/slimeknights/tconstruct/library/traits/ITrait.java
+++ b/src/main/java/slimeknights/tconstruct/library/traits/ITrait.java
@@ -5,6 +5,9 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
@@ -54,6 +57,11 @@ public interface ITrait extends IToolMod {
    * Note that, as opposed to the original event, this only gets called with a player.
    */
   void blockHarvestDrops(ItemStack tool, BlockEvent.HarvestDropsEvent event);
+
+  /**
+   * Called when a Block is right-clicked with the tool. see {@link net.minecraft.item.Item#onItemUse(ItemStack, EntityPlayer, World, BlockPos, EnumHand, EnumFacing, float, float, float)}
+   */
+  EnumActionResult onToolUse(ItemStack tool, EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ);
 
 
   /* Attacking */

--- a/src/main/java/slimeknights/tconstruct/tools/melee/item/BattleAxe.java
+++ b/src/main/java/slimeknights/tconstruct/tools/melee/item/BattleAxe.java
@@ -68,6 +68,10 @@ public class BattleAxe extends AoeToolCore {
   @Override
   public EnumActionResult onItemUse(ItemStack stack, EntityPlayer playerIn, World worldIn, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
     // todo: special action
+    EnumActionResult result = super.onItemUse(stack, playerIn, worldIn, pos, hand, facing, hitX, hitY, hitZ);
+    if (result != EnumActionResult.PASS) {
+      return result;
+    }
     return EnumActionResult.FAIL;
   }
 

--- a/src/main/java/slimeknights/tconstruct/tools/tools/Mattock.java
+++ b/src/main/java/slimeknights/tconstruct/tools/tools/Mattock.java
@@ -132,7 +132,7 @@ public class Mattock extends AoeToolCore {
       TinkerToolEvent.OnMattockHoe.fireEvent(stack, playerIn, worldIn, pos);
     }
     else if(ret == EnumActionResult.PASS) {
-      super.onItemUse(stack, playerIn, worldIn, pos, hand, facing, hitX, hitY, hitZ);
+      return super.onItemUse(stack, playerIn, worldIn, pos, hand, facing, hitX, hitY, hitZ);
     }
 
     return ret;

--- a/src/main/java/slimeknights/tconstruct/tools/tools/Mattock.java
+++ b/src/main/java/slimeknights/tconstruct/tools/tools/Mattock.java
@@ -131,6 +131,9 @@ public class Mattock extends AoeToolCore {
     if(ret == EnumActionResult.SUCCESS) {
       TinkerToolEvent.OnMattockHoe.fireEvent(stack, playerIn, worldIn, pos);
     }
+    else if(ret == EnumActionResult.PASS) {
+      super.onItemUse(stack, playerIn, worldIn, pos, hand, facing, hitX, hitY, hitZ);
+    }
 
     return ret;
   }

--- a/src/main/java/slimeknights/tconstruct/tools/tools/Shovel.java
+++ b/src/main/java/slimeknights/tconstruct/tools/tools/Shovel.java
@@ -93,7 +93,12 @@ public class Shovel extends AoeToolCore {
       }
     }
 
-    return result;
+    if(result == EnumActionResult.PASS) {
+      return super.onItemUse(stack, player, world, pos, hand, facing, hitX, hitY, hitZ);
+    }
+    else {
+      return result;
+    }
   }
 
   @Override


### PR DESCRIPTION
This implements right-click functionality for tool traits as specified in the title. The rules for which right-click function is used are simple.
1. If the tool has a built-in right-click function, this is applied.
2. If the built-in right-click function passes (returns EnumActionResult.PASS), the right click functions of traits are applied.
3. In the case of conflicting trait right-click functions, the first that returns != EnumActionResult.PASS is used.

The right click function is only called for the block that is clicked, not the AOE blocks.

[Here's an example trait that uses onToolUse.](https://gist.github.com/JamiesWhiteShirt/9336cc873022f6bc5a87d9e3888a9144)

I'm developing a mod which, among several things, will be adding a TConstruct tool trait. My intention with this tool trait is that it will add a specific right-click function to TConstruct tools. If you are curious why I need it, [this is the mod in question](https://minecraft.curseforge.com/projects/literal-ascension) where the trait will give the right click behaviour of the Carving Tool to any TConstruct tool.

I initially tried implementing this through PlayerInteractEvent.RightClickBlock. Unfortunately the event does not allow me to alter the EnumActionResult of the right-click to SUCCESS. The result is that there is no animation when the tool is used since. The animation will only happen if the EnumActionResult of the right click is SUCCESS.