### PR TITLE
Registry rework

### DIFF
--- a/src/main/java/slimeknights/tconstruct/common/registry/BaseRegistryAdapter.java
+++ b/src/main/java/slimeknights/tconstruct/common/registry/BaseRegistryAdapter.java
@@ -1,0 +1,63 @@
+package slimeknights.tconstruct.common.registry;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+// MANTLE
+// TODO: move to mantle
+/**
+ * A convenience wrapper for forge registries, to be used in combination with the {@link net.minecraftforge.event.RegistryEvent.Register} event.
+ * Simply put it allows you to register things by passing (thing, name) instead of having to set the name inline.
+ * There also is a convenience variant for items and itemblocks, see {@link ItemRegistryAdapter}.
+ */
+public class BaseRegistryAdapter<T extends IForgeRegistryEntry<T>> {
+
+  protected final IForgeRegistry<T> registry;
+  private final String modId;
+
+  /**
+   * Automatically creates determines the modid from the currently loading mod.
+   * If this results in the wrong namespace, use the other constructor where you can provide the modid.
+   * The modid is used as the namespace for resource locations, so if your mods id is "foo" it will register an item "bar" as "foo:bar".
+   */
+  public BaseRegistryAdapter(IForgeRegistry<T> registry) {
+    this(registry, ModLoadingContext.get().getActiveContainer().getModId());
+  }
+
+  /**
+   * Backup Constructor that allows setting the modid used when registering manually.
+   * The modid is used as the namespace for resource locations.
+   */
+  public BaseRegistryAdapter(IForgeRegistry<T> registry, String modId) {
+    this.registry = registry;
+    this.modId = modId;
+  }
+
+  /**
+   * Construct a resource location that belongs to the given namespace. Usually your mod.
+   */
+  public ResourceLocation getResource(String name) {
+    return new ResourceLocation(modId, name);
+  }
+
+  /**
+   * General purpose registration method. Just pass the string you want your thing registered as.
+   */
+  public <I extends T> I register(I forgeRegitryEntry, String name) {
+    return this.register(forgeRegitryEntry, this.getResource(name));
+  }
+
+  /**
+   * General purpose backup registration method. In case you want to set a very specific resource location.
+   * You should probably use the special purpose methods instead of this.
+   *
+   * Note: changes the things registry name. Do not call this with already registered objects!
+   */
+  public <I extends T> I register(I forgeRegistryEntry, ResourceLocation location) {
+    forgeRegistryEntry.setRegistryName(location);
+    registry.register(forgeRegistryEntry);
+    return forgeRegistryEntry;
+  }
+}

--- a/src/main/java/slimeknights/tconstruct/common/registry/ItemRegistryAdapter.java
+++ b/src/main/java/slimeknights/tconstruct/common/registry/ItemRegistryAdapter.java
@@ -1,0 +1,52 @@
+package slimeknights.tconstruct.common.registry;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraftforge.registries.IForgeRegistry;
+
+import javax.annotation.Nullable;
+
+import slimeknights.mantle.item.BlockTooltipItem;
+
+// MANTLE
+// TODO: move to mantle
+/**
+ * Provides utility registration methods when registering itemblocks.
+ */
+public class ItemRegistryAdapter extends BaseRegistryAdapter<Item> {
+
+  public ItemRegistryAdapter(IForgeRegistry<Item> registry) {
+    super(registry);
+  }
+
+  /**
+   * Registers a generic item block for a block.
+   * If your block does not have its own item, just use this method to make it available as an item.
+   * The item uses the same name as the block for registration.
+   * The registered BlockItem has tooltip support by default, see {@link BlockTooltipItem}
+   * @param block The block you want to have an item for
+   * @param itemGroup The creative tab the item shall be available in.
+   *                  Can be null for no creative tab.
+   * @return The registered item for the block
+   */
+  public BlockItem registerBlockItem(Block block, @Nullable ItemGroup itemGroup) {
+    Item.Properties itemProperties = new Item.Properties();
+    if(itemGroup != null) {
+      itemProperties.group(itemGroup);
+    }
+    BlockItem itemBlock = new BlockTooltipItem(block, itemProperties);
+    return register(itemBlock, block.getRegistryName());
+  }
+
+  /**
+   * Shortcut method to register your own BlockItem, registering with the same name as the block it represents.
+   *
+   * @param blockItem Item block instance to register
+   * @return Registered item block, should be the same as teh one passed in.
+   */
+  public <T extends BlockItem> T registerBlockItem(T blockItem) {
+    return register(blockItem, blockItem.getBlock().getRegistryName());
+  }
+}

--- a/src/main/java/slimeknights/tconstruct/gadgets/TinkerGadgets.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/TinkerGadgets.java
@@ -25,6 +25,8 @@ import slimeknights.mantle.pulsar.pulse.Pulse;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.common.ServerProxy;
 import slimeknights.tconstruct.common.TinkerPulse;
+import slimeknights.tconstruct.common.registry.BaseRegistryAdapter;
+import slimeknights.tconstruct.common.registry.ItemRegistryAdapter;
 import slimeknights.tconstruct.gadgets.block.DriedClayBlock;
 import slimeknights.tconstruct.gadgets.block.DriedClaySlabBlock;
 import slimeknights.tconstruct.gadgets.block.PunjiBlock;
@@ -111,70 +113,70 @@ public class TinkerGadgets extends TinkerPulse {
 
   @SubscribeEvent
   public void registerBlocks(final RegistryEvent.Register<Block> event) {
-    IForgeRegistry<Block> registry = event.getRegistry();
+    BaseRegistryAdapter<Block> registry = new BaseRegistryAdapter<>(event.getRegistry());
 
-    register(registry, new StoneLadderBlock(), "stone_ladder");
+    registry.register(new StoneLadderBlock(), "stone_ladder");
 
-    register(registry, new StoneTorchBlock(), "stone_torch");
-    register(registry, new WallStoneTorchBlock(), "wall_stone_torch");
+    registry.register(new StoneTorchBlock(), "stone_torch");
+    registry.register(new WallStoneTorchBlock(), "wall_stone_torch");
 
-    register(registry, new PunjiBlock(), "punji");
+    registry.register(new PunjiBlock(), "punji");
 
-    register(registry, new WoodenRailBlock(), "wooden_rail");
-    register(registry, new WoodenDropperRailBlock(), "wooden_dropper_rail");
+    registry.register(new WoodenRailBlock(), "wooden_rail");
+    registry.register(new WoodenDropperRailBlock(), "wooden_dropper_rail");
 
-    dried_clay = register(registry, new DriedClayBlock(), "dried_clay");
-    dried_clay_bricks = register(registry, new DriedClayBlock(), "dried_clay_bricks");
+    dried_clay = registry.register(new DriedClayBlock(), "dried_clay");
+    dried_clay_bricks = registry.register(new DriedClayBlock(), "dried_clay_bricks");
 
-    register(registry, new DriedClaySlabBlock(), "dried_clay_slab");
-    register(registry, new DriedClaySlabBlock(), "dried_clay_bricks_slab");
+    registry.register(new DriedClaySlabBlock(), "dried_clay_slab");
+    registry.register(new DriedClaySlabBlock(), "dried_clay_bricks_slab");
 
-    register(registry, new StairsBaseBlock(dried_clay), "dried_clay_stairs");
-    register(registry, new StairsBaseBlock(dried_clay_bricks), "dried_clay_bricks_stairs");
+    registry.register(new StairsBaseBlock(dried_clay), "dried_clay_stairs");
+    registry.register(new StairsBaseBlock(dried_clay_bricks), "dried_clay_bricks_stairs");
   }
 
   @SubscribeEvent
   public void registerItems(final RegistryEvent.Register<Item> event) {
-    IForgeRegistry<Item> registry = event.getRegistry();
+    ItemRegistryAdapter registry = new ItemRegistryAdapter(event.getRegistry());
 
     CreativeTab tabGadgets = TinkerRegistry.tabGadgets;
-    registerBlockItem(registry, stone_ladder, tabGadgets);
+    registry.registerBlockItem(stone_ladder, tabGadgets);
 
-    registerBlockItem(registry, new WallOrFloorItem(stone_torch, wall_stone_torch, (new Item.Properties()).group(tabGadgets)));
+    registry.registerBlockItem(new WallOrFloorItem(stone_torch, wall_stone_torch, (new Item.Properties()).group(tabGadgets)));
 
-    registerBlockItem(registry, punji, tabGadgets);
+    registry.registerBlockItem(punji, tabGadgets);
 
-    registerBlockItem(registry, wooden_rail, tabGadgets);
-    registerBlockItem(registry, wooden_dropper_rail, tabGadgets);
+    registry.registerBlockItem(wooden_rail, tabGadgets);
+    registry.registerBlockItem(wooden_dropper_rail, tabGadgets);
 
-    registerBlockItem(registry, dried_clay, tabGadgets);
-    registerBlockItem(registry, dried_clay_bricks, tabGadgets);
+    registry.registerBlockItem(dried_clay, tabGadgets);
+    registry.registerBlockItem(dried_clay_bricks, tabGadgets);
 
-    registerBlockItem(registry, dried_clay_slab, tabGadgets);
-    registerBlockItem(registry, dried_clay_bricks_slab, tabGadgets);
+    registry.registerBlockItem(dried_clay_slab, tabGadgets);
+    registry.registerBlockItem(dried_clay_bricks_slab, tabGadgets);
 
-    registerBlockItem(registry, dried_clay_stairs, tabGadgets);
-    registerBlockItem(registry, dried_clay_bricks_stairs, tabGadgets);
+    registry.registerBlockItem(dried_clay_stairs, tabGadgets);
+    registry.registerBlockItem(dried_clay_bricks_stairs, tabGadgets);
 
-    register(registry, new Item((new Item.Properties()).group(tabGadgets)), "stone_stick");
+    registry.register(new Item((new Item.Properties()).group(tabGadgets)), "stone_stick");
 
     for (SlimeBlock.SlimeType type : SlimeBlock.SlimeType.VISIBLE_COLORS) {
-      register(registry, new SlimeSlingItem(), "slime_sling_" + type.getName());
-      register(registry, new SlimeBootsItem(type), "slime_boots_" + type.getName());
+      registry.register(new SlimeSlingItem(), "slime_sling_" + type.getName());
+      registry.register(new SlimeBootsItem(type), "slime_boots_" + type.getName());
     }
 
-    register(registry, new PiggyBackPackItem(), "piggy_backpack");
+    registry.register(new PiggyBackPackItem(), "piggy_backpack");
 
     for (FrameType frameType : FrameType.values()) {
-      register(registry, new FancyItemFrameItem((world, pos, dir) -> new FancyItemFrameEntity(world, pos, dir, frameType.getId())), frameType.getName() + "_item_frame");
+      registry.register(new FancyItemFrameItem((world, pos, dir) -> new FancyItemFrameEntity(world, pos, dir, frameType.getId())), frameType.getName() + "_item_frame");
     }
 
-    register(registry, new GlowBallItem(), "glow_ball");
-    register(registry, new EflnBallItem(), "efln_ball");
+    registry.register(new GlowBallItem(), "glow_ball");
+    registry.register(new EflnBallItem(), "efln_ball");
 
-    register(registry, new SpaghettiItem(), "hard_spaghetti");
-    register(registry, new SpaghettiItem(), "soggy_spaghetti");
-    register(registry, new SpaghettiItem(), "cold_spaghetti");
+    registry.register(new SpaghettiItem(), "hard_spaghetti");
+    registry.register(new SpaghettiItem(), "soggy_spaghetti");
+    registry.register(new SpaghettiItem(), "cold_spaghetti");
   }
 
   @SubscribeEvent

--- a/src/main/java/slimeknights/tconstruct/shared/TinkerCommons.java
+++ b/src/main/java/slimeknights/tconstruct/shared/TinkerCommons.java
@@ -12,10 +12,12 @@ import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
-import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.ObjectHolder;
+
 import org.apache.logging.log4j.Logger;
+
 import slimeknights.mantle.block.StairsBaseBlock;
+import slimeknights.mantle.client.CreativeTab;
 import slimeknights.mantle.item.EdibleItem;
 import slimeknights.mantle.item.GeneratedItem;
 import slimeknights.mantle.pulsar.pulse.Pulse;
@@ -25,10 +27,26 @@ import slimeknights.tconstruct.common.TinkerPulse;
 import slimeknights.tconstruct.common.conditions.ConfigOptionEnabledCondition;
 import slimeknights.tconstruct.common.config.Config;
 import slimeknights.tconstruct.common.item.TinkerBookItem;
+import slimeknights.tconstruct.common.registry.BaseRegistryAdapter;
+import slimeknights.tconstruct.common.registry.ItemRegistryAdapter;
 import slimeknights.tconstruct.library.TinkerPulseIds;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.Util;
-import slimeknights.tconstruct.shared.block.*;
+import slimeknights.tconstruct.shared.block.ClearGlassBlock;
+import slimeknights.tconstruct.shared.block.ClearStainedGlassBlock;
+import slimeknights.tconstruct.shared.block.CongealedSlimeBlock;
+import slimeknights.tconstruct.shared.block.ConsecratedSoilBlock;
+import slimeknights.tconstruct.shared.block.DecoGroundBlock;
+import slimeknights.tconstruct.shared.block.DecoGroundSlabBlock;
+import slimeknights.tconstruct.shared.block.FirewoodBlock;
+import slimeknights.tconstruct.shared.block.FirewoodSlabBlock;
+import slimeknights.tconstruct.shared.block.GlowBlock;
+import slimeknights.tconstruct.shared.block.GraveyardSoilBlock;
+import slimeknights.tconstruct.shared.block.GroutBlock;
+import slimeknights.tconstruct.shared.block.MetalBlock;
+import slimeknights.tconstruct.shared.block.OreBlock;
+import slimeknights.tconstruct.shared.block.SlimeBlock;
+import slimeknights.tconstruct.shared.block.SlimyMudBlock;
 import slimeknights.tconstruct.shared.item.AlubrassItem;
 
 /**
@@ -169,239 +187,241 @@ public class TinkerCommons extends TinkerPulse {
 
   @SubscribeEvent
   public void registerBlocks(final RegistryEvent.Register<Block> event) {
-    IForgeRegistry<Block> registry = event.getRegistry();
+    BaseRegistryAdapter<Block> registry = new BaseRegistryAdapter<>(event.getRegistry());
     boolean forced = Config.forceRegisterAll; // causes to always register all items
 
     // Soils
-    register(registry, new GroutBlock(), "grout");
+    registry.register(new GroutBlock(), "grout");
 
-    register(registry, new GraveyardSoilBlock(), "graveyard_soil");
-    register(registry, new ConsecratedSoilBlock(), "consecrated_soil");
+    registry.register(new GraveyardSoilBlock(), "graveyard_soil");
+    registry.register(new ConsecratedSoilBlock(), "consecrated_soil");
 
-    register(registry, new SlimyMudBlock(SlimyMudBlock.MudType.SLIMY_MUD_GREEN), "slimy_mud_green");
-    register(registry, new SlimyMudBlock(SlimyMudBlock.MudType.SLIMY_MUD_BLUE), "slimy_mud_blue");
-    register(registry, new SlimyMudBlock(SlimyMudBlock.MudType.SLIMY_MUD_MAGMA), "slimy_mud_magma");
+    registry.register(new SlimyMudBlock(SlimyMudBlock.MudType.SLIMY_MUD_GREEN), "slimy_mud_green");
+    registry.register(new SlimyMudBlock(SlimyMudBlock.MudType.SLIMY_MUD_BLUE), "slimy_mud_blue");
+    registry.register(new SlimyMudBlock(SlimyMudBlock.MudType.SLIMY_MUD_MAGMA), "slimy_mud_magma");
 
     // Slimes
-    register(registry, new SlimeBlock(true), "blue_slime");
-    register(registry, new SlimeBlock(true), "purple_slime");
-    register(registry, new SlimeBlock(true), "blood_slime");
-    register(registry, new SlimeBlock(true), "magma_slime");
-    register(registry, new SlimeBlock(false), "pink_slime");
+    registry.register(new SlimeBlock(true), "blue_slime");
+    registry.register(new SlimeBlock(true), "purple_slime");
+    registry.register(new SlimeBlock(true), "blood_slime");
+    registry.register(new SlimeBlock(true), "magma_slime");
+    registry.register(new SlimeBlock(false), "pink_slime");
 
-    register(registry, new CongealedSlimeBlock(true), "congealed_green_slime");
-    register(registry, new CongealedSlimeBlock(true), "congealed_blue_slime");
-    register(registry, new CongealedSlimeBlock(true), "congealed_purple_slime");
-    register(registry, new CongealedSlimeBlock(true), "congealed_blood_slime");
-    register(registry, new CongealedSlimeBlock(true), "congealed_magma_slime");
-    register(registry, new CongealedSlimeBlock(false), "congealed_pink_slime");
+    registry.register(new CongealedSlimeBlock(true), "congealed_green_slime");
+    registry.register(new CongealedSlimeBlock(true), "congealed_blue_slime");
+    registry.register(new CongealedSlimeBlock(true), "congealed_purple_slime");
+    registry.register(new CongealedSlimeBlock(true), "congealed_blood_slime");
+    registry.register(new CongealedSlimeBlock(true), "congealed_magma_slime");
+    registry.register(new CongealedSlimeBlock(false), "congealed_pink_slime");
 
     // Ores
-    register(registry, new OreBlock(), "cobalt_ore");
-    register(registry, new OreBlock(), "ardite_ore");
+    registry.register(new OreBlock(), "cobalt_ore");
+    registry.register(new OreBlock(), "ardite_ore");
 
     // Firewood
-    lavawood = register(registry, new FirewoodBlock(), "lavawood");
-    firewood = register(registry, new FirewoodBlock(), "firewood");
+    lavawood = registry.register(new FirewoodBlock(), "lavawood");
+    firewood = registry.register(new FirewoodBlock(), "firewood");
 
     // Decorative Stuff
-    mud_bricks = register(registry, new DecoGroundBlock(), "mud_bricks");
+    mud_bricks = registry.register(new DecoGroundBlock(), "mud_bricks");
 
-    register(registry, new ClearGlassBlock(), "clear_glass");
+    registry.register(new ClearGlassBlock(), "clear_glass");
 
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.WHITE), "white_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.ORANGE), "orange_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.MAGENTA), "magenta_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.LIGHT_BLUE), "light_blue_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.YELLOW), "yellow_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.LIME), "lime_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.PINK), "pink_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.GRAY), "gray_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.LIGHT_GRAY), "light_gray_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.CYAN), "cyan_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.PURPLE), "purple_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.BLUE), "blue_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.BROWN), "brown_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.GREEN), "green_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.RED), "red_clear_stained_glass");
-    register(registry, new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.BLACK), "black_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.WHITE), "white_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.ORANGE), "orange_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.MAGENTA), "magenta_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.LIGHT_BLUE), "light_blue_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.YELLOW), "yellow_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.LIME), "lime_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.PINK), "pink_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.GRAY), "gray_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.LIGHT_GRAY), "light_gray_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.CYAN), "cyan_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.PURPLE), "purple_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.BLUE), "blue_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.BROWN), "brown_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.GREEN), "green_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.RED), "red_clear_stained_glass");
+    registry.register(new ClearStainedGlassBlock(ClearStainedGlassBlock.GlassColor.BLACK), "black_clear_stained_glass");
 
     // Slabs
-    register(registry, new DecoGroundSlabBlock(), "mud_bricks_slab");
-    register(registry, new FirewoodSlabBlock(), "lavawood_slab");
-    register(registry, new FirewoodSlabBlock(), "firewood_slab");
+    registry.register(new DecoGroundSlabBlock(), "mud_bricks_slab");
+    registry.register(new FirewoodSlabBlock(), "lavawood_slab");
+    registry.register(new FirewoodSlabBlock(), "firewood_slab");
 
     // Stairs
-    register(registry, new StairsBaseBlock(mud_bricks), "mud_bricks_stairs");
-    register(registry, new StairsBaseBlock(lavawood), "lavawood_stairs");
-    register(registry, new StairsBaseBlock(firewood), "firewood_stairs");
+    registry.register(new StairsBaseBlock(mud_bricks), "mud_bricks_stairs");
+    registry.register(new StairsBaseBlock(lavawood), "lavawood_stairs");
+    registry.register(new StairsBaseBlock(firewood), "firewood_stairs");
 
     // Metals
     if (isToolsLoaded() || isSmelteryLoaded() || forced) {
-      register(registry, new MetalBlock(MetalBlock.MetalType.COBALT), "cobalt_block");
-      register(registry, new MetalBlock(MetalBlock.MetalType.ARDITE), "ardite_block");
-      register(registry, new MetalBlock(MetalBlock.MetalType.MANYULLYN), "manyullyn_block");
-      register(registry, new MetalBlock(MetalBlock.MetalType.KNIGHTSLIME), "knightslime_block");
-      register(registry, new MetalBlock(MetalBlock.MetalType.PIGIRON), "pigiron_block");
-      register(registry, new MetalBlock(MetalBlock.MetalType.ALUBRASS), "alubrass_block");
-      register(registry, new MetalBlock(MetalBlock.MetalType.SILKY_JEWEL), "silky_jewel_block");
+      registry.register(new MetalBlock(MetalBlock.MetalType.COBALT), "cobalt_block");
+      registry.register(new MetalBlock(MetalBlock.MetalType.ARDITE), "ardite_block");
+      registry.register(new MetalBlock(MetalBlock.MetalType.MANYULLYN), "manyullyn_block");
+      registry.register(new MetalBlock(MetalBlock.MetalType.KNIGHTSLIME), "knightslime_block");
+      registry.register(new MetalBlock(MetalBlock.MetalType.PIGIRON), "pigiron_block");
+      registry.register(new MetalBlock(MetalBlock.MetalType.ALUBRASS), "alubrass_block");
+      registry.register(new MetalBlock(MetalBlock.MetalType.SILKY_JEWEL), "silky_jewel_block");
     }
 
     if (isToolsLoaded() || isGadgetsLoaded() || forced) {
-      register(registry, new GlowBlock(), "glow");
+      registry.register(new GlowBlock(), "glow");
     }
   }
 
   @SubscribeEvent
   public void registerItems(final RegistryEvent.Register<Item> event) {
-    IForgeRegistry<Item> registry = event.getRegistry();
+    ItemRegistryAdapter registry = new ItemRegistryAdapter(event.getRegistry());
+    CreativeTab tabGeneral = TinkerRegistry.tabGeneral;
+    CreativeTab tabWorld = TinkerRegistry.tabWorld;
     boolean forced = Config.forceRegisterAll; // causes to always register all items
 
-    register(registry, new TinkerBookItem(), "book");
+    registry.register(new TinkerBookItem(), "book");
 
     // Soils
-    registerBlockItem(registry, grout, TinkerRegistry.tabGeneral);
+    registry.registerBlockItem(grout, tabGeneral);
 
-    registerBlockItem(registry, graveyard_soil, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, consecrated_soil, TinkerRegistry.tabGeneral);
+    registry.registerBlockItem(graveyard_soil, tabGeneral);
+    registry.registerBlockItem(consecrated_soil, tabGeneral);
 
-    registerBlockItem(registry, slimy_mud_green, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, slimy_mud_blue, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, slimy_mud_magma, TinkerRegistry.tabGeneral);
+    registry.registerBlockItem(slimy_mud_green, tabGeneral);
+    registry.registerBlockItem(slimy_mud_blue, tabGeneral);
+    registry.registerBlockItem(slimy_mud_magma, tabGeneral);
 
     // Slimes
-    registerBlockItem(registry, blue_slime, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, purple_slime, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, blood_slime, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, magma_slime, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, pink_slime, TinkerRegistry.tabWorld);
+    registry.registerBlockItem(blue_slime, tabWorld);
+    registry.registerBlockItem(purple_slime, tabWorld);
+    registry.registerBlockItem(blood_slime, tabWorld);
+    registry.registerBlockItem(magma_slime, tabWorld);
+    registry.registerBlockItem(pink_slime, tabWorld);
 
-    registerBlockItem(registry, congealed_green_slime, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, congealed_blue_slime, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, congealed_purple_slime, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, congealed_blood_slime, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, congealed_magma_slime, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, congealed_pink_slime, TinkerRegistry.tabWorld);
+    registry.registerBlockItem(congealed_green_slime, tabWorld);
+    registry.registerBlockItem(congealed_blue_slime, tabWorld);
+    registry.registerBlockItem(congealed_purple_slime, tabWorld);
+    registry.registerBlockItem(congealed_blood_slime, tabWorld);
+    registry.registerBlockItem(congealed_magma_slime, tabWorld);
+    registry.registerBlockItem(congealed_pink_slime, tabWorld);
 
     // Ores
-    registerBlockItem(registry, cobalt_ore, TinkerRegistry.tabWorld);
-    registerBlockItem(registry, ardite_ore, TinkerRegistry.tabWorld);
+    registry.registerBlockItem(cobalt_ore, tabWorld);
+    registry.registerBlockItem(ardite_ore, tabWorld);
 
     // Firewood
-    registerBlockItem(registry, lavawood, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, firewood, TinkerRegistry.tabGeneral);
+    registry.registerBlockItem(lavawood, tabGeneral);
+    registry.registerBlockItem(firewood, tabGeneral);
 
     // Decorative Stuff
-    registerBlockItem(registry, mud_bricks, TinkerRegistry.tabGeneral);
+    registry.registerBlockItem(mud_bricks, tabGeneral);
 
-    registerBlockItem(registry, clear_glass, TinkerRegistry.tabGeneral);
+    registry.registerBlockItem(clear_glass, tabGeneral);
 
-    registerBlockItem(registry, white_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, orange_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, magenta_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, light_blue_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, yellow_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, lime_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, pink_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, gray_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, light_gray_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, cyan_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, purple_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, blue_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, brown_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, green_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, red_clear_stained_glass, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, black_clear_stained_glass, TinkerRegistry.tabGeneral);
+    registry.registerBlockItem(white_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(orange_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(magenta_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(light_blue_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(yellow_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(lime_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(pink_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(gray_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(light_gray_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(cyan_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(purple_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(blue_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(brown_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(green_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(red_clear_stained_glass, tabGeneral);
+    registry.registerBlockItem(black_clear_stained_glass, tabGeneral);
 
     // Slabs
-    registerBlockItem(registry, mud_bricks_slab, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, lavawood_slab, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, firewood_slab, TinkerRegistry.tabGeneral);
+    registry.registerBlockItem(mud_bricks_slab, tabGeneral);
+    registry.registerBlockItem(lavawood_slab, tabGeneral);
+    registry.registerBlockItem(firewood_slab, tabGeneral);
 
     // Stairs
-    registerBlockItem(registry, mud_bricks_stairs, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, lavawood_stairs, TinkerRegistry.tabGeneral);
-    registerBlockItem(registry, firewood_stairs, TinkerRegistry.tabGeneral);
+    registry.registerBlockItem(mud_bricks_stairs, tabGeneral);
+    registry.registerBlockItem(lavawood_stairs, tabGeneral);
+    registry.registerBlockItem(firewood_stairs, tabGeneral);
 
     // Metals
     if (isToolsLoaded() || isSmelteryLoaded() || forced) {
-      registerBlockItem(registry, cobalt_block, TinkerRegistry.tabGeneral);
-      registerBlockItem(registry, ardite_block, TinkerRegistry.tabGeneral);
-      registerBlockItem(registry, manyullyn_block, TinkerRegistry.tabGeneral);
-      registerBlockItem(registry, knightslime_block, TinkerRegistry.tabGeneral);
-      registerBlockItem(registry, pigiron_block, TinkerRegistry.tabGeneral);
-      registerBlockItem(registry, alubrass_block, TinkerRegistry.tabGeneral);
-      registerBlockItem(registry, silky_jewel_block, TinkerRegistry.tabGeneral);
+      registry.registerBlockItem(cobalt_block, tabGeneral);
+      registry.registerBlockItem(ardite_block, tabGeneral);
+      registry.registerBlockItem(manyullyn_block, tabGeneral);
+      registry.registerBlockItem(knightslime_block, tabGeneral);
+      registry.registerBlockItem(pigiron_block, tabGeneral);
+      registry.registerBlockItem(alubrass_block, tabGeneral);
+      registry.registerBlockItem(silky_jewel_block, tabGeneral);
     }
 
     if (isToolsLoaded() || isGadgetsLoaded() || forced) {
-      registerBlockItem(registry, glow);
+      registry.registerBlockItem(glow, TinkerRegistry.tabGadgets);
     }
 
-    register(registry, new EdibleItem(TinkerFood.BLUE_SLIME_BALL, TinkerRegistry.tabGeneral), "blue_slime_ball");
-    register(registry, new EdibleItem(TinkerFood.PURPLE_SLIME_BALL, TinkerRegistry.tabGeneral), "purple_slime_ball");
-    register(registry, new EdibleItem(TinkerFood.BLOOD_SLIME_BALL, TinkerRegistry.tabGeneral), "blood_slime_ball");
-    register(registry, new EdibleItem(TinkerFood.MAGMA_SLIME_BALL, TinkerRegistry.tabGeneral), "magma_slime_ball");
-    register(registry, new EdibleItem(TinkerFood.PINK_SLIME_BALL, TinkerRegistry.tabGeneral), "pink_slime_ball");
+    registry.register(new EdibleItem(TinkerFood.BLUE_SLIME_BALL, tabGeneral), "blue_slime_ball");
+    registry.register(new EdibleItem(TinkerFood.PURPLE_SLIME_BALL, tabGeneral), "purple_slime_ball");
+    registry.register(new EdibleItem(TinkerFood.BLOOD_SLIME_BALL, tabGeneral), "blood_slime_ball");
+    registry.register(new EdibleItem(TinkerFood.MAGMA_SLIME_BALL, tabGeneral), "magma_slime_ball");
+    registry.register(new EdibleItem(TinkerFood.PINK_SLIME_BALL, tabGeneral), "pink_slime_ball");
 
     if (isSmelteryLoaded() || forced) {
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "seared_brick");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "mud_brick");
+      registry.register(new GeneratedItem(tabGeneral), "seared_brick");
+      registry.register(new GeneratedItem(tabGeneral), "mud_brick");
     }
 
     // Ingots and nuggets
     if (isToolsLoaded() || isSmelteryLoaded() || forced) {
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "cobalt_nugget");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "cobalt_ingot");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "ardite_nugget");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "ardite_ingot");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "manyullyn_nugget");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "manyullyn_ingot");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "pigiron_nugget");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "pigiron_ingot");
-      register(registry, new AlubrassItem(TinkerRegistry.tabGeneral), "alubrass_nugget");
-      register(registry, new AlubrassItem(TinkerRegistry.tabGeneral), "alubrass_ingot");
+      registry.register(new GeneratedItem(tabGeneral), "cobalt_nugget");
+      registry.register(new GeneratedItem(tabGeneral), "cobalt_ingot");
+      registry.register(new GeneratedItem(tabGeneral), "ardite_nugget");
+      registry.register(new GeneratedItem(tabGeneral), "ardite_ingot");
+      registry.register(new GeneratedItem(tabGeneral), "manyullyn_nugget");
+      registry.register(new GeneratedItem(tabGeneral), "manyullyn_ingot");
+      registry.register(new GeneratedItem(tabGeneral), "pigiron_nugget");
+      registry.register(new GeneratedItem(tabGeneral), "pigiron_ingot");
+      registry.register(new AlubrassItem(tabGeneral), "alubrass_nugget");
+      registry.register(new AlubrassItem(tabGeneral), "alubrass_ingot");
     }
 
     if (isToolsLoaded() || forced) {
-      register(registry, new EdibleItem(TinkerFood.BACON, TinkerRegistry.tabGeneral), "bacon");
+      registry.register(new EdibleItem(TinkerFood.BACON, tabGeneral), "bacon");
 
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "green_slime_crystal");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "blue_slime_crystal");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "magma_slime_crystal");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "width_expander");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "height_expander");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "reinforcement");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "silky_cloth");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "silky_jewel");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "necrotic_bone");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "moss");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "mending_moss");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "creative_modifier");
+      registry.register(new GeneratedItem(tabGeneral), "green_slime_crystal");
+      registry.register(new GeneratedItem(tabGeneral), "blue_slime_crystal");
+      registry.register(new GeneratedItem(tabGeneral), "magma_slime_crystal");
+      registry.register(new GeneratedItem(tabGeneral), "width_expander");
+      registry.register(new GeneratedItem(tabGeneral), "height_expander");
+      registry.register(new GeneratedItem(tabGeneral), "reinforcement");
+      registry.register(new GeneratedItem(tabGeneral), "silky_cloth");
+      registry.register(new GeneratedItem(tabGeneral), "silky_jewel");
+      registry.register(new GeneratedItem(tabGeneral), "necrotic_bone");
+      registry.register(new GeneratedItem(tabGeneral), "moss");
+      registry.register(new GeneratedItem(tabGeneral), "mending_moss");
+      registry.register(new GeneratedItem(tabGeneral), "creative_modifier");
 
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "knightslime_nugget");
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "knightslime_ingot");
+      registry.register(new GeneratedItem(tabGeneral), "knightslime_nugget");
+      registry.register(new GeneratedItem(tabGeneral), "knightslime_ingot");
     }
 
     if (isGadgetsLoaded() || forced) {
-      register(registry, new GeneratedItem(TinkerRegistry.tabGeneral), "dried_brick");
+      registry.register(new GeneratedItem(tabGeneral), "dried_brick");
 
-      register(registry, new EdibleItem(TinkerFood.MONSTER_JERKY, TinkerRegistry.tabGeneral), "monster_jerky");
-      register(registry, new EdibleItem(TinkerFood.BEEF_JERKY, TinkerRegistry.tabGeneral), "beef_jerky");
-      register(registry, new EdibleItem(TinkerFood.CHICKEN_JERKY, TinkerRegistry.tabGeneral), "chicken_jerky");
-      register(registry, new EdibleItem(TinkerFood.PORK_JERKY, TinkerRegistry.tabGeneral), "pork_jerky");
-      register(registry, new EdibleItem(TinkerFood.MUTTON_JERKY, TinkerRegistry.tabGeneral), "mutton_jerky");
-      register(registry, new EdibleItem(TinkerFood.RABBIT_JERKY, TinkerRegistry.tabGeneral), "rabbit_jerky");
-      register(registry, new EdibleItem(TinkerFood.FISH_JERKY, TinkerRegistry.tabGeneral), "fish_jerky");
-      register(registry, new EdibleItem(TinkerFood.SALMON_JERKY, TinkerRegistry.tabGeneral), "salmon_jerky");
-      register(registry, new EdibleItem(TinkerFood.CLOWNFISH_JERKY, TinkerRegistry.tabGeneral), "clownfish_jerky");
-      register(registry, new EdibleItem(TinkerFood.PUFFERFISH_JERKY, TinkerRegistry.tabGeneral), "pufferfish_jerky");
+      registry.register(new EdibleItem(TinkerFood.MONSTER_JERKY, tabGeneral), "monster_jerky");
+      registry.register(new EdibleItem(TinkerFood.BEEF_JERKY, tabGeneral), "beef_jerky");
+      registry.register(new EdibleItem(TinkerFood.CHICKEN_JERKY, tabGeneral), "chicken_jerky");
+      registry.register(new EdibleItem(TinkerFood.PORK_JERKY, tabGeneral), "pork_jerky");
+      registry.register(new EdibleItem(TinkerFood.MUTTON_JERKY, tabGeneral), "mutton_jerky");
+      registry.register(new EdibleItem(TinkerFood.RABBIT_JERKY, tabGeneral), "rabbit_jerky");
+      registry.register(new EdibleItem(TinkerFood.FISH_JERKY, tabGeneral), "fish_jerky");
+      registry.register(new EdibleItem(TinkerFood.SALMON_JERKY, tabGeneral), "salmon_jerky");
+      registry.register(new EdibleItem(TinkerFood.CLOWNFISH_JERKY, tabGeneral), "clownfish_jerky");
+      registry.register(new EdibleItem(TinkerFood.PUFFERFISH_JERKY, tabGeneral), "pufferfish_jerky");
 
-      register(registry, new EdibleItem(TinkerFood.GREEN_SLIME_DROP, TinkerRegistry.tabGeneral), "green_slime_drop");
-      register(registry, new EdibleItem(TinkerFood.BLUE_SLIME_DROP, TinkerRegistry.tabGeneral), "blue_slime_drop");
-      register(registry, new EdibleItem(TinkerFood.PURPLE_SLIME_DROP, TinkerRegistry.tabGeneral), "purple_slime_drop");
-      register(registry, new EdibleItem(TinkerFood.BLOOD_SLIME_DROP, TinkerRegistry.tabGeneral), "blood_slime_drop");
-      register(registry, new EdibleItem(TinkerFood.MAGMA_SLIME_DROP, TinkerRegistry.tabGeneral), "magma_slime_drop");
+      registry.register(new EdibleItem(TinkerFood.GREEN_SLIME_DROP, tabGeneral), "green_slime_drop");
+      registry.register(new EdibleItem(TinkerFood.BLUE_SLIME_DROP, tabGeneral), "blue_slime_drop");
+      registry.register(new EdibleItem(TinkerFood.PURPLE_SLIME_DROP, tabGeneral), "purple_slime_drop");
+      registry.register(new EdibleItem(TinkerFood.BLOOD_SLIME_DROP, tabGeneral), "blood_slime_drop");
+      registry.register(new EdibleItem(TinkerFood.MAGMA_SLIME_DROP, tabGeneral), "magma_slime_drop");
     }
   }
 

--- a/src/main/java/slimeknights/tconstruct/world/TinkerWorld.java
+++ b/src/main/java/slimeknights/tconstruct/world/TinkerWorld.java
@@ -27,7 +27,6 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.ObjectHolder;
 
 import org.apache.logging.log4j.Logger;
@@ -37,6 +36,8 @@ import slimeknights.mantle.pulsar.pulse.Pulse;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.common.ServerProxy;
 import slimeknights.tconstruct.common.TinkerPulse;
+import slimeknights.tconstruct.common.registry.BaseRegistryAdapter;
+import slimeknights.tconstruct.common.registry.ItemRegistryAdapter;
 import slimeknights.tconstruct.library.TinkerPulseIds;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.Util;
@@ -126,113 +127,114 @@ public class TinkerWorld extends TinkerPulse {
 
   @SubscribeEvent
   public void registerBlocks(final RegistryEvent.Register<Block> event) {
-    IForgeRegistry<Block> registry = event.getRegistry();
+    BaseRegistryAdapter<Block> registry = new BaseRegistryAdapter<>(event.getRegistry());
 
-    register(registry, new SlimeDirtBlock(), "green_slime_dirt");
-    register(registry, new SlimeDirtBlock(), "blue_slime_dirt");
-    register(registry, new SlimeDirtBlock(), "purple_slime_dirt");
-    register(registry, new SlimeDirtBlock(), "magma_slime_dirt");
+    registry.register(new SlimeDirtBlock(), "green_slime_dirt");
+    registry.register(new SlimeDirtBlock(), "blue_slime_dirt");
+    registry.register(new SlimeDirtBlock(), "purple_slime_dirt");
+    registry.register(new SlimeDirtBlock(), "magma_slime_dirt");
 
     for (SlimeGrassBlock.FoliageType type : SlimeGrassBlock.FoliageType.values()) {
-      register(registry, new SlimeGrassBlock(type), type.getName() + "_vanilla_slime_grass");
-      register(registry, new SlimeGrassBlock(type), type.getName() + "_green_slime_grass");
-      register(registry, new SlimeGrassBlock(type), type.getName() + "_blue_slime_grass");
-      register(registry, new SlimeGrassBlock(type), type.getName() + "_purple_slime_grass");
-      register(registry, new SlimeGrassBlock(type), type.getName() + "_magma_slime_grass");
+      registry.register(new SlimeGrassBlock(type), type.getName() + "_vanilla_slime_grass");
+      registry.register(new SlimeGrassBlock(type), type.getName() + "_green_slime_grass");
+      registry.register(new SlimeGrassBlock(type), type.getName() + "_blue_slime_grass");
+      registry.register(new SlimeGrassBlock(type), type.getName() + "_purple_slime_grass");
+      registry.register(new SlimeGrassBlock(type), type.getName() + "_magma_slime_grass");
     }
 
-    register(registry, new SlimeLeavesBlock(SlimeGrassBlock.FoliageType.BLUE), "blue_slime_leaves");
-    register(registry, new SlimeLeavesBlock(SlimeGrassBlock.FoliageType.PURPLE), "purple_slime_leaves");
-    register(registry, new SlimeLeavesBlock(SlimeGrassBlock.FoliageType.ORANGE), "orange_slime_leaves");
+    registry.register(new SlimeLeavesBlock(SlimeGrassBlock.FoliageType.BLUE), "blue_slime_leaves");
+    registry.register(new SlimeLeavesBlock(SlimeGrassBlock.FoliageType.PURPLE), "purple_slime_leaves");
+    registry.register(new SlimeLeavesBlock(SlimeGrassBlock.FoliageType.ORANGE), "orange_slime_leaves");
 
     for (SlimeGrassBlock.FoliageType foliageType : SlimeGrassBlock.FoliageType.values()) {
       for (SlimeTallGrassBlock.SlimePlantType plantType : SlimeTallGrassBlock.SlimePlantType.values()) {
-        register(registry, new SlimeTallGrassBlock(foliageType, plantType), foliageType.getName() + "_slime_" + plantType.getName());
+        registry.register(new SlimeTallGrassBlock(foliageType, plantType), foliageType.getName() + "_slime_" + plantType.getName());
       }
     }
 
-    register(registry, new SlimeSaplingBlock(new BlueSlimeTree(false)), "blue_slime_sapling");
-    register(registry, new SlimeSaplingBlock(new MagmaSlimeTree()), "orange_slime_sapling");
-    register(registry, new SlimeSaplingBlock(new PurpleSlimeTree(false)), "purple_slime_sapling");
+    registry.register(new SlimeSaplingBlock(new BlueSlimeTree(false)), "blue_slime_sapling");
+    registry.register(new SlimeSaplingBlock(new MagmaSlimeTree()), "orange_slime_sapling");
+    registry.register(new SlimeSaplingBlock(new PurpleSlimeTree(false)), "purple_slime_sapling");
 
-    register(registry, new SlimeVineBlock(SlimeGrassBlock.FoliageType.PURPLE, SlimeVineBlock.VineStage.START), "purple_slime_vine");
-    register(registry, new SlimeVineBlock(SlimeGrassBlock.FoliageType.PURPLE, SlimeVineBlock.VineStage.MIDDLE), "purple_slime_vine_middle");
-    register(registry, new SlimeVineBlock(SlimeGrassBlock.FoliageType.PURPLE, SlimeVineBlock.VineStage.END), "purple_slime_vine_end");
+    registry.register(new SlimeVineBlock(SlimeGrassBlock.FoliageType.PURPLE, SlimeVineBlock.VineStage.START), "purple_slime_vine");
+    registry.register(new SlimeVineBlock(SlimeGrassBlock.FoliageType.PURPLE, SlimeVineBlock.VineStage.MIDDLE), "purple_slime_vine_middle");
+    registry.register(new SlimeVineBlock(SlimeGrassBlock.FoliageType.PURPLE, SlimeVineBlock.VineStage.END), "purple_slime_vine_end");
 
-    register(registry, new SlimeVineBlock(SlimeGrassBlock.FoliageType.BLUE, SlimeVineBlock.VineStage.START), "blue_slime_vine");
-    register(registry, new SlimeVineBlock(SlimeGrassBlock.FoliageType.BLUE, SlimeVineBlock.VineStage.MIDDLE), "blue_slime_vine_middle");
-    register(registry, new SlimeVineBlock(SlimeGrassBlock.FoliageType.BLUE, SlimeVineBlock.VineStage.END), "blue_slime_vine_end");
+    registry.register(new SlimeVineBlock(SlimeGrassBlock.FoliageType.BLUE, SlimeVineBlock.VineStage.START), "blue_slime_vine");
+    registry.register(new SlimeVineBlock(SlimeGrassBlock.FoliageType.BLUE, SlimeVineBlock.VineStage.MIDDLE), "blue_slime_vine_middle");
+    registry.register(new SlimeVineBlock(SlimeGrassBlock.FoliageType.BLUE, SlimeVineBlock.VineStage.END), "blue_slime_vine_end");
   }
 
   @SubscribeEvent
   public void registerItems(final RegistryEvent.Register<Item> event) {
-    IForgeRegistry<Item> registry = event.getRegistry();
-
-    register(registry, new SpawnEggItem(WorldEntities.blue_slime_entity, 0x47eff5, 0xacfff4, (new Item.Properties()).group(ItemGroup.MISC)), "blue_slime_spawn_egg");
+    ItemRegistryAdapter registry = new ItemRegistryAdapter(event.getRegistry());
     CreativeTab tabWorld = TinkerRegistry.tabWorld;
 
-    registerBlockItem(registry, green_slime_dirt, tabWorld);
-    registerBlockItem(registry, blue_slime_dirt, tabWorld);
-    registerBlockItem(registry, purple_slime_dirt, tabWorld);
-    registerBlockItem(registry, magma_slime_dirt, tabWorld);
+    SpawnEggItem blueSlimeSpawnEgg = new SpawnEggItem(WorldEntities.blue_slime_entity, 0x47eff5, 0xacfff4, (new Item.Properties()).group(ItemGroup.MISC));
+    registry.register(blueSlimeSpawnEgg, "blue_slime_spawn_egg");
 
-    registerBlockItem(registry, blue_vanilla_slime_grass, tabWorld);
-    registerBlockItem(registry, purple_vanilla_slime_grass, tabWorld);
-    registerBlockItem(registry, orange_vanilla_slime_grass, tabWorld);
-    registerBlockItem(registry, blue_green_slime_grass, tabWorld);
-    registerBlockItem(registry, purple_green_slime_grass, tabWorld);
-    registerBlockItem(registry, orange_green_slime_grass, tabWorld);
-    registerBlockItem(registry, blue_blue_slime_grass, tabWorld);
-    registerBlockItem(registry, purple_blue_slime_grass, tabWorld);
-    registerBlockItem(registry, orange_blue_slime_grass, tabWorld);
-    registerBlockItem(registry, blue_purple_slime_grass, tabWorld);
-    registerBlockItem(registry, purple_purple_slime_grass, tabWorld);
-    registerBlockItem(registry, orange_purple_slime_grass, tabWorld);
-    registerBlockItem(registry, blue_magma_slime_grass, tabWorld);
-    registerBlockItem(registry, purple_magma_slime_grass, tabWorld);
-    registerBlockItem(registry, orange_magma_slime_grass, tabWorld);
+    registry.registerBlockItem(green_slime_dirt, tabWorld);
+    registry.registerBlockItem(blue_slime_dirt, tabWorld);
+    registry.registerBlockItem(purple_slime_dirt, tabWorld);
+    registry.registerBlockItem(magma_slime_dirt, tabWorld);
 
-    registerBlockItem(registry, blue_slime_leaves, tabWorld);
-    registerBlockItem(registry, purple_slime_leaves, tabWorld);
-    registerBlockItem(registry, orange_slime_leaves, tabWorld);
+    registry.registerBlockItem(blue_vanilla_slime_grass, tabWorld);
+    registry.registerBlockItem(purple_vanilla_slime_grass, tabWorld);
+    registry.registerBlockItem(orange_vanilla_slime_grass, tabWorld);
+    registry.registerBlockItem(blue_green_slime_grass, tabWorld);
+    registry.registerBlockItem(purple_green_slime_grass, tabWorld);
+    registry.registerBlockItem(orange_green_slime_grass, tabWorld);
+    registry.registerBlockItem(blue_blue_slime_grass, tabWorld);
+    registry.registerBlockItem(purple_blue_slime_grass, tabWorld);
+    registry.registerBlockItem(orange_blue_slime_grass, tabWorld);
+    registry.registerBlockItem(blue_purple_slime_grass, tabWorld);
+    registry.registerBlockItem(purple_purple_slime_grass, tabWorld);
+    registry.registerBlockItem(orange_purple_slime_grass, tabWorld);
+    registry.registerBlockItem(blue_magma_slime_grass, tabWorld);
+    registry.registerBlockItem(purple_magma_slime_grass, tabWorld);
+    registry.registerBlockItem(orange_magma_slime_grass, tabWorld);
 
-    registerBlockItem(registry, blue_slime_fern, tabWorld);
-    registerBlockItem(registry, purple_slime_fern, tabWorld);
-    registerBlockItem(registry, orange_slime_fern, tabWorld);
+    registry.registerBlockItem(blue_slime_leaves, tabWorld);
+    registry.registerBlockItem(purple_slime_leaves, tabWorld);
+    registry.registerBlockItem(orange_slime_leaves, tabWorld);
 
-    registerBlockItem(registry, blue_slime_tall_grass, tabWorld);
-    registerBlockItem(registry, purple_slime_tall_grass, tabWorld);
-    registerBlockItem(registry, orange_slime_tall_grass, tabWorld);
+    registry.registerBlockItem(blue_slime_fern, tabWorld);
+    registry.registerBlockItem(purple_slime_fern, tabWorld);
+    registry.registerBlockItem(orange_slime_fern, tabWorld);
 
-    registerBlockItem(registry, blue_slime_sapling, tabWorld);
-    registerBlockItem(registry, orange_slime_sapling, tabWorld);
-    registerBlockItem(registry, purple_slime_sapling, tabWorld);
+    registry.registerBlockItem(blue_slime_tall_grass, tabWorld);
+    registry.registerBlockItem(purple_slime_tall_grass, tabWorld);
+    registry.registerBlockItem(orange_slime_tall_grass, tabWorld);
 
-    registerBlockItem(registry, purple_slime_vine, tabWorld);
-    registerBlockItem(registry, purple_slime_vine_middle, tabWorld);
-    registerBlockItem(registry, purple_slime_vine_end, tabWorld);
+    registry.registerBlockItem(blue_slime_sapling, tabWorld);
+    registry.registerBlockItem(orange_slime_sapling, tabWorld);
+    registry.registerBlockItem(purple_slime_sapling, tabWorld);
 
-    registerBlockItem(registry, blue_slime_vine, tabWorld);
-    registerBlockItem(registry, blue_slime_vine_middle, tabWorld);
-    registerBlockItem(registry, blue_slime_vine_end, tabWorld);
+    registry.registerBlockItem(purple_slime_vine, tabWorld);
+    registry.registerBlockItem(purple_slime_vine_middle, tabWorld);
+    registry.registerBlockItem(purple_slime_vine_end, tabWorld);
+
+    registry.registerBlockItem(blue_slime_vine, tabWorld);
+    registry.registerBlockItem(blue_slime_vine_middle, tabWorld);
+    registry.registerBlockItem(blue_slime_vine_end, tabWorld);
   }
 
   @SubscribeEvent
   public void registerEntities(final RegistryEvent.Register<EntityType<?>> event) {
-    IForgeRegistry<EntityType<?>> registry = event.getRegistry();
+    BaseRegistryAdapter<EntityType<?>> registry = new BaseRegistryAdapter<>(event.getRegistry());
 
-    registry.register(WorldEntities.blue_slime_entity.setRegistryName("tconstruct:blue_slime_entity"));
+    registry.register(WorldEntities.blue_slime_entity, "blue_slime_entity");
   }
 
   @SubscribeEvent
   public void onFeaturesRegistry(RegistryEvent.Register<Feature<?>> event) {
-    IForgeRegistry<Feature<?>> registry = event.getRegistry();
+    BaseRegistryAdapter<Feature<?>> registry = new BaseRegistryAdapter<>(event.getRegistry());
 
-    SLIME_ISLAND_PIECE = Registry.register(Registry.STRUCTURE_PIECE, "tconstruct:slime_island_piece", SlimeIslandPiece::new);
-    register(registry, new SlimeIslandStructure(NoFeatureConfig::deserialize), "slime_island");
+    SLIME_ISLAND_PIECE = Registry.register(Registry.STRUCTURE_PIECE, registry.getResource("slime_island_piece"), SlimeIslandPiece::new);
+    registry.register(new SlimeIslandStructure(NoFeatureConfig::deserialize), "slime_island");
 
-    NETHER_SLIME_ISLAND_PIECE = Registry.register(Registry.STRUCTURE_PIECE, "tconstruct:nether_slime_island_piece", NetherSlimeIslandPiece::new);
-    register(registry, new NetherSlimeIslandStructure(NoFeatureConfig::deserialize), "nether_slime_island");
+    NETHER_SLIME_ISLAND_PIECE = Registry.register(Registry.STRUCTURE_PIECE, registry.getResource("nether_slime_island_piece"), NetherSlimeIslandPiece::new);
+    registry.register(new NetherSlimeIslandStructure(NoFeatureConfig::deserialize), "nether_slime_island");
   }
 
   @SubscribeEvent


### PR DESCRIPTION
Change our util for registries to be a bit cleaner.
In theory we could just call .setRegistryName inline on each item.. but it looks cleaner like that.
Also the ItemBlock utils are very useful.

Ditched the list-variants since they don't make sense from a design standpoint.