### PR TITLE
Always return a IFluidTankProperties for the smeltery tank

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/smeltery/SmelteryTank.java
+++ b/src/main/java/slimeknights/tconstruct/library/smeltery/SmelteryTank.java
@@ -77,6 +77,12 @@ public class SmelteryTank implements IFluidTank, IFluidHandler {
 
   @Override
   public IFluidTankProperties[] getTankProperties() {
+    // if the size is 0 (no fluids) simply return an empty properties
+    // some other mods expect having at least 1 value here
+    if(liquids.size() == 0) {
+      return new IFluidTankProperties[]{ new FluidTankProperties(null, maxCapacity, true, true) };
+    }
+
     IFluidTankProperties[] properties = new IFluidTankProperties[liquids.size()];
     for(int i = 0; i < liquids.size(); i++) {
       boolean first = i == 0;


### PR DESCRIPTION
Even when we have no fluids, this fixes fluid pipes such as Immersive Engineering's not connecting to an empty smeltery.

Talking to BluSunrize on IRC, he stated that a IFluidTankProperties array of size 0 is considered equivalent to no tank, partly since that method used to never return null. Since we make the first tank have the remaining empty capacity, I figured it should be fine simply returning a full empty tank, but I wanted to double check instead of pushing directly to master.