### PR TITLE
BouncedPacket exploit fix

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tools/common/network/BouncedPacket.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/network/BouncedPacket.java
@@ -21,8 +21,9 @@ public class BouncedPacket extends AbstractPacketThreadsafe {
 
   @Override
   public void handleServerSafe(NetHandlerPlayServer netHandler) {
-	if(netHandler.player.getItemStackFromSlot(EntityEquipmentSlot.FEET).getItem() instanceof ItemSlimeBoots)
+    if(netHandler.player.getItemStackFromSlot(EntityEquipmentSlot.FEET).getItem() instanceof ItemSlimeBoots) {
       netHandler.player.fallDistance = 0;
+    }
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/tools/common/network/BouncedPacket.java
+++ b/src/main/java/slimeknights/tconstruct/tools/common/network/BouncedPacket.java
@@ -1,10 +1,12 @@
 package slimeknights.tconstruct.tools.common.network;
 
 import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.network.NetHandlerPlayServer;
 
 import io.netty.buffer.ByteBuf;
 import slimeknights.mantle.network.AbstractPacketThreadsafe;
+import slimeknights.tconstruct.gadgets.item.ItemSlimeBoots;
 
 public class BouncedPacket extends AbstractPacketThreadsafe {
 
@@ -19,7 +21,8 @@ public class BouncedPacket extends AbstractPacketThreadsafe {
 
   @Override
   public void handleServerSafe(NetHandlerPlayServer netHandler) {
-    netHandler.player.fallDistance = 0;
+	if(netHandler.player.getItemStackFromSlot(EntityEquipmentSlot.FEET).getItem() instanceof ItemSlimeBoots)
+      netHandler.player.fallDistance = 0;
   }
 
   @Override


### PR DESCRIPTION
BouncedPacket should check server-side if the player has the slime boots in the right equipment slot. Without any check, the server will set the player's fall distance to zero everytime it receives a BouncedPacket, and that's exploitable.
