### PR TITLE
Fix Faucets draining from the wrong side of the source

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileFaucet.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/tileentity/TileFaucet.java
@@ -101,7 +101,7 @@ public class TileFaucet extends TileEntity implements ITickable {
     if(drained != null) {
       return;
     }
-    IFluidHandler toDrain = getFluidHandler(pos.offset(direction), direction);
+    IFluidHandler toDrain = getFluidHandler(pos.offset(direction), direction.getOpposite());
     IFluidHandler toFill = getFluidHandler(pos.down(), EnumFacing.UP);
     if(toDrain != null && toFill != null) {
       // can we drain?


### PR DESCRIPTION
Fixes issues including:

A faucet on the underside of an Immersive Engineering Wooden Barrel will not drain fluids unless the *top* side of the barrel has been hammered.

A faucet on the underside of an Astral Sorcery Lightwell will not drain fluids at all, since the Lightwell only allows fluid interaction from below, and the faucet is trying to do it from above.