### PR TITLE
PR for Issue #2928

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/TinkerRegistry.java
+++ b/src/main/java/slimeknights/tconstruct/library/TinkerRegistry.java
@@ -1,5 +1,18 @@
 package slimeknights.tconstruct.library;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -10,7 +23,6 @@ import com.google.common.collect.Sets;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.set.hash.THashSet;
 import gnu.trove.set.hash.TLinkedHashSet;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
@@ -26,20 +38,6 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.oredict.OreDictionary;
-
-import org.apache.logging.log4j.Logger;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
-
 import slimeknights.mantle.client.CreativeTab;
 import slimeknights.mantle.util.RecipeMatch;
 import slimeknights.tconstruct.library.events.MaterialEvent;
@@ -53,6 +51,7 @@ import slimeknights.tconstruct.library.smeltery.AlloyRecipe;
 import slimeknights.tconstruct.library.smeltery.CastingRecipe;
 import slimeknights.tconstruct.library.smeltery.ICastingRecipe;
 import slimeknights.tconstruct.library.smeltery.MeltingRecipe;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tinkering.PartMaterialType;
 import slimeknights.tconstruct.library.tools.IPattern;
 import slimeknights.tconstruct.library.tools.IToolPart;
@@ -325,7 +324,7 @@ public final class TinkerRegistry {
   ---------------------------------------------------------------------------*/
 
   /** This set contains all known tools */
-  private static final Set<ToolCore> tools = new TLinkedHashSet<ToolCore>();
+  private static final Set<ITinkerable> tools = new TLinkedHashSet<ITinkerable>();
   private static final Set<IToolPart> toolParts = new TLinkedHashSet<IToolPart>();
   private static final Set<ToolCore> toolStationCrafting = Sets.newLinkedHashSet();
   private static final Set<ToolCore> toolForgeCrafting = Sets.newLinkedHashSet();
@@ -348,7 +347,7 @@ public final class TinkerRegistry {
     }
   }
 
-  public static Set<ToolCore> getTools() {
+  public static Set<ITinkerable> getTools() {
     return ImmutableSet.copyOf(tools);
   }
 
@@ -382,7 +381,7 @@ public final class TinkerRegistry {
     toolStationCrafting.add(tool);
   }
 
-  public static Set<ToolCore> getToolStationCrafting() {
+  public static Set<ITinkerable> getToolStationCrafting() {
     return ImmutableSet.copyOf(toolStationCrafting);
   }
 
@@ -391,7 +390,7 @@ public final class TinkerRegistry {
     toolForgeCrafting.add(tool);
   }
 
-  public static Set<ToolCore> getToolForgeCrafting() {
+  public static Set<ITinkerable> getToolForgeCrafting() {
     return ImmutableSet.copyOf(toolForgeCrafting);
   }
 

--- a/src/main/java/slimeknights/tconstruct/library/book/content/ContentTool.java
+++ b/src/main/java/slimeknights/tconstruct/library/book/content/ContentTool.java
@@ -64,8 +64,8 @@ public class ContentTool extends TinkerPage {
       toolName = parent.name;
     }
     if(tool == null) {
-      tool = TinkerRegistry.getTools().stream()
-                           .filter(toolCore -> toolName.equals(toolCore.getIdentifier()))
+      tool = (ToolCore) TinkerRegistry.getTools().stream()
+                           .filter(toolCore -> toolName.equals(((ToolCore) toolCore).getIdentifier()))
                            .findFirst()
                            .orElseThrow(() -> new RuntimeException("Unknown tool " + toolName));
     }

--- a/src/main/java/slimeknights/tconstruct/library/book/sectiontransformer/ToolSectionTransformer.java
+++ b/src/main/java/slimeknights/tconstruct/library/book/sectiontransformer/ToolSectionTransformer.java
@@ -10,6 +10,7 @@ import slimeknights.mantle.client.book.data.PageData;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.book.content.ContentListing;
 import slimeknights.tconstruct.library.book.content.ContentTool;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tools.ToolCore;
 
 @SideOnly(Side.CLIENT)
@@ -24,11 +25,11 @@ public class ToolSectionTransformer extends ContentListingSectionTransformer {
     // only add tool pages if the tool exists
     if(page.content instanceof ContentTool) {
       String toolName = ((ContentTool) page.content).toolName;
-      Optional<ToolCore> tool = TinkerRegistry.getTools().stream()
-                                              .filter(toolCore -> toolName.equals(toolCore.getIdentifier()))
+      Optional<ITinkerable> tool = TinkerRegistry.getTools().stream()
+                                              .filter(toolCore -> toolName.equals(((ToolCore) toolCore).getIdentifier()))
                                               .findFirst();
 
-      tool.ifPresent(toolCore -> listing.addEntry(toolCore.getLocalizedName(), page));
+      tool.ifPresent(toolCore -> listing.addEntry(((ToolCore)toolCore).getLocalizedName(), page));
     }
     else {
       super.processPage(book, listing, page);

--- a/src/main/java/slimeknights/tconstruct/library/tinkering/ITinkerable.java
+++ b/src/main/java/slimeknights/tconstruct/library/tinkering/ITinkerable.java
@@ -1,6 +1,10 @@
 package slimeknights.tconstruct.library.tinkering;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import slimeknights.tconstruct.library.materials.Material;
 
 import java.util.List;
 
@@ -18,4 +22,32 @@ public interface ITinkerable {
 
   /** What the tool is made out of. Displayed whet Ctrl is held */
   void getTooltipComponents(ItemStack stack, List<String> tooltips);
+  
+  //From TinkersItem
+  public List<PartMaterialType> getRequiredComponents();
+  //not sure why these both exist but I'll include both just in case
+  public List<PartMaterialType> getToolBuildComponents();
+  
+  public ItemStack buildItemFromStacks(ItemStack[] stacks);
+  
+  public ItemStack buildItem(List<Material> materials);
+  
+  public NBTTagCompound buildItemNBT(List<Material> materials);
+  
+  public NBTTagCompound buildData(List<Material> materials);
+  
+  public ItemStack buildItemForRendering(List<Material> materials);
+  
+  public ItemStack buildItemForRenderingInGui();
+  
+  @SideOnly(Side.CLIENT)
+  public Material getMaterialForPartForGuiRendering(int index);
+  
+  public NBTTagCompound buildTag(List<Material> materials);
+  
+  public void addMaterialTraits(NBTTagCompound root, List<Material> materials);
+  
+  public int[] getRepairParts();
+  
+  public float getRepairModifierForPart(int index);
 }

--- a/src/main/java/slimeknights/tconstruct/library/tinkering/TinkersItem.java
+++ b/src/main/java/slimeknights/tconstruct/library/tinkering/TinkersItem.java
@@ -195,7 +195,7 @@ public abstract class TinkersItem extends Item implements ITinkerable, IModifyab
   /**
    * Creates an NBT Tag with the materials that were used to build the item.
    */
-  private NBTTagCompound buildData(List<Material> materials) {
+  public NBTTagCompound buildData(List<Material> materials) {
     NBTTagCompound base = new NBTTagCompound();
     NBTTagList materialList = new NBTTagList();
 

--- a/src/main/java/slimeknights/tconstruct/library/tools/ToolPart.java
+++ b/src/main/java/slimeknights/tconstruct/library/tools/ToolPart.java
@@ -28,6 +28,7 @@ import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.library.materials.IMaterialStats;
 import slimeknights.tconstruct.library.materials.Material;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tinkering.MaterialItem;
 import slimeknights.tconstruct.library.tinkering.PartMaterialType;
 import slimeknights.tconstruct.library.traits.ITrait;
@@ -64,7 +65,7 @@ public class ToolPart extends MaterialItem implements IToolPart {
 
   @Override
   public boolean canUseMaterial(Material mat) {
-    for(ToolCore tool : TinkerRegistry.getTools()) {
+    for(ITinkerable tool : TinkerRegistry.getTools()) {
       for(PartMaterialType pmt : tool.getRequiredComponents()) {
         if(pmt.isValid(this, mat)) {
           return true;
@@ -212,7 +213,7 @@ public class ToolPart extends MaterialItem implements IToolPart {
 
   @Override
   public boolean hasUseForStat(String stat) {
-    for(ToolCore tool : TinkerRegistry.getTools()) {
+    for(ITinkerable tool : TinkerRegistry.getTools()) {
       for(PartMaterialType pmt : tool.getRequiredComponents()) {
         if(pmt.isValidItem(this) && pmt.usesStat(stat)) {
           return true;

--- a/src/main/java/slimeknights/tconstruct/library/utils/ToolBuilder.java
+++ b/src/main/java/slimeknights/tconstruct/library/utils/ToolBuilder.java
@@ -1,12 +1,18 @@
 package slimeknights.tconstruct.library.utils;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import gnu.trove.map.TIntIntMap;
 import gnu.trove.map.hash.TIntIntHashMap;
-import gnu.trove.procedure.TIntIntProcedure;
-
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -14,16 +20,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
 import net.minecraft.util.text.translation.I18n;
-
-import org.apache.logging.log4j.Logger;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-
 import slimeknights.mantle.util.RecipeMatch;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.Util;
@@ -32,6 +28,7 @@ import slimeknights.tconstruct.library.materials.Material;
 import slimeknights.tconstruct.library.modifiers.IModifier;
 import slimeknights.tconstruct.library.modifiers.TinkerGuiException;
 import slimeknights.tconstruct.library.tinkering.IRepairable;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tinkering.MaterialItem;
 import slimeknights.tconstruct.library.tinkering.PartMaterialType;
 import slimeknights.tconstruct.library.tinkering.TinkersItem;
@@ -40,7 +37,6 @@ import slimeknights.tconstruct.library.tools.Pattern;
 import slimeknights.tconstruct.library.tools.ToolCore;
 import slimeknights.tconstruct.library.traits.AbstractTrait;
 import slimeknights.tconstruct.library.traits.ITrait;
-import slimeknights.tconstruct.tools.TinkerTools;
 
 public final class ToolBuilder {
 
@@ -59,7 +55,7 @@ public final class ToolBuilder {
    * @param stacks Input.
    * @return The built tool or null if none could be built.
    */
-  public static ItemStack tryBuildTool(ItemStack[] stacks, String name, Collection<ToolCore> possibleTools) {
+  public static ItemStack tryBuildTool(ItemStack[] stacks, String name, Collection<ITinkerable> possibleTools) {
     int length = -1;
     ItemStack[] input;
     // remove trailing nulls
@@ -81,7 +77,7 @@ public final class ToolBuilder {
 
     input = Arrays.copyOf(stacks, length);
 
-    for(Item item : possibleTools) {
+    for(ITinkerable item : possibleTools) {
       if(!(item instanceof ToolCore)) {
         continue;
       }

--- a/src/main/java/slimeknights/tconstruct/tools/AggregateModelRegistrar.java
+++ b/src/main/java/slimeknights/tconstruct/tools/AggregateModelRegistrar.java
@@ -17,6 +17,7 @@ import slimeknights.tconstruct.common.ModelRegisterUtil;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.library.modifiers.IModifier;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tinkering.PartMaterialType;
 import slimeknights.tconstruct.library.tools.Pattern;
 import slimeknights.tconstruct.library.tools.ToolCore;
@@ -54,7 +55,7 @@ public class AggregateModelRegistrar extends AbstractToolPulse {
   }
 
   private void registerStencil(Item pattern, ToolPart toolPart) {
-    for(ToolCore toolCore : TinkerRegistry.getTools()) {
+    for(ITinkerable toolCore : TinkerRegistry.getTools()) {
       for(PartMaterialType partMaterialType : toolCore.getRequiredComponents()) {
         if(partMaterialType.getPossibleParts().contains(toolPart)) {
           ItemStack stencil = new ItemStack(pattern);

--- a/src/main/java/slimeknights/tconstruct/tools/common/client/GuiToolForge.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/client/GuiToolForge.java
@@ -7,6 +7,7 @@ import net.minecraft.world.World;
 import java.util.Set;
 
 import slimeknights.tconstruct.library.TinkerRegistry;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tools.ToolCore;
 import slimeknights.tconstruct.tools.common.tileentity.TileToolForge;
 
@@ -19,7 +20,7 @@ public class GuiToolForge extends GuiToolStation {
   }
 
   @Override
-  public Set<ToolCore> getBuildableItems() {
+  public Set<ITinkerable> getBuildableItems() {
     return TinkerRegistry.getToolForgeCrafting();
   }
 }

--- a/src/main/java/slimeknights/tconstruct/tools/common/client/GuiToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/client/GuiToolStation.java
@@ -39,6 +39,7 @@ import slimeknights.tconstruct.library.client.ToolBuildGuiInfo;
 import slimeknights.tconstruct.library.modifiers.IModifier;
 import slimeknights.tconstruct.library.modifiers.ModifierNBT;
 import slimeknights.tconstruct.library.tinkering.IModifyable;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tinkering.IToolStationDisplay;
 import slimeknights.tconstruct.library.tinkering.PartMaterialType;
 import slimeknights.tconstruct.library.tinkering.TinkersItem;
@@ -149,7 +150,7 @@ public class GuiToolStation extends GuiTinkerStation {
     Keyboard.enableRepeatEvents(false);
   }
 
-  public Set<ToolCore> getBuildableItems() {
+  public Set<ITinkerable> getBuildableItems() {
     return TinkerRegistry.getToolStationCrafting();
   }
 

--- a/src/main/java/slimeknights/tconstruct/tools/common/client/module/GuiButtonsToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/client/module/GuiButtonsToolStation.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import slimeknights.tconstruct.library.TinkerRegistryClient;
 import slimeknights.tconstruct.library.client.Icons;
 import slimeknights.tconstruct.library.client.ToolBuildGuiInfo;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.tools.common.client.GuiButtonItem;
 import slimeknights.tconstruct.tools.common.client.GuiButtonRepair;
 import slimeknights.tconstruct.tools.common.client.GuiToolStation;
@@ -42,8 +43,8 @@ public class GuiButtonsToolStation extends GuiSideButtons {
       addSideButton(button);
     }
 
-    for(Item item : parent.getBuildableItems()) {
-      ToolBuildGuiInfo info = TinkerRegistryClient.getToolBuildInfoForTool(item);
+    for(ITinkerable item : parent.getBuildableItems()) {
+      ToolBuildGuiInfo info = TinkerRegistryClient.getToolBuildInfoForTool((Item) item);
       if(info != null) {
         GuiButtonItem<ToolBuildGuiInfo> button = new GuiButtonItem<ToolBuildGuiInfo>(index++, -1, -1, info.tool, info);
         shiftButton(button, 0, -18 * style);

--- a/src/main/java/slimeknights/tconstruct/tools/common/debug/TempToolCrafting.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/debug/TempToolCrafting.java
@@ -12,6 +12,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import slimeknights.tconstruct.library.TinkerRegistry;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tools.ToolCore;
 
 public class TempToolCrafting implements IRecipe {
@@ -47,7 +48,7 @@ public class TempToolCrafting implements IRecipe {
     }
 
     ItemStack[] inputs = input.toArray(new ItemStack[input.size()]);
-    for(ToolCore tool : TinkerRegistry.getTools()) {
+    for(ITinkerable tool : TinkerRegistry.getTools()) {
       outputTool = tool.buildItemFromStacks(inputs);
       if(outputTool != null) {
         break;

--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolForge.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolForge.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.common.Sounds;
 import slimeknights.tconstruct.library.TinkerRegistry;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tools.ToolCore;
 import slimeknights.tconstruct.tools.common.tileentity.TileToolStation;
 
@@ -19,7 +20,7 @@ public class ContainerToolForge extends ContainerToolStation {
   }
 
   @Override
-  protected Set<ToolCore> getBuildableTools() {
+  protected Set<ITinkerable> getBuildableTools() {
     return TinkerRegistry.getToolForgeCrafting();
   }
 

--- a/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/inventory/ContainerToolStation.java
@@ -21,6 +21,7 @@ import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.modifiers.TinkerGuiException;
 import slimeknights.tconstruct.library.tinkering.IModifyable;
 import slimeknights.tconstruct.library.tinkering.IRepairable;
+import slimeknights.tconstruct.library.tinkering.ITinkerable;
 import slimeknights.tconstruct.library.tinkering.PartMaterialType;
 import slimeknights.tconstruct.library.tinkering.TinkersItem;
 import slimeknights.tconstruct.library.tools.ToolCore;
@@ -260,7 +261,7 @@ public class ContainerToolStation extends ContainerTinkerStation<TileToolStation
     return ToolBuilder.tryBuildTool(input, toolName, getBuildableTools());
   }
 
-  protected Set<ToolCore> getBuildableTools() {
+  protected Set<ITinkerable> getBuildableTools() {
     return TinkerRegistry.getToolStationCrafting();
   }
 


### PR DESCRIPTION
Moves methods from TinkerItem to ITinkerable
Changes Registry to use ITinkerable instead of ToolCore
Changes various methods throughout to be compatible with Registry changes