### PR TITLE
Correct and add cross-player velocity interactions

### DIFF
--- a/src/main/java/slimeknights/tconstruct/common/config/Config.java
+++ b/src/main/java/slimeknights/tconstruct/common/config/Config.java
@@ -37,6 +37,7 @@ public final class Config {
   public static boolean reuseStencil = true;
   public static boolean craftCastableMaterials = false;
   public static boolean chestsKeepInventory = true;
+  public static boolean slingOther = false;
   public static boolean autosmeltlapis = true;
   public static boolean obsidianAlloy = true;
   public static boolean claycasts = true;
@@ -143,6 +144,11 @@ public final class Config {
       prop = configFile.get(cat, "chestsKeepInventory", chestsKeepInventory);
       prop.setComment("Pattern and Part chests keep their inventory when harvested.");
       chestsKeepInventory = prop.getBoolean();
+      propOrder.add(prop.getName());
+
+      prop = configFile.get(cat, "slimeslingOther", slingOther);
+      prop.setComment("Slime sling pushes away other entities.");
+      slingOther = prop.getBoolean();
       propOrder.add(prop.getName());
 
       prop = configFile.get(cat, "enableClayCasts", claycasts);

--- a/src/main/java/slimeknights/tconstruct/gadgets/item/ItemSlimeSling.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/item/ItemSlimeSling.java
@@ -103,7 +103,7 @@ public class ItemSlimeSling extends ItemTooltip {
                   vec.z * f / sizeFactor);
           TinkerTools.proxy.spawnAttackParticle(Particles.FRYPAN_ATTACK, player, 0.6d);
           if(mop.entityHit instanceof EntityPlayerMP) {
-            TinkerNetwork.sendPacket(player, new SPacketEntityVelocity(mop.entityHit));
+            TinkerNetwork.sendPacket(mop.entityHit, new SPacketEntityVelocity(mop.entityHit));
           }
         }
 

--- a/src/main/java/slimeknights/tconstruct/library/utils/ToolHelper.java
+++ b/src/main/java/slimeknights/tconstruct/library/utils/ToolHelper.java
@@ -751,7 +751,7 @@ public final class ToolHelper {
       // Send movement changes caused by attacking directly to hit players.
       // I guess this is to allow better handling at the hit players side? No idea why it resets the motion though.
       if(targetEntity instanceof EntityPlayerMP && targetEntity.velocityChanged) {
-        TinkerNetwork.sendPacket(player, new SPacketEntityVelocity(targetEntity));
+        TinkerNetwork.sendPacket(targetEntity, new SPacketEntityVelocity(targetEntity));
         targetEntity.velocityChanged = false;
         targetEntity.motionX = oldVelX;
         targetEntity.motionY = oldVelY;

--- a/src/main/java/slimeknights/tconstruct/tools/melee/item/FryPan.java
+++ b/src/main/java/slimeknights/tconstruct/tools/melee/item/FryPan.java
@@ -115,7 +115,7 @@ public class FryPan extends TinkerToolCore {
       entity.addVelocity(x, y, z);
       TinkerTools.proxy.spawnAttackParticle(Particles.FRYPAN_ATTACK, player, 0.6d);
       if(entity instanceof EntityPlayerMP) {
-        TinkerNetwork.sendPacket(player, new SPacketEntityVelocity(entity));
+        TinkerNetwork.sendPacket(entity, new SPacketEntityVelocity(entity));
       }
     }
   }


### PR DESCRIPTION
This pull request corrects a couple SPacketEntityVelocity packet sends to make the frying pan and presumably other weapons apply velocity updates to other players properly.

It also adds optional interaction of the slimesling with other entities, including other players, mostly using code borrowed from the frying pan.  (that was how I found the bug).  The feature is off by default and configurable.