### PR TITLE
Add new ore preference system, to allow oredict outputs to use a specific mod if available

### DIFF
--- a/src/main/java/slimeknights/tconstruct/common/config/Config.java
+++ b/src/main/java/slimeknights/tconstruct/common/config/Config.java
@@ -18,6 +18,7 @@ import java.util.List;
 import slimeknights.mantle.pulsar.config.ForgeCFG;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.library.Util;
+import slimeknights.tconstruct.library.utils.RecipeUtil;
 
 public final class Config {
 
@@ -45,6 +46,10 @@ public final class Config {
   public static double oreToIngotRatio = 2;
   public static String[] craftingStationBlacklist = new String[] {
       "de.ellpeck.actuallyadditions.mod.tile.TileEntityItemViewer"
+  };
+  private static String[] orePreference = {
+      "minecraft",
+      "tconstruct"
   };
   //public static List<String> craftingStationBlacklist = Collections.emptyList();
 
@@ -193,7 +198,11 @@ public final class Config {
       craftingStationBlacklist = prop.getStringList();
       propOrder.add(prop.getName());
 
-
+      prop = configFile.get(cat, "orePreference", orePreference);
+      prop.setComment("Preferred mod ID for oredictionary outputs. Top most mod ID will be the preferred output ID, and if none is found the first output stack is used.");
+      orePreference = prop.getStringList();
+      RecipeUtil.setOrePreferences(orePreference);
+      propOrder.add(prop.getName());
     }
     // Worldgen
     {

--- a/src/main/java/slimeknights/tconstruct/common/config/Config.java
+++ b/src/main/java/slimeknights/tconstruct/common/config/Config.java
@@ -49,7 +49,12 @@ public final class Config {
   };
   private static String[] orePreference = {
       "minecraft",
-      "tconstruct"
+      "tconstruct",
+      "thermalfoundation",
+      "forestry",
+      "immersiveengineering",
+      "embers",
+      "ic2"
   };
   //public static List<String> craftingStationBlacklist = Collections.emptyList();
 

--- a/src/main/java/slimeknights/tconstruct/library/MaterialIntegration.java
+++ b/src/main/java/slimeknights/tconstruct/library/MaterialIntegration.java
@@ -1,14 +1,12 @@
 package slimeknights.tconstruct.library;
 
 import net.minecraft.block.Block;
-import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.registries.IForgeRegistry;
 
-import java.util.List;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.common.config.Config;
 import slimeknights.tconstruct.library.materials.Material;
@@ -145,14 +143,7 @@ public class MaterialIntegration {
   private void registerRepresentativeItem() {
     // also set the representative item
     if(material.getRepresentativeItem().isEmpty() && representativeItem != null && !representativeItem.isEmpty()) {
-      List<ItemStack> ore = OreDictionary.getOres(representativeItem, false);
-      if(!ore.isEmpty()) {
-        ItemStack itemStack = ore.get(0).copy();
-        if(itemStack.getMetadata() == OreDictionary.WILDCARD_VALUE) {
-          itemStack.setItemDamage(0);
-        }
-        material.setRepresentativeItem(itemStack);
-      }
+      material.setRepresentativeItem(representativeItem);
     }
   }
 

--- a/src/main/java/slimeknights/tconstruct/library/materials/Material.java
+++ b/src/main/java/slimeknights/tconstruct/library/materials/Material.java
@@ -32,6 +32,7 @@ import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.library.client.CustomFontColor;
 import slimeknights.tconstruct.library.client.MaterialRenderInfo;
 import slimeknights.tconstruct.library.traits.ITrait;
+import slimeknights.tconstruct.library.utils.RecipeUtil;
 
 public class Material extends RecipeMatchRegistry {
 
@@ -100,6 +101,11 @@ public class Material extends RecipeMatchRegistry {
    * In general if you want to give a person this material, you can give them this item.
    */
   private ItemStack representativeItem = ItemStack.EMPTY;
+
+  /**
+   * Ore name that represents this material
+   */
+  private String representativeOre = null;
 
   /**
    * This item will be used instead of the generic shard item when returning leftovers.
@@ -342,6 +348,10 @@ public class Material extends RecipeMatchRegistry {
     this.addItem("block" + oredictSuffix, 1, Material.VALUE_Block);
   }
 
+  public void setRepresentativeItem(String representativeOre) {
+    this.representativeOre = representativeOre;
+  }
+
   public void setRepresentativeItem(Item representativeItem) {
     setRepresentativeItem(new ItemStack(representativeItem));
   }
@@ -366,6 +376,12 @@ public class Material extends RecipeMatchRegistry {
   }
 
   public ItemStack getRepresentativeItem() {
+    if(representativeOre != null) {
+      ItemStack ore = RecipeUtil.getPreference(representativeOre);
+      if(!ore.isEmpty()) {
+        return ore;
+      }
+    }
     return representativeItem;
   }
 

--- a/src/main/java/slimeknights/tconstruct/library/smeltery/OreCastingRecipe.java
+++ b/src/main/java/slimeknights/tconstruct/library/smeltery/OreCastingRecipe.java
@@ -4,56 +4,44 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.oredict.OreDictionary;
+
 import java.util.List;
 
 import slimeknights.mantle.util.RecipeMatch;
-import slimeknights.tconstruct.library.utils.RecipeUtil;
 
 /**
  * A casting recipe that takes its output from an oredict entry.
  * Used for ingot casting etc.
+ * @Deprecated Use {@link PreferenceCastingRecipe}
  */
+@Deprecated
 public class OreCastingRecipe extends CastingRecipe {
 
-  /** @Deprecated use oreName instead */
-  @Deprecated
   protected final List<ItemStack> outputs;
-  protected final String oreName;
 
-  /**
-   * The ore list is retained internally, that means changes to the list affect the result
-   * @Deprecated use {@link #OreCastingRecipe(String, RecipeMatch, Fluid, int)}
-   */
-  @Deprecated
   public OreCastingRecipe(List<ItemStack> ore, RecipeMatch cast, Fluid fluid, int amount) {
     this(ore, cast, new FluidStack(fluid, amount), calcCooldownTime(fluid, amount), false, false);
   }
 
   public OreCastingRecipe(String ore, RecipeMatch cast, Fluid fluid, int amount) {
-    this(ore, cast, new FluidStack(fluid, amount), calcCooldownTime(fluid, amount), false, false);
+    this(OreDictionary.getOres(ore), cast, new FluidStack(fluid, amount), calcCooldownTime(fluid, amount), false, false);
   }
 
   public OreCastingRecipe(String ore, RecipeMatch cast, FluidStack fluid, int time, boolean consumesCast, boolean switchOutputs) {
-    super(new ItemStack(Blocks.COBBLESTONE), cast, fluid, time, consumesCast, switchOutputs);
-    this.outputs = null;
-    this.oreName = ore;
+    this(OreDictionary.getOres(ore), cast, fluid, time, consumesCast, switchOutputs);
   }
 
-  /**
-   * The ore list is retained internally, that means changes to the list affect the result
-   * @Deprecated use {@link #OreCastingRecipe(String, RecipeMatch, FluidStack, int, boolean, boolean)}
-   */
-  @Deprecated
+  /** The ore list is retained internally, that means changes to the list affect the result */
   public OreCastingRecipe(List<ItemStack> ore, RecipeMatch cast, FluidStack fluid, int time, boolean consumesCast, boolean switchOutputs) {
     super(new ItemStack(Blocks.COBBLESTONE), cast, fluid, time, consumesCast, switchOutputs);
     this.outputs = ore;
-    this.oreName = null;
   }
 
   @Override
   public boolean matches(ItemStack cast, Fluid fluid) {
     // always return false if there is no output
-    return !getResult().isEmpty() && super.matches(cast, fluid);
+    return !outputs.isEmpty() && super.matches(cast, fluid);
   }
 
   @Override
@@ -63,10 +51,6 @@ public class OreCastingRecipe extends CastingRecipe {
 
   @Override
   public ItemStack getResult() {
-    if(oreName != null) {
-      return RecipeUtil.getPreference(oreName);
-    }
-    // legacy logic kepy for backwards compatibility
     if(outputs.isEmpty()) {
       return ItemStack.EMPTY;
     }

--- a/src/main/java/slimeknights/tconstruct/library/smeltery/OreCastingRecipe.java
+++ b/src/main/java/slimeknights/tconstruct/library/smeltery/OreCastingRecipe.java
@@ -4,11 +4,10 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.oredict.OreDictionary;
-
 import java.util.List;
 
 import slimeknights.mantle.util.RecipeMatch;
+import slimeknights.tconstruct.library.utils.RecipeUtil;
 
 /**
  * A casting recipe that takes its output from an oredict entry.
@@ -16,30 +15,45 @@ import slimeknights.mantle.util.RecipeMatch;
  */
 public class OreCastingRecipe extends CastingRecipe {
 
+  /** @Deprecated use oreName instead */
+  @Deprecated
   protected final List<ItemStack> outputs;
+  protected final String oreName;
 
+  /**
+   * The ore list is retained internally, that means changes to the list affect the result
+   * @Deprecated use {@link #OreCastingRecipe(String, RecipeMatch, Fluid, int)}
+   */
+  @Deprecated
   public OreCastingRecipe(List<ItemStack> ore, RecipeMatch cast, Fluid fluid, int amount) {
     this(ore, cast, new FluidStack(fluid, amount), calcCooldownTime(fluid, amount), false, false);
   }
 
   public OreCastingRecipe(String ore, RecipeMatch cast, Fluid fluid, int amount) {
-    this(OreDictionary.getOres(ore), cast, new FluidStack(fluid, amount), calcCooldownTime(fluid, amount), false, false);
+    this(ore, cast, new FluidStack(fluid, amount), calcCooldownTime(fluid, amount), false, false);
   }
 
   public OreCastingRecipe(String ore, RecipeMatch cast, FluidStack fluid, int time, boolean consumesCast, boolean switchOutputs) {
-    this(OreDictionary.getOres(ore), cast, fluid, time, consumesCast, switchOutputs);
+    super(new ItemStack(Blocks.COBBLESTONE), cast, fluid, time, consumesCast, switchOutputs);
+    this.outputs = null;
+    this.oreName = ore;
   }
 
-  /** The ore list is retained internally, that means changes to the list affect the result */
+  /**
+   * The ore list is retained internally, that means changes to the list affect the result
+   * @Deprecated use {@link #OreCastingRecipe(String, RecipeMatch, FluidStack, int, boolean, boolean)}
+   */
+  @Deprecated
   public OreCastingRecipe(List<ItemStack> ore, RecipeMatch cast, FluidStack fluid, int time, boolean consumesCast, boolean switchOutputs) {
     super(new ItemStack(Blocks.COBBLESTONE), cast, fluid, time, consumesCast, switchOutputs);
     this.outputs = ore;
+    this.oreName = null;
   }
 
   @Override
   public boolean matches(ItemStack cast, Fluid fluid) {
     // always return false if there is no output
-    return !outputs.isEmpty() && super.matches(cast, fluid);
+    return !getResult().isEmpty() && super.matches(cast, fluid);
   }
 
   @Override
@@ -49,6 +63,10 @@ public class OreCastingRecipe extends CastingRecipe {
 
   @Override
   public ItemStack getResult() {
+    if(oreName != null) {
+      return RecipeUtil.getPreference(oreName);
+    }
+    // legacy logic kepy for backwards compatibility
     if(outputs.isEmpty()) {
       return ItemStack.EMPTY;
     }

--- a/src/main/java/slimeknights/tconstruct/library/smeltery/PreferenceCastingRecipe.java
+++ b/src/main/java/slimeknights/tconstruct/library/smeltery/PreferenceCastingRecipe.java
@@ -1,0 +1,42 @@
+package slimeknights.tconstruct.library.smeltery;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import slimeknights.mantle.util.RecipeMatch;
+import slimeknights.tconstruct.library.utils.RecipeUtil;
+
+/**
+ * A casting recipe that takes its output from an oredict entry using the preference system to determine the output
+ * Used for ingot casting etc.
+ */
+public class PreferenceCastingRecipe extends CastingRecipe {
+
+  protected final String oreName;
+
+  public PreferenceCastingRecipe(String ore, RecipeMatch cast, Fluid fluid, int amount) {
+    this(ore, cast, new FluidStack(fluid, amount), calcCooldownTime(fluid, amount), false, false);
+  }
+
+  public PreferenceCastingRecipe(String ore, RecipeMatch cast, FluidStack fluid, int time, boolean consumesCast, boolean switchOutputs) {
+    super(new ItemStack(Blocks.COBBLESTONE), cast, fluid, time, consumesCast, switchOutputs);
+    this.oreName = ore;
+  }
+
+  @Override
+  public boolean matches(ItemStack cast, Fluid fluid) {
+    // always return false if there is no output
+    return !getResult().isEmpty() && super.matches(cast, fluid);
+  }
+
+  @Override
+  public ItemStack getResult(ItemStack cast, Fluid fluid) {
+    return getResult().copy();
+  }
+
+  @Override
+  public ItemStack getResult() {
+    return RecipeUtil.getPreference(oreName);
+  }
+}

--- a/src/main/java/slimeknights/tconstruct/library/utils/RecipeUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/utils/RecipeUtil.java
@@ -31,14 +31,7 @@ public final class RecipeUtil {
    * @return  The preferred ItemStack, or ItemStack.EMPTY if the name is empty
    */
   public static ItemStack getPreference(String oreName) {
-    ItemStack stack = preferenceCache.computeIfAbsent(oreName, RecipeUtil::cachePreference);
-
-    // if nothing matches, return empty
-    // we would just return empty, but that would cache that value
-    if(stack == null) {
-      return ItemStack.EMPTY;
-    }
-    return stack.copy();
+    return preferenceCache.computeIfAbsent(oreName, RecipeUtil::cachePreference).copy();
   }
 
   /**
@@ -50,7 +43,7 @@ public final class RecipeUtil {
     List<ItemStack> items = OreDictionary.getOres(oreName, false);
 
     if(items.isEmpty()) {
-      return null;
+      return ItemStack.EMPTY;
     }
 
     // search through each preference name, finding the first item for the name

--- a/src/main/java/slimeknights/tconstruct/library/utils/RecipeUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/utils/RecipeUtil.java
@@ -4,13 +4,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.oredict.OreDictionary;
 import slimeknights.mantle.client.CreativeTab;
 
-public class RecipeUtil {
+public final class RecipeUtil {
   // list of orePreferences, to be filled by the config
   private static String[] orePreferences = new String[0];
   // cache to avoid grabing the same name twice

--- a/src/main/java/slimeknights/tconstruct/library/utils/RecipeUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/utils/RecipeUtil.java
@@ -1,0 +1,86 @@
+package slimeknights.tconstruct.library.utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.oredict.OreDictionary;
+import slimeknights.mantle.client.CreativeTab;
+
+public class RecipeUtil {
+  // list of orePreferences, to be filled by the config
+  private static String[] orePreferences = new String[0];
+  // cache to avoid grabing the same name twice
+  private static Map<String,ItemStack> preferenceCache = new HashMap<>();
+
+  private RecipeUtil() {}
+
+  /**
+   * Called by the config to add the preferences. Do not call outside of Tinkers Construct
+   * @param preferences
+   */
+  public static void setOrePreferences(String[] preferences) {
+    orePreferences = preferences;
+  }
+
+  /**
+   * Gets the preferred ore for the given oredict name
+   * @param oreName  Oredictionary key
+   * @return  The preferred ItemStack, or ItemStack.EMPTY if the name is empty
+   */
+  public static ItemStack getPreference(String oreName) {
+    // if we found one before, use that
+    if(preferenceCache.containsKey(oreName)) {
+      return preferenceCache.get(oreName).copy();
+    }
+
+    List<ItemStack> items = OreDictionary.getOres(oreName, false);
+
+    // if nothing matches the name, just return nothing
+    if(items.isEmpty()) {
+      return ItemStack.EMPTY;
+    }
+
+    cachePreference(oreName, items);
+    return preferenceCache.get(oreName).copy();
+  }
+
+  /**
+   * Function called to actually do the caching
+   * @param oreName  String to check
+   * @param items    Items to search
+   */
+  private static void cachePreference(String oreName, List<ItemStack> items) {
+    // search through each preference name, finding the first item for the name
+    ItemStack preference = null;
+    for(String mod : orePreferences) {
+      Optional<ItemStack> optional = items
+          .stream()
+          .filter(stack -> !stack.isEmpty() && stack.getItem().getRegistryName().getResourceDomain().equals(mod))
+          .findFirst();
+
+      // if we found something, use that stack and stop searching
+      if(optional.isPresent()) {
+        preference = optional.get();
+        break;
+      }
+    }
+    // if we found no preference, just use the first available stack
+    if(preference == null) {
+      preference = items.get(0);
+    }
+
+    // ensure we do not return a wildcard value
+    if(preference.getMetadata() == OreDictionary.WILDCARD_VALUE) {
+      NonNullList<ItemStack> subItems = NonNullList.create();
+      preference.getItem().getSubItems(CreativeTab.SEARCH, subItems);
+      preference = subItems.get(0);
+    }
+
+    // finally cache the preference
+    preferenceCache.put(oreName, preference);
+  }
+}

--- a/src/main/java/slimeknights/tconstruct/library/utils/RecipeUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/utils/RecipeUtil.java
@@ -58,7 +58,7 @@ public final class RecipeUtil {
     for(String mod : orePreferences) {
       Optional<ItemStack> optional = items
           .stream()
-          .filter(stack -> !stack.isEmpty() && stack.getItem().getRegistryName().getResourceDomain().equals(mod))
+          .filter(stack -> stack.getItem().getRegistryName().getResourceDomain().equals(mod))
           .findFirst();
 
       // if we found something, use that stack and stop searching

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/casting/CastingRecipeWrapper.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/casting/CastingRecipeWrapper.java
@@ -46,13 +46,7 @@ public class CastingRecipeWrapper implements IRecipeWrapper {
     }
     this.inputFluid = ImmutableList.of(recipe.getFluid());
     this.recipe = recipe;
-    // special treatment of oredict output recipies
-    if(recipe.getResult().isEmpty()) {
-      output = null;
-    }
-    else {
-      output = ImmutableList.of(recipe.getResult());
-    }
+    this.output = ImmutableList.of(recipe.getResult());
 
     this.castingBlock = castingBlock;
   }
@@ -99,7 +93,7 @@ public class CastingRecipeWrapper implements IRecipeWrapper {
         && (!checkCast || !this.hasCast()
             || (!this.cast.isEmpty()
                 && !this.cast.get(0).isEmpty()))
-        && (output == null || !this.output.isEmpty()
-            && !this.output.get(0).isEmpty());
+        && !this.output.isEmpty()
+        && !this.output.get(0).isEmpty();
   }
 }

--- a/src/main/java/slimeknights/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/TinkerSmeltery.java
@@ -140,7 +140,7 @@ public class TinkerSmeltery extends TinkerPulse {
   public static ItemStack castPlate;
   public static ItemStack castGear;
 
-  private static Map<Fluid, Set<Pair<List<ItemStack>, Integer>>> knownOreFluids = Maps.newHashMap();
+  private static Map<Fluid, Set<Pair<String, Integer>>> knownOreFluids = Maps.newHashMap();
   public static List<FluidStack> castCreationFluids = Lists.newLinkedList();
   public static List<FluidStack> clayCreationFluids = Lists.newLinkedList();
 
@@ -641,24 +641,24 @@ public class TinkerSmeltery extends TinkerPulse {
    */
   @SuppressWarnings("unchecked")
   public static void registerOredictMeltingCasting(Fluid fluid, String ore) {
-    ImmutableSet.Builder<Pair<List<ItemStack>, Integer>> builder = ImmutableSet.builder();
-    Pair<List<ItemStack>, Integer> nuggetOre = Pair.of(OreDictionary.getOres("nugget" + ore), Material.VALUE_Nugget);
-    Pair<List<ItemStack>, Integer> ingotOre = Pair.of(OreDictionary.getOres("ingot" + ore), Material.VALUE_Ingot);
-    Pair<List<ItemStack>, Integer> blockOre = Pair.of(OreDictionary.getOres("block" + ore), Material.VALUE_Block);
-    Pair<List<ItemStack>, Integer> oreOre = Pair.of(OreDictionary.getOres("ore" + ore), Material.VALUE_Ore());
-    Pair<List<ItemStack>, Integer> oreNetherOre = Pair.of(OreDictionary.getOres("oreNether" + ore), (int) (2 * Material.VALUE_Ingot * Config.oreToIngotRatio));
-    Pair<List<ItemStack>, Integer> oreDenseOre = Pair.of(OreDictionary.getOres("denseore" + ore), (int) (3 * Material.VALUE_Ingot * Config.oreToIngotRatio));
-    Pair<List<ItemStack>, Integer> orePoorOre = Pair.of(OreDictionary.getOres("orePoor" + ore), (int) (Material.VALUE_Nugget * 3 * Config.oreToIngotRatio));
-    Pair<List<ItemStack>, Integer> oreNuggetOre = Pair.of(OreDictionary.getOres("oreNugget" + ore), (int) (Material.VALUE_Nugget * Config.oreToIngotRatio));
-    Pair<List<ItemStack>, Integer> plateOre = Pair.of(OreDictionary.getOres("plate" + ore), Material.VALUE_Ingot);
-    Pair<List<ItemStack>, Integer> gearOre = Pair.of(OreDictionary.getOres("gear" + ore), Material.VALUE_Ingot * 4);
-    Pair<List<ItemStack>, Integer> dustOre = Pair.of(OreDictionary.getOres("dust" + ore), Material.VALUE_Ingot);
+    ImmutableSet.Builder<Pair<String, Integer>> builder = ImmutableSet.builder();
+    Pair<String, Integer> nuggetOre = Pair.of("nugget" + ore, Material.VALUE_Nugget);
+    Pair<String, Integer> ingotOre = Pair.of("ingot" + ore, Material.VALUE_Ingot);
+    Pair<String, Integer> blockOre = Pair.of("block" + ore, Material.VALUE_Block);
+    Pair<String, Integer> oreOre = Pair.of("ore" + ore, Material.VALUE_Ore());
+    Pair<String, Integer> oreNetherOre = Pair.of("oreNether" + ore, (int) (2 * Material.VALUE_Ingot * Config.oreToIngotRatio));
+    Pair<String, Integer> oreDenseOre = Pair.of("denseore" + ore, (int) (3 * Material.VALUE_Ingot * Config.oreToIngotRatio));
+    Pair<String, Integer> orePoorOre = Pair.of("orePoor" + ore, (int) (Material.VALUE_Nugget * 3 * Config.oreToIngotRatio));
+    Pair<String, Integer> oreNuggetOre = Pair.of("oreNugget" + ore, (int) (Material.VALUE_Nugget * Config.oreToIngotRatio));
+    Pair<String, Integer> plateOre = Pair.of("plate" + ore, Material.VALUE_Ingot);
+    Pair<String, Integer> gearOre = Pair.of("gear" + ore, Material.VALUE_Ingot * 4);
+    Pair<String, Integer> dustOre = Pair.of("dust" + ore, Material.VALUE_Ingot);
 
     builder.add(nuggetOre, ingotOre, blockOre, oreOre, oreNetherOre, oreDenseOre, orePoorOre, oreNuggetOre, plateOre, gearOre, dustOre);
-    Set<Pair<List<ItemStack>, Integer>> knownOres = builder.build();
+    Set<Pair<String, Integer>> knownOres = builder.build();
 
     // register oredicts
-    for(Pair<List<ItemStack>, Integer> pair : knownOres) {
+    for(Pair<String, Integer> pair : knownOres) {
       TinkerRegistry.registerMelting(new MeltingRecipe(RecipeMatch.of(pair.getLeft(), pair.getRight()), fluid));
     }
 
@@ -738,11 +738,11 @@ public class TinkerSmeltery extends TinkerPulse {
           continue;
         }
         boolean found = false;
-        for(Map.Entry<Fluid, Set<Pair<List<ItemStack>, Integer>>> entry : knownOreFluids.entrySet()) {
+        for(Map.Entry<Fluid, Set<Pair<String, Integer>>> entry : knownOreFluids.entrySet()) {
           // check if it's a known oredict (all oredict lists are equal if they match the same oredict)
           // OR if it's an itemstack contained in one of our oredicts
-          for(Pair<List<ItemStack>, Integer> pair : entry.getValue()) {
-            for(ItemStack itemStack : pair.getLeft()) {
+          for(Pair<String, Integer> pair : entry.getValue()) {
+            for(ItemStack itemStack : OreDictionary.getOres(pair.getLeft(), false)) {
               if(ingredient.apply(itemStack)) {
                 // matches! Update fluid amount known
                 Integer amount = known.get(entry.getKey()); // what we found for the liquid so far

--- a/src/main/java/slimeknights/tconstruct/smeltery/TinkerSmeltery.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/TinkerSmeltery.java
@@ -54,7 +54,7 @@ import slimeknights.tconstruct.library.smeltery.BucketCastingRecipe;
 import slimeknights.tconstruct.library.smeltery.Cast;
 import slimeknights.tconstruct.library.smeltery.CastingRecipe;
 import slimeknights.tconstruct.library.smeltery.MeltingRecipe;
-import slimeknights.tconstruct.library.smeltery.OreCastingRecipe;
+import slimeknights.tconstruct.library.smeltery.PreferenceCastingRecipe;
 import slimeknights.tconstruct.library.tinkering.MaterialItem;
 import slimeknights.tconstruct.library.tools.IToolPart;
 import slimeknights.tconstruct.shared.TinkerCommons;
@@ -664,30 +664,30 @@ public class TinkerSmeltery extends TinkerPulse {
 
     // register oredict castings!
     // ingot casting
-    TinkerRegistry.registerTableCasting(new OreCastingRecipe(ingotOre.getLeft(),
-                                                             RecipeMatch.ofNBT(castIngot),
-                                                             fluid,
-                                                             ingotOre.getRight()));
+    TinkerRegistry.registerTableCasting(new PreferenceCastingRecipe(ingotOre.getLeft(),
+                                                                    RecipeMatch.ofNBT(castIngot),
+                                                                    fluid,
+                                                                    ingotOre.getRight()));
     // nugget casting
-    TinkerRegistry.registerTableCasting(new OreCastingRecipe(nuggetOre.getLeft(),
-                                                             RecipeMatch.ofNBT(castNugget),
-                                                             fluid,
-                                                             nuggetOre.getRight()));
+    TinkerRegistry.registerTableCasting(new PreferenceCastingRecipe(nuggetOre.getLeft(),
+                                                                    RecipeMatch.ofNBT(castNugget),
+                                                                    fluid,
+                                                                    nuggetOre.getRight()));
     // block casting
-    TinkerRegistry.registerBasinCasting(new OreCastingRecipe(blockOre.getLeft(),
-                                                             null, // no cast
-                                                             fluid,
-                                                             blockOre.getRight()));
+    TinkerRegistry.registerBasinCasting(new PreferenceCastingRecipe(blockOre.getLeft(),
+                                                                    null, // no cast
+                                                                    fluid,
+                                                                    blockOre.getRight()));
     // plate casting
-    TinkerRegistry.registerTableCasting(new OreCastingRecipe(plateOre.getLeft(),
-                                                             RecipeMatch.ofNBT(castPlate),
-                                                             fluid,
-                                                             plateOre.getRight()));
+    TinkerRegistry.registerTableCasting(new PreferenceCastingRecipe(plateOre.getLeft(),
+                                                                    RecipeMatch.ofNBT(castPlate),
+                                                                    fluid,
+                                                                    plateOre.getRight()));
     // gear casting
-    TinkerRegistry.registerTableCasting(new OreCastingRecipe(gearOre.getLeft(),
-                                                             RecipeMatch.ofNBT(castGear),
-                                                             fluid,
-                                                             gearOre.getRight()));
+    TinkerRegistry.registerTableCasting(new PreferenceCastingRecipe(gearOre.getLeft(),
+                                                                    RecipeMatch.ofNBT(castGear),
+                                                                    fluid,
+                                                                    gearOre.getRight()));
 
     // and also cast creation!
     for(FluidStack fs : castCreationFluids) {


### PR DESCRIPTION
As originally discussed in #2884, this adds the feature to choose a preference for oredict outputs. For example, adding Immersive Engineering to the top of the list will cause IE copper and steel to be used for outputs over Thermal Expansion or Chisel blocks.