### PR TITLE
Change the seared furnance to kill all mobs within itself when active

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
@@ -152,13 +152,11 @@ public class TileSearedFurnace extends TileHeatingStructureFuelTank<MultiblockSe
   protected void interactWithEntitiesInside() {
       AxisAlignedBB bb = info.getBoundingBox().contract(1).offset(0, 0.5, 0).expand(0, 0.5, 0);
 
-      List<Entity> entities = getWorld().getEntitiesWithinAABB(Entity.class, bb);
+      List<EntityLivingBase> entities = getWorld().getEntitiesWithinAABB(EntityLivingBase.class, bb);
 
-      for(Entity entity : entities) {
+      for(EntityLivingBase entity : entities) {
           if (entity instanceof EntityMob) {
-              EntityLivingBase entityLiving = (EntityLivingBase) entity;
-
-              entityLiving.setHealth(0F);
+              entity.setHealth(0F);
           }
       }
   }

--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
@@ -1,23 +1,27 @@
 package slimeknights.tconstruct.smeltery.tileentity;
 
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import org.apache.logging.log4j.Logger;
+
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.util.ITickable;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-
-import org.apache.logging.log4j.Logger;
-
-import javax.annotation.Nonnull;
-
 import slimeknights.mantle.common.IInventoryGui;
-import slimeknights.mantle.multiblock.IMasterLogic;
 import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.smeltery.client.GuiSearedFurnace;
 import slimeknights.tconstruct.smeltery.inventory.ContainerSearedFurnace;
@@ -54,6 +58,7 @@ public class TileSearedFurnace extends TileHeatingStructureFuelTank<MultiblockSe
       // we heat items every tick, as otherwise we are quite slow compared to a vanilla furnace
       if(tick % 4 == 0) {
         heatItems();
+        interactWithEntitiesInside();
       }
 
       if(needsFuel) {
@@ -142,6 +147,20 @@ public class TileSearedFurnace extends TileHeatingStructureFuelTank<MultiblockSe
   @Override
   protected int getUpdatedInventorySize(int width, int height, int depth) {
     return 9 + (3 * width * height * depth);
+  }
+  
+  protected void interactWithEntitiesInside() {
+      AxisAlignedBB bb = info.getBoundingBox().contract(1).offset(0, 0.5, 0).expand(0, 0.5, 0);
+
+      List<Entity> entities = getWorld().getEntitiesWithinAABB(Entity.class, bb);
+
+      for(Entity entity : entities) {
+          if (entity instanceof EntityMob) {
+              EntityLivingBase entityLiving = (EntityLivingBase) entity;
+
+              entityLiving.setHealth(0F);
+          }
+      }
   }
 
   /* GUI */

--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
@@ -58,7 +58,10 @@ public class TileSearedFurnace extends TileHeatingStructureFuelTank<MultiblockSe
       // we heat items every tick, as otherwise we are quite slow compared to a vanilla furnace
       if(tick % 4 == 0) {
         heatItems();
-        interactWithEntitiesInside();
+      }
+      
+      if(tick == 0) {
+          interactWithEntitiesInside();
       }
 
       if(needsFuel) {
@@ -155,8 +158,8 @@ public class TileSearedFurnace extends TileHeatingStructureFuelTank<MultiblockSe
       List<EntityLivingBase> entities = getWorld().getEntitiesWithinAABB(EntityLivingBase.class, bb);
 
       for(EntityLivingBase entity : entities) {
-          if (entity instanceof EntityMob) {
-              entity.setHealth(0F);
+          if(entity instanceof EntityMob) {
+              entity.setDead();
           }
       }
   }

--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
@@ -7,7 +7,6 @@ import javax.annotation.Nonnull;
 import org.apache.logging.log4j.Logger;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.player.InventoryPlayer;

--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
@@ -1,11 +1,5 @@
 package slimeknights.tconstruct.smeltery.tileentity;
 
-import java.util.List;
-
-import javax.annotation.Nonnull;
-
-import org.apache.logging.log4j.Logger;
-
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityMob;
@@ -20,6 +14,13 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
 import slimeknights.mantle.common.IInventoryGui;
 import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.smeltery.client.GuiSearedFurnace;
@@ -157,7 +158,7 @@ public class TileSearedFurnace extends TileHeatingStructureFuelTank<MultiblockSe
       List<EntityLivingBase> entities = getWorld().getEntitiesWithinAABB(EntityLivingBase.class, bb);
 
       for(EntityLivingBase entity : entities) {
-          if(entity instanceof EntityMob) {
+          if(entity instanceof EntityMob && entity.isEntityAlive()) {
               entity.setDead();
           }
       }

--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSearedFurnace.java
@@ -153,6 +153,7 @@ public class TileSearedFurnace extends TileHeatingStructureFuelTank<MultiblockSe
   }
   
   protected void interactWithEntitiesInside() {
+      // find all monsters within the furnace and kill them 
       AxisAlignedBB bb = info.getBoundingBox().contract(1).offset(0, 0.5, 0).expand(0, 0.5, 0);
 
       List<EntityLivingBase> entities = getWorld().getEntitiesWithinAABB(EntityLivingBase.class, bb);


### PR DESCRIPTION
Mobs killed this way will not drop xp nor items. Fixes #2638 

There are many ways to achieve the same effect but I chose killing mobs after they spawn primarily because of the ease of implementation. Preventing mob spawn requires subscribing to the mob spawning event and there are potentially a lot of similar tile entites which will subscribe to the same event. And also when the tile entity is destroyed, it requires even more handling to make sure the event is not passed to the non-existent tile entity.

Adding glow might also work but it requires additional checks for light level and the subsequent destruction of said glow blocks in the event the structure is invalid.