### PR TITLE
Store the UUID and other data in player heads

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tools/modifiers/ModBeheading.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modifiers/ModBeheading.java
@@ -11,6 +11,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.EnumHand;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
@@ -111,9 +112,7 @@ public class ModBeheading extends ToolModifier {
     // meta 3: player
     else if(entity instanceof EntityPlayer) {
       ItemStack head = new ItemStack(Items.SKULL, 1, 3);
-      NBTTagCompound nametag = new NBTTagCompound();
-      nametag.setString("SkullOwner", entity.getDisplayName().getFormattedText());
-      head.setTagCompound(nametag);
+      NBTUtil.writeGameProfile(head.getOrCreateSubCompound("SkullOwner"), ((EntityPlayer)entity).getGameProfile());
       return head;
     }
 


### PR DESCRIPTION
This makes heads not spontaneously become Steve heads in various circumstances.