### PR TITLE
Pull Request for #3441 - Add config option for kama

### DIFF
--- a/src/main/java/slimeknights/tconstruct/common/config/Config.java
+++ b/src/main/java/slimeknights/tconstruct/common/config/Config.java
@@ -43,6 +43,7 @@ public final class Config {
   public static boolean castableBricks = true;
   public static boolean leatherDryingRecipe = true;
   public static boolean gravelFlintRecipe = true;
+  public static boolean forgeKama = false;
   public static double oreToIngotRatio = 2;
   public static String[] craftingStationBlacklist = new String[] {
       "de.ellpeck.actuallyadditions.mod.tile.TileEntityItemViewer"
@@ -190,6 +191,12 @@ public final class Config {
       gravelFlintRecipe = prop.getBoolean();
       prop.setRequiresMcRestart(true);
       propOrder.add(prop.getName());
+	  
+	    prop = configFile.get(cat, "kamaInToolForge", forgeKama);
+  	  prop.setComment("Moves the kama to only the Tool Forge.");
+	    forgeKama = prop.getBoolean();
+	    prop.setRequiresMcRestart(true);
+	    propOrder.add(prop.getName());
 
       prop = configFile.get(cat, "oreToIngotRatio", oreToIngotRatio);
       prop.setComment("Determines the ratio of ore to ingot, or in other words how many ingots you get out of an ore. This ratio applies to all ores (including poor and dense). The ratio can be any decimal, including 1.5 and the like, but can't go below 1. THIS ALSO AFFECTS MELTING TEMPERATURE!");

--- a/src/main/java/slimeknights/tconstruct/tools/harvest/TinkerHarvestTools.java
+++ b/src/main/java/slimeknights/tconstruct/tools/harvest/TinkerHarvestTools.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 
 import slimeknights.mantle.pulsar.pulse.Pulse;
 import slimeknights.tconstruct.common.CommonProxy;
+import slimeknights.tconstruct.common.config.Config;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.Util;
 import slimeknights.tconstruct.library.tools.ToolCore;
@@ -100,8 +101,12 @@ public class TinkerHarvestTools extends AbstractToolPulse {
     TinkerRegistry.registerToolCrafting(shovel);
     TinkerRegistry.registerToolCrafting(hatchet);
     TinkerRegistry.registerToolCrafting(mattock);
-    TinkerRegistry.registerToolCrafting(kama);
-
+    if(Config.forgeKama) {
+      TinkerRegistry.registerToolForgeCrafting(kama);
+    } else {
+      TinkerRegistry.registerToolCrafting(kama);
+    }
+        
     TinkerRegistry.registerToolForgeCrafting(hammer);
     TinkerRegistry.registerToolForgeCrafting(excavator);
     TinkerRegistry.registerToolForgeCrafting(lumberAxe);


### PR DESCRIPTION
Simply adds and makes functional a config option for moving the kama from tool station+tool forge to tool forge only, default set to false. This is to make skyblock/ex nihilo more difficult early. See #3441.