### PR TITLE
Modified the glowing modifier to check for liquid blocks before glowing block placement

### DIFF
--- a/src/main/java/slimeknights/tconstruct/shared/block/BlockGlow.java
+++ b/src/main/java/slimeknights/tconstruct/shared/block/BlockGlow.java
@@ -3,6 +3,7 @@ package slimeknights.tconstruct.shared.block;
 import com.google.common.collect.ImmutableMap;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyDirection;
@@ -83,10 +84,17 @@ public class BlockGlow extends Block {
     super.neighborChanged(state, world, pos, blockIn);
   }
 
-  // function to determine if a side can contain a glow. Like the function from the ladder, only opposite
+  /**
+   *  Determines if a block side can contain a glow. 
+   *  Returns true if the block side is solid and the block at the given BlockPos is not a liquid
+   */
   protected boolean canBlockStay(World world, BlockPos pos, EnumFacing facing) {
     BlockPos placedOn = pos.offset(facing);
-    return world.getBlockState(placedOn).isSideSolid(world, placedOn, facing.getOpposite());
+    
+    boolean isSolidSide = world.getBlockState(placedOn).isSideSolid(world, placedOn, facing.getOpposite());
+    boolean isLiquid = world.getBlockState(pos).getBlock() instanceof BlockLiquid ;
+    
+    return !isLiquid && isSolidSide;
   }
 
   /**

--- a/src/main/java/slimeknights/tconstruct/tools/modifiers/ModGlowing.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modifiers/ModGlowing.java
@@ -24,7 +24,7 @@ public class ModGlowing extends ModifierTrait {
       BlockPos pos = entity.getPosition();
       // check light level at entity
 
-      if(world.getLightFromNeighbors(pos) < 8 && !entity.isInWater()) {
+      if(world.getLightFromNeighbors(pos) < 8) {
         for(BlockPos candidate : new BlockPos[]{pos, pos.up(), pos.north(), pos.east(), pos.south(), pos.west(), pos.down()}) {
           // addGlow tries all directions if the passed one doesn't work
           if(TinkerCommons.blockGlow.addGlow(world, candidate, EnumFacing.values()[random.nextInt(6)])) {

--- a/src/main/java/slimeknights/tconstruct/tools/modifiers/ModGlowing.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modifiers/ModGlowing.java
@@ -23,7 +23,7 @@ public class ModGlowing extends ModifierTrait {
     if(isSelected && !world.isRemote && !ToolHelper.isBroken(tool)) {
       BlockPos pos = entity.getPosition();
       // check light level at entity
-      if(world.getLight(pos) < 8) {
+      if(world.getLight(pos) < 8 && !entity.isInWater()) {
         for(BlockPos candidate : new BlockPos[]{pos, pos.up(), pos.north(), pos.east(), pos.south(), pos.west(), pos.down()}) {
           // addGlow tries all directions if the passed one doesn't work
           if(TinkerCommons.blockGlow.addGlow(world, candidate, EnumFacing.values()[random.nextInt(6)])) {

--- a/src/main/java/slimeknights/tconstruct/tools/modifiers/ModGlowing.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modifiers/ModGlowing.java
@@ -23,7 +23,8 @@ public class ModGlowing extends ModifierTrait {
     if(isSelected && !world.isRemote && !ToolHelper.isBroken(tool)) {
       BlockPos pos = entity.getPosition();
       // check light level at entity
-      if(world.getLight(pos) < 8 && !entity.isInWater()) {
+
+      if(world.getLightFromNeighbors(pos) < 8 && !entity.isInWater()) {
         for(BlockPos candidate : new BlockPos[]{pos, pos.up(), pos.north(), pos.east(), pos.south(), pos.west(), pos.down()}) {
           // addGlow tries all directions if the passed one doesn't work
           if(TinkerCommons.blockGlow.addGlow(world, candidate, EnumFacing.values()[random.nextInt(6)])) {


### PR DESCRIPTION
With this PR, the glowing modifier will no longer trying to add glowing blocks around the entity if the said entity is in water. Fixes #2535