### PR TITLE
Reset translation in channel renderer

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/client/ChannelRenderer.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/client/ChannelRenderer.java
@@ -161,5 +161,8 @@ public class ChannelRenderer extends FastTESR<TileChannel> {
       // draw at current bottom
       RenderUtil.putTexturedQuad(renderer, still, xz1, y1, xz1, wd, h, wd, EnumFacing.DOWN,  color, brightness, false);
     }
+
+    // Reset
+    renderer.setTranslation(0.0D, 0.0D, 0.0D);
   }
 }


### PR DESCRIPTION
This is a bug fix. Translating without reset will pollute other renderer.

Fix downstream issue: https://github.com/GregTechCE/GregTech/issues/655
