### PR TITLE
Fix #3702

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/multiblock/MultiblockCuboid.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/multiblock/MultiblockCuboid.java
@@ -38,6 +38,11 @@ public abstract class MultiblockCuboid extends MultiblockDetection {
     int masterY = center.getY();
     center = getOuterPos(world, center, EnumFacing.DOWN, 64).up();
 
+    // below lowest internal position
+    if (masterY < center.getY()) {
+      return null;
+    }
+
     // distances to the edges including the outer blocks
     int edges[] = new int[4];
     // order: south/west/north/east
@@ -69,11 +74,6 @@ public abstract class MultiblockCuboid extends MultiblockDetection {
       if(!detectLayer(world, center.up(height), height, edges, subBlocks)) {
         break;
       }
-    }
-
-    // below lowest internal position
-    if (masterY < center.getY()) {
-      return null;
     }
 
     // no walls?

--- a/src/main/java/slimeknights/tconstruct/smeltery/multiblock/MultiblockCuboid.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/multiblock/MultiblockCuboid.java
@@ -71,6 +71,11 @@ public abstract class MultiblockCuboid extends MultiblockDetection {
       }
     }
 
+    // below lowest internal position
+    if (masterY < center.getY()) {
+      return null;
+    }
+
     // no walls?
     if(height < 1 + masterY - center.getY()) {
       return null;


### PR DESCRIPTION
Prevents Multiblock structures from becoming active if a BlockMultiblockController Y position is equal to or lower than the floor layer