### PR TITLE
Fix tiny typo in EFLN description (save -> safe)

### DIFF
--- a/resources/assets/tconstruct/lang/en_US.lang
+++ b/resources/assets/tconstruct/lang/en_US.lang
@@ -429,7 +429,7 @@ item.tconstruct.fancy_frame.clear.name=Clear Item Frame
 item.tconstruct.throwball.glow.name=Glowball
 item.tconstruct.throwball.glow.tooltip=Not suited for consumption.
 item.tconstruct.throwball.efln.name=EFLN
-item.tconstruct.throwball.efln.tooltip=Explodes! Save for mining
+item.tconstruct.throwball.efln.tooltip=Explodes! Safe for mining
 
 ###################
 # Mom's Spaghetti #


### PR DESCRIPTION
Unless you meant they should be saved for mining of course.  
(Felt like overkill to submit an issue for this while it's a 1 letter change)