### PR TITLE
Update PropertyTableItem.java

### DIFF
--- a/src/main/java/slimeknights/tconstruct/shared/block/PropertyTableItem.java
+++ b/src/main/java/slimeknights/tconstruct/shared/block/PropertyTableItem.java
@@ -94,7 +94,7 @@ public class PropertyTableItem implements IUnlistedProperty<PropertyTableItem.Ta
       if(Float.compare(tableItem.r, r) != 0) {
         return false;
       }
-      return stack != null ? stack.equals(tableItem.stack) : tableItem.stack == null;
+      return !stack.isEmpty() ? stack.equals(tableItem.stack) : tableItem.stack.isEmpty();
     }
 
     @Override


### PR DESCRIPTION
fixed incorrect usage of null checks, ItemStacks *cannot* (shouldn't) be null.