### PR TITLE
Jei Improvements

### DIFF
--- a/src/main/java/slimeknights/tconstruct/TConstruct.java
+++ b/src/main/java/slimeknights/tconstruct/TConstruct.java
@@ -60,7 +60,8 @@ import slimeknights.tconstruct.world.TinkerWorld;
     version = TConstruct.modVersion,
     guiFactory = "slimeknights.tconstruct.common.config.ConfigGui$ConfigGuiFactory",
     dependencies = "required-after:Forge@[12.18.1.2073,);"
-                   + "required-after:mantle@[1.10.2-1.0.0,)",
+                   + "required-after:mantle@[1.10.2-1.0.0,);"
+                   + "after:JEI@[3.13.6.387,)",
     acceptedMinecraftVersions = "[1.10.2, 1.11)")
 public class TConstruct {
 

--- a/src/main/java/slimeknights/tconstruct/gadgets/item/ItemBlockRack.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/item/ItemBlockRack.java
@@ -4,14 +4,12 @@ import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemMultiTexture;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-
 import java.util.List;
 
 import javax.annotation.Nonnull;
 
 import slimeknights.tconstruct.library.Util;
-import slimeknights.tconstruct.shared.tileentity.TileTable;
+import slimeknights.tconstruct.tools.common.item.ItemBlockTable;
 
 public class ItemBlockRack extends ItemMultiTexture {
 
@@ -22,9 +20,8 @@ public class ItemBlockRack extends ItemMultiTexture {
   @Override
   public void addInformation(@Nonnull ItemStack stack, @Nonnull EntityPlayer playerIn, @Nonnull List<String> tooltip, boolean advanced) {
     if(stack.hasTagCompound()) {
-      NBTTagCompound tag = stack.getTagCompound().getCompoundTag(TileTable.FEET_TAG);
-      ItemStack legs = ItemStack.loadItemStackFromNBT(tag);
-      if(legs != null && legs.getItem() != null) {
+      ItemStack legs = ItemBlockTable.getLegStack(stack);
+      if(legs != null) {
         tooltip.add(legs.getDisplayName());
       }
 

--- a/src/main/java/slimeknights/tconstruct/library/client/GuiUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/client/GuiUtil.java
@@ -153,6 +153,22 @@ public class GuiUtil {
     }
   }
 
+  public static FluidStack getFluidStackAtPosition(SmelteryTank tank, int mouseX, int mouseY, int xmin, int ymin, int xmax, int ymax) {
+    if(xmin <= mouseX && mouseX < xmax && ymin <= mouseY && mouseY < ymax) {
+      int[] heights = calcLiquidHeights(tank.getFluids(), tank.getCapacity(), ymax - ymin);
+      int y = ymax - mouseY - 1;
+
+      for(int i = 0; i < heights.length; i++) {
+        if(y < heights[i]) {
+          return tank.getFluids().get(i);
+        }
+        y -= heights[i];
+      }
+    }
+
+    return null;
+  }
+
   public static void handleTankClick(SmelteryTank tank, int mouseX, int mouseY, int xmin, int ymin, int xmax, int ymax) {
     if(xmin <= mouseX && mouseX < xmax && ymin <= mouseY && mouseY < ymax) {
       int[] heights = calcLiquidHeights(tank.getFluids(), tank.getCapacity(), ymax - ymin);

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/CastingRecipeWrapper.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/CastingRecipeWrapper.java
@@ -7,7 +7,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import java.awt.*;
-import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -64,7 +63,7 @@ public class CastingRecipeWrapper extends BlankRecipeWrapper {
 
   @Override
   public void getIngredients(IIngredients ingredients) {
-    ingredients.setInputs(ItemStack.class, cast);
+    ingredients.setInputLists(ItemStack.class, ImmutableList.of(cast));
     ingredients.setInputs(FluidStack.class, inputFluid);
     ingredients.setOutputs(ItemStack.class, lazyInitOutput());
   }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/CraftingStationRecipeTransferInfo.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/CraftingStationRecipeTransferInfo.java
@@ -42,7 +42,10 @@ public class CraftingStationRecipeTransferInfo implements IRecipeTransferInfo<Co
   @Override
   public List<Slot> getInventorySlots(ContainerCraftingStation container) {
     List<Slot> slots = new ArrayList<Slot>();
-    for(int i = 10; i < container.inventorySlots.size(); i++) {
+
+    // we skip all slots from within the side inventory and crafting grid for transfer
+    // side inventory can cause too many issues since transfer is not validated the same way as clicking does
+    for(int i = container.getPlayerInventoryStart(); i < container.inventorySlots.size(); i++) {
       slots.add(container.getSlot(i));
     }
     return slots;

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/Focus.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/Focus.java
@@ -1,0 +1,24 @@
+package slimeknights.tconstruct.plugin.jei;
+
+import mezz.jei.api.recipe.IFocus;
+
+// this is simply a private copy since the JEI implementation is not in the API
+public class Focus<V> implements IFocus<V> {
+  private final Mode mode;
+  private final V value;
+
+  public Focus(Mode mode, V value) {
+    this.mode = mode;
+    this.value = value;
+  }
+
+  @Override
+  public V getValue() {
+    return value;
+  }
+
+  @Override
+  public Mode getMode() {
+    return mode;
+  }
+}

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.IJeiHelpers;
@@ -22,6 +24,7 @@ import mezz.jei.api.IJeiRuntime;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.ISubtypeRegistry;
+import mezz.jei.api.gui.BlankAdvancedGuiHandler;
 import mezz.jei.api.ingredients.IModIngredientRegistration;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import slimeknights.tconstruct.TConstruct;
@@ -33,6 +36,9 @@ import slimeknights.tconstruct.library.smeltery.ICastingRecipe;
 import slimeknights.tconstruct.shared.block.BlockTable;
 import slimeknights.tconstruct.smeltery.TinkerSmeltery;
 import slimeknights.tconstruct.smeltery.block.BlockCasting;
+import slimeknights.tconstruct.smeltery.client.GuiSmeltery;
+import slimeknights.tconstruct.smeltery.client.GuiTinkerTank;
+import slimeknights.tconstruct.smeltery.client.IGuiLiquidTank;
 import slimeknights.tconstruct.tools.TinkerTools;
 import slimeknights.tconstruct.tools.common.block.BlockToolTable;
 
@@ -122,6 +128,11 @@ public class JEIPlugin implements IModPlugin {
           registry.addRecipes(ImmutableList.of(new CastingRecipeWrapper(recipe, castingCategory.castingBasin)));
         }
       }
+
+      // liquid recipe lookup for smeltery and tinker tank
+      registry.addAdvancedGuiHandlers(
+          new TinkerGuiTankHandler<GuiTinkerTank>(GuiTinkerTank.class),
+          new TinkerGuiTankHandler<GuiSmeltery>(GuiSmeltery.class));
     }
 
     // drying rack
@@ -136,5 +147,26 @@ public class JEIPlugin implements IModPlugin {
 
   @Override
   public void onRuntimeAvailable(@Nonnull IJeiRuntime jeiRuntime) {
+  }
+
+
+  private static class TinkerGuiTankHandler<T extends GuiContainer & IGuiLiquidTank> extends BlankAdvancedGuiHandler<T> {
+    private Class<T> clazz;
+
+    public TinkerGuiTankHandler(Class<T> clazz) {
+      this.clazz = clazz;
+    }
+
+    @Nonnull
+    @Override
+    public Class<T> getGuiContainerClass() {
+      return clazz;
+    }
+
+    @Nullable
+    @Override
+    public Object getIngredientUnderMouse(T guiContainer, int mouseX, int mouseY) {
+      return guiContainer.getFluidStackAtPosition(mouseX, mouseY);
+    }
   }
 }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/PatternSubtypeInterpreter.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/PatternSubtypeInterpreter.java
@@ -1,0 +1,23 @@
+package slimeknights.tconstruct.plugin.jei;
+
+import mezz.jei.api.ISubtypeRegistry.ISubtypeInterpreter;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import slimeknights.tconstruct.library.tools.Pattern;
+
+// Handles pattern and cast subtypes
+public class PatternSubtypeInterpreter implements ISubtypeInterpreter {
+
+  @Override
+  public String getSubtypeInfo(ItemStack stack) {
+    String meta = stack.getItemDamage() + ":";
+
+    Item part = Pattern.getPartFromTag(stack);
+    if(part == null) {
+      return meta;
+    }
+
+    return meta + part.getRegistryName();
+  }
+
+}

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/TableSubtypeInterpreter.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/TableSubtypeInterpreter.java
@@ -1,0 +1,28 @@
+package slimeknights.tconstruct.plugin.jei;
+
+import mezz.jei.api.ISubtypeRegistry.ISubtypeInterpreter;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import slimeknights.tconstruct.library.utils.TagUtil;
+import slimeknights.tconstruct.shared.tileentity.TileTable;
+
+// Hanldes table and rack subtypes
+public class TableSubtypeInterpreter implements ISubtypeInterpreter {
+
+  @Override
+  public String getSubtypeInfo(ItemStack stack) {
+    // we have to handle the metadata here
+    String meta = stack.getMetadata() + ":";
+
+    // if the legs exist, return that for the identification key
+    NBTTagCompound tag = TagUtil.getTagSafe(stack).getCompoundTag(TileTable.FEET_TAG);
+    ItemStack legs = ItemStack.loadItemStackFromNBT(tag);
+    if(legs != null && legs.getItem() != null) {
+      return meta + legs.getItem().getRegistryName() + ":" + legs.getMetadata();
+    }
+
+    // otherwise, simply go back to the meta
+    return meta;
+  }
+
+}

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/ToolPartSubtypeInterpreter.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/ToolPartSubtypeInterpreter.java
@@ -1,0 +1,23 @@
+package slimeknights.tconstruct.plugin.jei;
+
+import mezz.jei.api.ISubtypeRegistry.ISubtypeInterpreter;
+import net.minecraft.item.ItemStack;
+import slimeknights.tconstruct.library.materials.Material;
+import slimeknights.tconstruct.library.utils.TinkerUtil;
+
+// Handles all Tinker tool parts subtypes
+public class ToolPartSubtypeInterpreter implements ISubtypeInterpreter {
+
+  @Override
+  public String getSubtypeInfo(ItemStack stack) {
+    String meta = stack.getItemDamage() + ":";
+
+    Material material = TinkerUtil.getMaterialFromStack(stack);
+    if(material == null) {
+      return meta;
+    }
+
+    return meta + material.getIdentifier();
+  }
+
+}

--- a/src/main/java/slimeknights/tconstruct/smeltery/client/GuiSmeltery.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/client/GuiSmeltery.java
@@ -2,6 +2,8 @@ package slimeknights.tconstruct.smeltery.client;
 
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.FluidStack;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -13,7 +15,7 @@ import slimeknights.tconstruct.smeltery.inventory.ContainerSmeltery;
 import slimeknights.tconstruct.smeltery.tileentity.TileSmeltery;
 import slimeknights.tconstruct.tools.common.inventory.ContainerSideInventory;
 
-public class GuiSmeltery extends GuiHeatingStructureFuelTank {
+public class GuiSmeltery extends GuiHeatingStructureFuelTank implements IGuiLiquidTank {
 
   public static final ResourceLocation BACKGROUND = Util.getResource("textures/gui/smeltery.png");
 
@@ -91,6 +93,11 @@ public class GuiSmeltery extends GuiHeatingStructureFuelTank {
       GuiUtil.handleTankClick(smeltery.getTank(), mouseX - cornerX, mouseY - cornerY, 8, 16, 60, 68);
     }
     super.mouseClicked(mouseX, mouseY, mouseButton);
+  }
+
+  @Override
+  public FluidStack getFluidStackAtPosition(int mouseX, int mouseY) {
+    return GuiUtil.getFluidStackAtPosition(smeltery.getTank(), mouseX - cornerX, mouseY - cornerY, 8, 16, 60, 68);
   }
 
 }

--- a/src/main/java/slimeknights/tconstruct/smeltery/client/GuiTinkerTank.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/client/GuiTinkerTank.java
@@ -7,13 +7,14 @@ import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.inventory.Container;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.FluidStack;
 import slimeknights.mantle.client.gui.GuiElement;
 import slimeknights.mantle.inventory.BaseContainer;
 import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.library.client.GuiUtil;
 import slimeknights.tconstruct.smeltery.tileentity.TileTinkerTank;
 
-public class GuiTinkerTank extends GuiContainer {
+public class GuiTinkerTank extends GuiContainer implements IGuiLiquidTank {
 
   public static final ResourceLocation BACKGROUND = Util.getResource("textures/gui/tinker_tank.png");
   protected GuiElement scala = new GuiElement(122, 0, 106, 106, 256, 256);
@@ -64,6 +65,11 @@ public class GuiTinkerTank extends GuiContainer {
     }
 
     super.mouseClicked(mouseX, mouseY, mouseButton);
+  }
+
+  @Override
+  public FluidStack getFluidStackAtPosition(int mouseX, int mouseY) {
+    return GuiUtil.getFluidStackAtPosition(tinkerTank.getTank(), mouseX - guiLeft, mouseY - guiTop, 8, 16, 114, 122);
   }
 
   protected void drawBackground(ResourceLocation background) {

--- a/src/main/java/slimeknights/tconstruct/smeltery/client/IGuiLiquidTank.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/client/IGuiLiquidTank.java
@@ -1,0 +1,7 @@
+package slimeknights.tconstruct.smeltery.client;
+
+import net.minecraftforge.fluids.FluidStack;
+
+public interface IGuiLiquidTank {
+  FluidStack getFluidStackAtPosition(int mouseX, int mouseY);
+}

--- a/src/main/java/slimeknights/tconstruct/tools/common/TableRecipe.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/TableRecipe.java
@@ -55,4 +55,11 @@ public class TableRecipe extends ShapedOreRecipe {
     }
     return super.getRecipeOutput();
   }
+
+  /**
+   * Gets the recipe output without applying the legs block
+   */
+  public ItemStack getPlainRecipeOutput() {
+    return output;
+  }
 }

--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerCraftingStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerCraftingStation.java
@@ -120,4 +120,10 @@ public class ContainerCraftingStation extends ContainerTinkerStation<TileCraftin
     return null;
   }
 
+  /**
+   * @return the starting slot for the player inventory. Present for usage in the JEI crafting station support
+   */
+  public int getPlayerInventoryStart() {
+    return playerInventoryStart;
+  }
 }

--- a/src/main/java/slimeknights/tconstruct/tools/common/item/ItemBlockTable.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/item/ItemBlockTable.java
@@ -16,6 +16,7 @@ import slimeknights.mantle.util.LocUtils;
 import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.library.smeltery.ICast;
 import slimeknights.tconstruct.library.tools.IPattern;
+import slimeknights.tconstruct.library.utils.TagUtil;
 import slimeknights.tconstruct.shared.tileentity.TileTable;
 import slimeknights.tconstruct.tools.common.block.BlockToolTable;
 
@@ -32,15 +33,31 @@ public class ItemBlockTable extends ItemBlockMeta {
       return;
     }
 
-    NBTTagCompound tag = stack.getTagCompound().getCompoundTag(TileTable.FEET_TAG);
-    ItemStack legs = ItemStack.loadItemStackFromNBT(tag);
-    if(legs != null && legs.getItem() != null) {
+    ItemStack legs = getLegStack(stack);
+    if(legs != null) {
       tooltip.add(legs.getDisplayName());
     }
 
     if(stack.getTagCompound().hasKey("inventory")) {
       this.addInventoryInformation(stack, playerIn, tooltip, advanced);
     }
+  }
+
+  /**
+   * Gets the itemstack that determines the leg's texture from the table
+   * @param table  Input table
+   * @return  The itemstack determining the leg's texture, or null if none exists
+   */
+  public static ItemStack getLegStack(ItemStack table) {
+    NBTTagCompound tag = TagUtil.getTagSafe(table).getCompoundTag(TileTable.FEET_TAG);
+    ItemStack stack = ItemStack.loadItemStackFromNBT(tag);
+
+    // don't use a stack with a null item
+    if(stack == null || stack.getItem() == null) {
+      return null;
+    }
+
+    return stack;
   }
 
   protected void addInventoryInformation(@Nonnull ItemStack stack, @Nonnull EntityPlayer playerIn, @Nonnull List<String> tooltip, boolean advanced) {


### PR DESCRIPTION
The following four commits are a collection of fixes and improvements for JEI. Specific changes are listed below:

* Fluids in the tinker tank and smeltery GUIs now support fluid recipe and usage lookup by pressing "R" and "U".
* Added subtype information for patterns, casts, tables, racks, and tool parts. In addition, when viewing a table recipe, it will now animate through all available tables by default, and just the relevant recipe if a table is in focus (item transfer still allows any wood to be pulled from the inventory)
* Fixed #2570 by preventing the item transfer from placing items in the side inventory
* Added a version dependency for JEI. If it is loaded, it must have what is currently the latest build, 3.13.6.387, as I use API methods from that build.
* Fixes only wood showing on cast creation recipes