### PR TITLE
Fix bucket casting recipe not properly setting the output

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/smeltery/BucketCastingRecipe.java
+++ b/src/main/java/slimeknights/tconstruct/library/smeltery/BucketCastingRecipe.java
@@ -1,30 +1,36 @@
 package slimeknights.tconstruct.library.smeltery;
 
-import net.minecraft.init.Items;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidUtil;
-import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
 public class BucketCastingRecipe implements ICastingRecipe {
 
-  public static final BucketCastingRecipe INSTANCE = new BucketCastingRecipe();
+  private Item bucket;
 
-  protected BucketCastingRecipe() {}
+  /**
+   * Casting recipe to fill a fluid container
+   * @param bucket  Fluid container item, must have a fluid handler capability
+   */
+  public BucketCastingRecipe(Item bucket) {
+    this.bucket = bucket;
+  }
 
   @Override
   public ItemStack getResult(ItemStack cast, Fluid fluid) {
-    ItemStack output = new ItemStack(Items.BUCKET);
-    IFluidHandler fluidHandler = FluidUtil.getFluidHandler(output);
+    ItemStack output = new ItemStack(bucket);
+    IFluidHandlerItem fluidHandler = FluidUtil.getFluidHandler(output);
     assert fluidHandler != null;
     fluidHandler.fill(getFluid(cast, fluid), true);
 
-    return output;
+    return fluidHandler.getContainer();
   }
 
   @Override
   public boolean matches(ItemStack cast, Fluid fluid) {
-    return cast.getItem() == Items.BUCKET;
+    return cast.getItem() == bucket;
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/TinkerSmeltery.java
@@ -402,7 +402,7 @@ public class TinkerSmeltery extends TinkerPulse {
     int bucket = Fluid.BUCKET_VOLUME;
 
     // bucket casting
-    TinkerRegistry.registerTableCasting(BucketCastingRecipe.INSTANCE);
+    TinkerRegistry.registerTableCasting(new BucketCastingRecipe(Items.BUCKET));
 
     // Water
     Fluid water = FluidRegistry.WATER;


### PR DESCRIPTION
I would have just committed directly to master, but I made a change to the API that I want your opinion on.

Basically, I swapped the BucketCastingRecipe from using a singleton instance to taking an item in the constructor so anther mod can add a recipe for their fluid container by calling the constructor. I wanted to be certain you were fine with removing the old protected constructor as it was likely unused in our API anyways (and the 1.11 build is still Alpha)