### PR TITLE
Added config to set minimum display size for fluids in Smeltery GUI

### DIFF
--- a/src/main/java/slimeknights/tconstruct/common/config/Config.java
+++ b/src/main/java/slimeknights/tconstruct/common/config/Config.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.Logger;
 import slimeknights.mantle.pulsar.config.ForgeCFG;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.library.Util;
-import slimeknights.tconstruct.library.client.GuiUtil;
 import slimeknights.tconstruct.library.utils.RecipeUtil;
 
 import java.util.Collections;
@@ -337,7 +336,7 @@ public final class Config {
       prop.setMaxValue(8);
       minFluidHeight = prop.getInt();
       propOrder.add(prop.getName());
-      GuiUtil.setMinFluidHeight(minFluidHeight);
+      Util.setMinFluidHeight(minFluidHeight);
 
       prop = configFile.get(cat, "enableForgeBucketModel", enableForgeBucketModel);
       prop.setComment("If true tools will enable the forge bucket model on startup and then turn itself off. This is only there so that a fresh install gets the buckets turned on by default.");

--- a/src/main/java/slimeknights/tconstruct/common/config/Config.java
+++ b/src/main/java/slimeknights/tconstruct/common/config/Config.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import slimeknights.mantle.pulsar.config.ForgeCFG;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.library.Util;
+import slimeknights.tconstruct.library.client.GuiUtil;
 import slimeknights.tconstruct.library.utils.RecipeUtil;
 
 import java.util.Collections;
@@ -88,6 +89,7 @@ public final class Config {
   public static boolean dumpTextureMap = false; // requires debug module
   public static boolean testIMC = false; // requires debug module
   public static boolean temperatureCelsius = true;
+  public static int minFluidHeight = 3;
 
   /* Config File */
 
@@ -328,6 +330,14 @@ public final class Config {
       temperatureCelsius = prop.getBoolean();
       propOrder.add(prop.getName());
       Util.setTemperaturePref(temperatureCelsius);
+
+      prop = configFile.get(cat, "minFluidHeight", minFluidHeight);
+      prop.setComment("Minimum fluid height to display in smeltery. Make those tiny amounts easier to click on. Can make the Smeltery appear more full than it really is.");
+      prop.setMinValue(1);
+      prop.setMaxValue(8);
+      minFluidHeight = prop.getInt();
+      propOrder.add(prop.getName());
+      GuiUtil.setMinFluidHeight(minFluidHeight);
 
       prop = configFile.get(cat, "enableForgeBucketModel", enableForgeBucketModel);
       prop.setComment("If true tools will enable the forge bucket model on startup and then turn itself off. This is only there so that a fresh install gets the buckets turned on by default.");

--- a/src/main/java/slimeknights/tconstruct/library/Util.java
+++ b/src/main/java/slimeknights/tconstruct/library/Util.java
@@ -222,4 +222,18 @@ public class Util {
     }
     return translateFormatted("gui.general.temperature.kelvin", temperature);
   }
+
+  private static int minFluidHeight = 3;
+
+  /**
+   * Sets the preference from the config. For internal use only
+   * @param minHeight  integer minimum display height for fluids
+   */
+  public static void setMinFluidHeight(int minHeight) {
+    minFluidHeight = minHeight;
+  }
+
+  public static int getMinFluidHeight() {
+    return minFluidHeight;
+  }
 }

--- a/src/main/java/slimeknights/tconstruct/library/client/GuiUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/client/GuiUtil.java
@@ -34,6 +34,8 @@ import slimeknights.tconstruct.smeltery.TinkerSmeltery;
 import slimeknights.tconstruct.smeltery.client.SmelteryRenderer;
 import slimeknights.tconstruct.smeltery.network.SmelteryFluidClicked;
 
+import static slimeknights.tconstruct.library.Util.getMinFluidHeight;
+
 public class GuiUtil {
 
   private GuiUtil() {
@@ -154,18 +156,8 @@ public class GuiUtil {
     return null;
   }
 
-  private static int minFluidHeight = 3;
-
-  /**
-   * Sets the preference from the config. For internal use only
-   * @param minHeight  integer minimum display height for fluids
-   */
-  public static void setMinFluidHeight(int minHeight) {
-    minFluidHeight = minHeight;
-  }
-
   private static int[] calcLiquidHeights(List<FluidStack> liquids, int capacity, int height) {
-    return SmelteryRenderer.calcLiquidHeights(liquids, capacity, height, minFluidHeight);
+    return SmelteryRenderer.calcLiquidHeights(liquids, capacity, height, getMinFluidHeight());
   }
 
   public static void drawGuiTank(SmelteryTank liquids, int x, int y, int w, int height, float zLevel) {

--- a/src/main/java/slimeknights/tconstruct/library/client/GuiUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/client/GuiUtil.java
@@ -154,8 +154,18 @@ public class GuiUtil {
     return null;
   }
 
+  private static int minFluidHeight = 3;
+
+  /**
+   * Sets the preference from the config. For internal use only
+   * @param minHeight  integer minimum display height for fluids
+   */
+  public static void setMinFluidHeight(int minHeight) {
+    minFluidHeight = minHeight;
+  }
+
   private static int[] calcLiquidHeights(List<FluidStack> liquids, int capacity, int height) {
-    return SmelteryRenderer.calcLiquidHeights(liquids, capacity, height, 3);
+    return SmelteryRenderer.calcLiquidHeights(liquids, capacity, height, minFluidHeight);
   }
 
   public static void drawGuiTank(SmelteryTank liquids, int x, int y, int w, int height, float zLevel) {


### PR DESCRIPTION
**The problem:**

Some users have trouble clicking on fluids in the Smeltery GUI when they are displayed at their minimum height (such as when they're just a few mB).


**Solution:**

A configuration option which allows changing of the current hard-coded value of `3` for the minimum fluid size.


**Use cases:**

- Users with limited dexterity, but no problems visually. They don't specifically need to adjust Minecraft's GUI Scale to see and interact with most things, but the small fluids are hard to accurately stop the mouse on. I have a friend who falls into this category. She has a lot of trouble mousing over and clicking on those tiny fluids and often ends up just draining the Smeltery into individual tanks and starting over
- Users with mild visual degradation, not enough to desire all Minecraft GUIs be scaled up, but would like a little more surface area for visually identifying fluids in the Smeltery GUI
- The power user who simply feels the need to tweak everything. Because they can. :grin: Ok, maybe not. But every list needs a third point, right?


**Potential issues:**

This will cause fluids to occupy more space in the Smeltery GUI. It's smart enough to start scaling when it runs out of space, but increasing the displayed height of fluids will cause the Smeltery to appear to have more in it than it really does. This alreay occurs to some degree with the current minimum height, but increasing the minimum height amplifies that effect. It's especially noticable with multiple fluids (if you smelt a number of nuggets for instance).

The visual scaling to fit can also give a false sense of ratio. If one of the fluids is of an amount much larger than any of the others, it will be picked to be scaled down before the smaller amounts are touched. This leads to an appearance that is is smaller than it is, and may even appear to be the same size as the other fluids depending on the contents of the Smeltery. Note that I did not touch any of the scaling code, this was already in place.

I still feel like the benefits outweigh the side effects, especially if the user is aware of them. My friend experienced much frustration with her Smeltery (which she otherwise just loves) until I made this change for her. She was thrilled that she could now adjust the display of the fluid height.

**Mitigation:**

The default value for the new config option is the same as the previously hardcoded value. Unless the user explicityly changes it, there will be no change in functionality. Applying this PR will not change the user experience when they upgrade to the latest version. No surprises.

For those users that do wish to change it, I added a warning in the comment for the config option: `Can make the Smeltery appear more full than it really is.`

And there is of course still the actual values displayed in the GUI. It is possible to find out exactly how much of what is in your Smeltery and how much capactity remains. Granted some users struggle with those values and the conversions they often entail.


**Testing:**

I did my best to test this thoroughly. Here is what all I did.

Setup:

- Code is based on commit 3070bf3 from branch 1.12, latest at the time I wrote this
- 1x1x1 (interior) Smeltery (1152mB)
- 6 different non-alloying nuggets (96mB total)
  - This is the most I could get with just Tinkers without resorting to editing NBT to get minimal values of water and lava as well


- GUI Scale = `Small`, minFluidHeight = `1`
  - This is the smallest scenario I could come up with
  - Able to mouse over and click on any fluid. While not practical (IMO), it is functional

- GUI Scale = `Normal`, minFluidHeight = `6`
  - I believe this is what my friend is using
  - While it appears to eat a lot of your available space in a small Smeltery, those with accuracy problems will appreciate the larger area to identify and interact with fluids

- minFluidHeight = `9`
  - The largest value that does not force the smeltery GUI to scale the six fluids to fit

- minFluidHeight = `16`
  - Attempting to force resizing of fluids to fit GUI
  - Interestingly enough, the fluids seem to be sized close to `minFluidHeight = 6`, while other smaller values (`9` for instance) do in fact produce larger display. If I remember correctly the scaling intentionally leaves a bit of headroom to signal a non-full Smeltery

- Moved fluids into Tinker Tank
  - Verified that the Tinker Tank GUI is affected in the same way as the Smeltery. It has a larger tank size for a 1x1x1 interior (108B) so it has more space in the GUI, but it also means that the side effects are amplified

Also note that this only affects the GUI representation of fluids, not the in-world representation in the Smeltery.


**Test Conclusions:**

Based on those test results, I think that restricting `minFluidHeight` to a range starting at `1` and ending around `6-8` seems the most reasonable. I'll leave the maximum at `8` and you can change it as you wish.