### PR TITLE
Fixed a small error in translation

### DIFF
--- a/resources/assets/tconstruct/lang/ru_RU.lang
+++ b/resources/assets/tconstruct/lang/ru_RU.lang
@@ -328,7 +328,7 @@ item.tconstruct.sharpening_kit.tooltip=Объедините с кремнем и
 
 item.forge.bucketFilled.blood=Ведро крови
 
-# Струменты
+# Инструменты
 item.tconstruct.pickaxe.name=кирка
 item.tconstruct.shovel.name=лопата
 item.tconstruct.hatchet.name=топор
@@ -413,7 +413,7 @@ item.tconstruct.slime_boots.blood.name=Кровавые ботинки
 item.tconstruct.slime_boots.magma.name=Огнеслизневые ботинки
 item.tconstruct.slime_boots.tooltip=Отскакиваете при падении
 item.tconstruct.slimesling.name=Слизнерогатка
-item.tconstruct.slimesling.tooltip=Взведите, нацельтесь под ноги, отпустите!\nОдевайте слизневые ботинки, если жизнь дорога!
+item.tconstruct.slimesling.tooltip=Взведите, нацельтесь под ноги, отпустите!\nНадевайте слизневые ботинки, если жизнь дорога!
 item.tconstruct.piggybackpack.name=Рюкзак-седло
 item.tconstruct.piggybackpack.tooltip=ПКМ на мобе или игроке для его поднятия
 item.tconstruct.stone_stick.name=Каменный стержень


### PR DESCRIPTION
When you equip something, it's "надевать" (nadevat'), not "одевать" (odevat'). It's a common error even in Russia.

Когда вы что-то кладете в слоты брони, это "надевать", а не "одевать". Даже те, кому русский - родной язык, часто совершают эту ошибку.