### PR TITLE
Make ToolHelper#breakTool check for unbreakable tools.

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/utils/ToolHelper.java
+++ b/src/main/java/slimeknights/tconstruct/library/utils/ToolHelper.java
@@ -522,6 +522,7 @@ public final class ToolHelper {
 
   public static void breakTool(ItemStack stack, EntityLivingBase entity) {
     NBTTagCompound tag = TagUtil.getToolTag(stack);
+    if (tag.getBoolean(ModReinforced.TAG_UNBREAKABLE)) return;
     tag.setBoolean(Tags.BROKEN, true);
     TagUtil.setToolTag(stack, tag);
 


### PR DESCRIPTION
Fixes #3242 #3241 #3206 #3173
I checked the ExU code, which uses the ToolHelper method for breaking tools, so this prevents it (but ExU doesn't accept PR's, and their public issue tracker seems to be left unattended).

Not sure which branch I'm supposed to target, this should work on most branches.
Can adapt the PR if needed.