### PR TITLE
Enable whitelisting of slime island world gen dimensions

### DIFF
--- a/src/main/java/slimeknights/tconstruct/common/config/Config.java
+++ b/src/main/java/slimeknights/tconstruct/common/config/Config.java
@@ -73,7 +73,8 @@ public final class Config {
   public static boolean genIslandsInSuperflat = false;
   public static int slimeIslandsRate = 730; // Every x-th chunk will have a slime island. so 1 = every chunk, 100 = every 100th
   public static int magmaIslandsRate = 100; // Every x-th chunk will have a slime island. so 1 = every chunk, 100 = every 100th
-  public static int[] slimeIslandBlacklist = new int[]{-1, 1};
+  public static int[] slimeIslandDimensions = new int[]{-1, 1};
+  public static boolean slimeIslandDimensionsIsBlacklist = true;
   public static boolean slimeIslandsOnlyGenerateInSurfaceWorlds = true;
   public static boolean genCobalt = true;
   public static int cobaltRate = 20; // max. cobalt per chunk
@@ -271,9 +272,16 @@ public final class Config {
       magmaIslandsRate = prop.getInt();
       propOrder.add(prop.getName());
 
-      prop = configFile.get(cat, "slimeIslandBlacklist", slimeIslandBlacklist);
-      prop.setComment("Prevents generation of slime islands in the listed dimensions");
-      slimeIslandBlacklist = prop.getIntList();
+      configFile.renameProperty(cat, "slimeIslandBlacklist", "slimeIslandDimensions");
+
+      prop = configFile.get(cat, "slimeIslandDimensions", slimeIslandDimensions);
+      prop.setComment("List of dimensions in which to enable or disable generation of slime islands");
+      slimeIslandDimensions = prop.getIntList();
+      propOrder.add(prop.getName());
+
+      prop = configFile.get(cat, "slimeIslandDimensionsIsBlacklist", slimeIslandDimensionsIsBlacklist);
+      prop.setComment("Whether the list of slime island dimensions behaves as a blacklist or a whitelist");
+      slimeIslandDimensionsIsBlacklist = prop.getBoolean();
       propOrder.add(prop.getName());
 
       prop = configFile.get(cat, "slimeIslandsOnlyGenerateInSurfaceWorlds", slimeIslandsOnlyGenerateInSurfaceWorlds);

--- a/src/main/java/slimeknights/tconstruct/world/worldgen/SlimeIslandGenerator.java
+++ b/src/main/java/slimeknights/tconstruct/world/worldgen/SlimeIslandGenerator.java
@@ -103,12 +103,12 @@ public class SlimeIslandGenerator implements IWorldGenerator {
   }
 
   protected boolean shouldGenerateInDimension(int id) {
-    for(int dim : Config.slimeIslandBlacklist) {
+    for(int dim : Config.slimeIslandDimensions) {
       if(dim == id) {
-        return false;
+        return !Config.slimeIslandDimensionsIsBlacklist;
       }
     }
-    return true;
+    return Config.slimeIslandDimensionsIsBlacklist;
   }
 
   @Override


### PR DESCRIPTION
This change allows the user to toggle whether the list of slime island
dimension identifiers represents a blacklist or a whitelist. This allows
users with a large number of (possibly generated) dimensions to limit
the dimensions in which slime island generation takes place to a smaller
number without manually enumerating each one.

The following changes to the mod configuration options have been made:

 - `slimeIslandBlacklist` has been renamed to `slimeIslandDimensions`
 - `slimeIslandDimensionsIsBlacklist` has been added

`slimeIslandDimensions` describes the list of dimensions in which slime
island generation will be whitelisted/blacklisted and defaults to the
old default value of `slimeIslandBlacklist`, which was `-1` and `1` (the
Nether and the End).

`slimeIslandDimensionsIsBlacklist` describes whether
`slimeIslandDimensions` represents a blacklist or a whitelist, and
defaults to `true` (blacklist). This maintains backwards compatibility
with the previous behaviour.

Resolves #3132, resolves #3519, resolves #3831 and resolves #3933.