### PR TITLE
Fix various bugs with repairing Mom's Spaghetti

### DIFF
--- a/src/main/java/slimeknights/tconstruct/gadgets/item/ItemMomsSpaghetti.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/item/ItemMomsSpaghetti.java
@@ -178,8 +178,6 @@ public class ItemMomsSpaghetti extends ItemFood implements IRepairable, IModifya
         repairItem.shrink(1);
 
         //change = Math.min(change, stack.getMaxDamage() - stack.getItemDamage());
-        stack.setItemDamage(stack.getItemDamage() - USES_PER_WHEAT);
-
         ToolHelper.healTool(stack, USES_PER_WHEAT, null);
       }
       else {

--- a/src/main/java/slimeknights/tconstruct/gadgets/item/ItemMomsSpaghetti.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/item/ItemMomsSpaghetti.java
@@ -156,18 +156,25 @@ public class ItemMomsSpaghetti extends ItemFood implements IRepairable, IModifya
       return ItemStack.EMPTY;
     }
 
-    // don't accept anything that's not wheat
+    // don't accept anything that's not wheat and don't accept all empty
+    boolean allEmpty = true;
     for(ItemStack repairItem : repairItems) {
-      if(repairItem != null && repairItem.getItem() != Items.WHEAT) {
-        return ItemStack.EMPTY;
+      if(!repairItem.isEmpty()) {
+        allEmpty = false;
+        if(repairItem.getItem() != Items.WHEAT) {
+          return ItemStack.EMPTY;
+        }
       }
+    }
+    if (allEmpty) {
+      return ItemStack.EMPTY;
     }
 
     ItemStack stack = repairable.copy();
     int index = 0;
     while(stack.getItemDamage() > 0 && index < repairItems.size()) {
       ItemStack repairItem = repairItems.get(index);
-      if(repairItem.getCount() > 0) {
+      if(!repairItem.isEmpty() && repairItem.getCount() > 0) {
         repairItem.shrink(1);
 
         //change = Math.min(change, stack.getMaxDamage() - stack.getItemDamage());


### PR DESCRIPTION
- Fix Mom's Spaghetti requiring all five repair items to be non-empty
- Fix Mom's Spaghetti repairing double the intended amount. Each wheat gave two uses before this PR, but it seemed like the intended amount of uses (`USES_PER_WHEAT`) was one. This is a slight nerf to Mom's Spaghetti - perhaps `USES_PER_WHEAT` could be increased to 2?