### PR TITLE
Fixed issue #3730

### DIFF
--- a/src/main/java/slimeknights/tconstruct/gadgets/block/BlockWoodRailDropper.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/block/BlockWoodRailDropper.java
@@ -29,6 +29,8 @@ public class BlockWoodRailDropper extends BlockWoodRail {
     assert itemHandlerCart != null;
     for(int i = 0; i < itemHandlerCart.getSlots(); i++) {
       ItemStack itemStack = itemHandlerCart.extractItem(i, 1, true);
+      if(itemStack.isEmpty()) // If current slot is empty, move on to the next slot.
+      	continue;
       if(ItemHandlerHelper.insertItem(itemHandlerTE, itemStack, true).isEmpty()) {
         itemStack = itemHandlerCart.extractItem(i, 1, false);
         ItemHandlerHelper.insertItem(itemHandlerTE, itemStack, false);

--- a/src/main/java/slimeknights/tconstruct/gadgets/block/BlockWoodRailDropper.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/block/BlockWoodRailDropper.java
@@ -29,8 +29,9 @@ public class BlockWoodRailDropper extends BlockWoodRail {
     assert itemHandlerCart != null;
     for(int i = 0; i < itemHandlerCart.getSlots(); i++) {
       ItemStack itemStack = itemHandlerCart.extractItem(i, 1, true);
-      if(itemStack.isEmpty()) // If current slot is empty, move on to the next slot.
+      if(itemStack.isEmpty()) {
       	continue;
+      }
       if(ItemHandlerHelper.insertItem(itemHandlerTE, itemStack, true).isEmpty()) {
         itemStack = itemHandlerCart.extractItem(i, 1, false);
         ItemHandlerHelper.insertItem(itemHandlerTE, itemStack, false);


### PR DESCRIPTION
Wood Rail Dropper was only allowing the first slot of Minecart With Hopper to be emptied.