### PR TITLE
Fixes a null ItemStack return

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/smeltery/OreCastingRecipe.java
+++ b/src/main/java/slimeknights/tconstruct/library/smeltery/OreCastingRecipe.java
@@ -50,7 +50,7 @@ public class OreCastingRecipe extends CastingRecipe {
   @Override
   public ItemStack getResult() {
     if(outputs.isEmpty()) {
-      return null;
+      return ItemStack.EMPTY;
     }
     return outputs.get(0);
   }


### PR DESCRIPTION
So, clearly this returning null at all meant there's an invalid OreCastingRecipe somewhere, but this null return is setting so many things on fire I can't really get to the bottom of what is causing the issue.  Probably what is causing #3233