### PR TITLE
Improve FPS in JEI by culling quads of BakedSimpleItem when in the GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ options.txt
 /resources/assets/tinker
 /resources/assets/unused
 /design
+/classes/

--- a/src/main/java/slimeknights/tconstruct/library/client/model/BakedSimpleItem.java
+++ b/src/main/java/slimeknights/tconstruct/library/client/model/BakedSimpleItem.java
@@ -5,30 +5,75 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.vecmath.Matrix4f;
 
-import slimeknights.mantle.client.model.BakedSimple;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.block.model.ItemOverrideList;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.client.model.ItemLayerModel;
+import net.minecraftforge.client.model.PerspectiveMapWrapper;
+import net.minecraftforge.common.model.TRSRTransformation;
+import org.apache.commons.lang3.tuple.Pair;
 
-public class BakedSimpleItem extends BakedSimple {
+/**
+ * Based on {@link ItemLayerModel.BakedItemModel}
+ * Implements culling for items in the GUI
+ */
+public class BakedSimpleItem implements IBakedModel {
+  private final ImmutableList<BakedQuad> quads;
+  private final TextureAtlasSprite particle;
+  private final ImmutableMap<ItemCameraTransforms.TransformType, TRSRTransformation> transforms;
+  private final IBakedModel otherModel;
+  private final boolean isCulled;
+  private final ItemOverrideList overrides;
 
-  public BakedSimpleItem(ImmutableList<net.minecraft.client.renderer.block.model.BakedQuad> quads, ImmutableMap<net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformType, net.minecraftforge.common.model.TRSRTransformation> transforms, net.minecraft.client.renderer.block.model.IBakedModel base) {
-    super(quads, transforms, base);
+  public BakedSimpleItem(ImmutableList<BakedQuad> quads, ImmutableMap<ItemCameraTransforms.TransformType, TRSRTransformation> transforms, IBakedModel original) {
+      this(quads, original.getParticleTexture(), transforms, original.getOverrides(), null);
   }
 
-  public BakedSimpleItem(List<net.minecraft.client.renderer.block.model.BakedQuad> quads, ImmutableMap<net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformType, net.minecraftforge.common.model.TRSRTransformation> transforms, net.minecraft.client.renderer.block.model.IBakedModel base) {
-    super(quads, transforms, base);
-  }
-
-  public BakedSimpleItem(List<net.minecraft.client.renderer.block.model.BakedQuad> quads, ImmutableMap<net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformType, net.minecraftforge.common.model.TRSRTransformation> transforms, net.minecraft.client.renderer.texture.TextureAtlasSprite particle, boolean ambientOcclusion, boolean isGui3d, net.minecraft.client.renderer.block.model.ItemOverrideList overrides) {
-    super(quads, transforms, particle, ambientOcclusion, isGui3d, overrides);
-  }
-
-  @Nonnull
-  @Override
-  public List<net.minecraft.client.renderer.block.model.BakedQuad> getQuads(net.minecraft.block.state.IBlockState state, net.minecraft.util.EnumFacing side, long rand) {
-    if(side == null) {
-      return super.getQuads(state, null, rand);
+  private BakedSimpleItem(ImmutableList<BakedQuad> quads, TextureAtlasSprite particle, ImmutableMap<ItemCameraTransforms.TransformType, TRSRTransformation> transforms, ItemOverrideList overrides, @Nullable IBakedModel unculledModel) {
+    this.quads = quads;
+    this.particle = particle;
+    this.transforms = transforms;
+    this.overrides = overrides;
+    if(unculledModel != null) {
+      this.otherModel = unculledModel;
+      this.isCulled = true;
+    } else {
+      ImmutableList.Builder<BakedQuad> builder = ImmutableList.builder();
+      for(BakedQuad quad : quads) {
+        if(quad.getFace() == EnumFacing.SOUTH) {
+          builder.add(quad);
+        }
+      }
+      this.otherModel = new BakedSimpleItem(builder.build(), particle, transforms, overrides, this);
+      isCulled = false;
     }
+  }
+
+  public boolean isAmbientOcclusion() { return true; }
+  public boolean isGui3d() { return false; }
+  public boolean isBuiltInRenderer() { return false; }
+  public TextureAtlasSprite getParticleTexture() { return particle; }
+  public ItemOverrideList getOverrides() { return overrides; }
+  public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) {
+    if(side == null) return quads;
     return ImmutableList.of();
+  }
+
+  @Override
+  public Pair<? extends IBakedModel, Matrix4f> handlePerspective(ItemCameraTransforms.TransformType type) {
+    Pair<? extends IBakedModel, Matrix4f> pair = PerspectiveMapWrapper.handlePerspective(this, transforms, type);
+    if(type == ItemCameraTransforms.TransformType.GUI && !isCulled && pair.getRight() == null) {
+      return Pair.of(otherModel, null);
+    } else if(type != ItemCameraTransforms.TransformType.GUI && isCulled) {
+      return Pair.of(otherModel, pair.getRight());
+    }
+    return pair;
   }
 }

--- a/src/main/java/slimeknights/tconstruct/library/client/model/BakedSimpleItem.java
+++ b/src/main/java/slimeknights/tconstruct/library/client/model/BakedSimpleItem.java
@@ -62,7 +62,9 @@ public class BakedSimpleItem implements IBakedModel {
   public TextureAtlasSprite getParticleTexture() { return particle; }
   public ItemOverrideList getOverrides() { return overrides; }
   public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) {
-    if(side == null) return quads;
+    if(side == null) {
+      return quads;
+    }
     return ImmutableList.of();
   }
 


### PR DESCRIPTION
Fixes #3176

This basically implements the same culling logic found in fry's fix here:
https://github.com/MinecraftForge/MinecraftForge/commit/f42137907e0a87adf1522fded5827086fc0b13f2 
The gist of it is that you can cull most of the quads off of items when they are in the gui because you can't see the sides.

Combined with the previous fixes (https://github.com/SlimeKnights/TinkersConstruct/commit/48b420bfce63159fa31c75eb896a94794cf17661 and #3180), this brings my FPS over 60 even when rendering every single Tinker's item at once in JEI!
Before this PR I got about 40 FPS, before all the fixes together I was getting like 9. Not bad :D