### PR TITLE
Small performance improvement for model CacheKey

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/client/model/BakedBowModel.java
+++ b/src/main/java/slimeknights/tconstruct/library/client/model/BakedBowModel.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.block.model.ItemOverrideList;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraftforge.common.model.TRSRTransformation;
 
@@ -20,6 +21,7 @@ import javax.annotation.Nonnull;
 import slimeknights.mantle.client.model.TRSRBakedModel;
 import slimeknights.tconstruct.library.client.model.format.AmmoPosition;
 import slimeknights.tconstruct.library.tools.IAmmoUser;
+import slimeknights.tconstruct.library.utils.TagUtil;
 
 public class BakedBowModel extends BakedToolModel {
 
@@ -82,13 +84,13 @@ public class BakedBowModel extends BakedToolModel {
 
     final Item ammoItem;
     final int ammoMeta;
-    final String ammoData;
+    final NBTTagCompound ammoData;
 
     private CacheKeyAmmo(IBakedModel parent, ItemStack stack, ItemStack ammo) {
       super(parent, stack);
       ammoItem = ammo.getItem();
       ammoMeta = ammo.getMetadata();
-      ammoData = getDataFromStack(ammo);
+      ammoData = TagUtil.getTagSafe(ammo);
     }
 
     @Override

--- a/src/main/java/slimeknights/tconstruct/library/client/model/BakedToolModel.java
+++ b/src/main/java/slimeknights/tconstruct/library/client/model/BakedToolModel.java
@@ -165,15 +165,11 @@ public class BakedToolModel extends BakedWrapper.Perspective {
   protected static class CacheKey {
 
     final IBakedModel parent;
-    final String data;
+    final NBTTagCompound data;
 
     protected CacheKey(IBakedModel parent, ItemStack stack) {
       this.parent = parent;
-      this.data = getDataFromStack(stack);
-    }
-
-    protected String getDataFromStack(ItemStack stack) {
-      return TagUtil.getTagSafe(stack).toString();
+      this.data = TagUtil.getTagSafe(stack);
     }
 
     @Override

--- a/src/main/java/slimeknights/tconstruct/library/utils/TagUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/utils/TagUtil.java
@@ -29,7 +29,7 @@ public final class TagUtil {
   }
 
   public static NBTTagCompound getTagSafe(NBTTagCompound tag, String key) {
-    if(tag == null || !tag.hasKey(key)) {
+    if(tag == null) {
       return new NBTTagCompound();
     }
 
@@ -37,7 +37,7 @@ public final class TagUtil {
   }
 
   public static NBTTagList getTagListSafe(NBTTagCompound tag, String key, int type) {
-    if(tag == null || !tag.hasKey(key)) {
+    if(tag == null) {
       return new NBTTagList();
     }
 


### PR DESCRIPTION
Ran across this while profiling items rendering in JEI and looking for any simple small fixes.
`NBTTagCompound#toString` is apparently *super* slow, and the nbt itself can be used as a cache key just as well without converting it to a string first.

The changes to the `TagUtil` checks are because vanilla actually does those same checks now, so they were made redundant.

Here's profiling before and after: (9.8% to 0.1%)
![cachekey-before](https://user-images.githubusercontent.com/916092/31001992-95fa7eb2-a49c-11e7-910e-3334454cc570.png)

![cachekey-after](https://user-images.githubusercontent.com/916092/31001994-982c963e-a49c-11e7-9057-3d5ca643a231.png)