### PR TITLE
backport redstone fix to 1.8.9

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/block/BlockEnumSmeltery.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/BlockEnumSmeltery.java
@@ -5,6 +5,7 @@ import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.IStringSerializable;
@@ -49,6 +50,14 @@ public class BlockEnumSmeltery<T extends Enum<T> & EnumBlock.IEnumMeta & IString
 
   @Override
   public void onNeighborBlockChange(World worldIn, BlockPos pos, IBlockState state, Block neighborBlock) {
+    if(neighborBlock == Blocks.redstone_wire
+       || neighborBlock == Blocks.powered_repeater
+       || neighborBlock == Blocks.unpowered_repeater
+       || neighborBlock == Blocks.powered_comparator
+       || neighborBlock == Blocks.unpowered_comparator
+       || neighborBlock == Blocks.redstone_torch) {
+      return;
+    }
     TileEntity te = worldIn.getTileEntity(pos);
     if(te instanceof TileSmelteryComponent) {
       ((TileSmelteryComponent) te).notifyMasterOfChange();


### PR DESCRIPTION
I've been stuck on 1.8.9 mods since I want to use Thaumcraft and the redstone smeltery lag is just awful. This PR is to backport the fix in #1962 to version 1.8.9