### PR TITLE
Fix null ItemStack check in Kama's doHarvestCrop

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tools/tools/Kama.java
+++ b/src/main/java/slimeknights/tconstruct/tools/tools/Kama.java
@@ -206,7 +206,7 @@ public class Kama extends AoeToolCore {
 
     IPlantable seed = null;
     for(ItemStack drop : drops) {
-      if(drop != null && drop.getItem() instanceof IPlantable) {
+      if(!drop.isEmpty() && drop.getItem() instanceof IPlantable) {
         seed = (IPlantable) drop.getItem();
         drop.shrink(1);
         if(drop.isEmpty()) {


### PR DESCRIPTION
I was looking for other bugs similar to the one in #3963, where NonNullLists items were being compared with null. I only found one of these - in Kama's doHarvestCrop.

Is this `.isEmpty` check even needed? If it isn't, may as well remove the whole "is not null/empty" check altogether.