### PR TITLE
Fixed crashing when breaking smeltery (Issue #3293 )

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSmeltery.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSmeltery.java
@@ -267,6 +267,7 @@ public class TileSmeltery extends TileHeatingStructureFuelTank<MultiblockSmelter
           FluidStack toDrain = liquid.copy();
           FluidStack drained = liquids.drain(toDrain, true);
           // error logging
+          assert drained != null;
           if(!drained.isFluidEqual(toDrain) || drained.amount != toDrain.amount) {
             log.error("Smeltery alloy creation drained incorrect amount: was %s:%d, should be %s:%d", drained
                 .getUnlocalizedName(), drained.amount, toDrain.getUnlocalizedName(), toDrain.amount);


### PR DESCRIPTION
This fix is already in the MC 1.11.2 version so this is a backport of that fix to MC 1.10.2
https://github.com/MJRLegends/TinkersConstruct/blob/1.11.2/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileSmeltery.java#L270

Fixes issue #3293