### PR TITLE
Delegate isEmpty() to inventory Fix #3571

### DIFF
--- a/src/main/java/slimeknights/tconstruct/shared/inventory/InventoryCraftingPersistent.java
+++ b/src/main/java/slimeknights/tconstruct/shared/inventory/InventoryCraftingPersistent.java
@@ -35,6 +35,11 @@ public class InventoryCraftingPersistent extends InventoryCrafting {
     return this.length;
   }
 
+  @Override
+  public boolean isEmpty() {
+    return this.parent.isEmpty();
+  }
+  
   @Nonnull
   @Override
   public ItemStack getStackInSlot(int index) {


### PR DESCRIPTION
Fix the method call returning true not matter the content of the inventory.
Basic delegating call since there isn't need for performance enhancement.
Overall close the gap with the vanilla crafting table behavior from a recipe matching point of view.