### PR TITLE
1.12 Fixed 'slimeIslandsOnlyGenerateInSurfaceWorlds' config option

### DIFF
--- a/src/main/java/slimeknights/tconstruct/common/config/Config.java
+++ b/src/main/java/slimeknights/tconstruct/common/config/Config.java
@@ -277,7 +277,7 @@ public final class Config {
       propOrder.add(prop.getName());
 
       prop = configFile.get(cat, "slimeIslandsOnlyGenerateInSurfaceWorlds", slimeIslandsOnlyGenerateInSurfaceWorlds);
-      prop.setComment("If true, slime islands wont generate in dimensions which aren't of type surface. This means they wont generate in modded cave dimensions like the deep dark.");
+      prop.setComment("If true, slime islands only generate in dimensions which are of type surface. This means they won't generate in modded cave dimensions like the deep dark.");
       slimeIslandsOnlyGenerateInSurfaceWorlds = prop.getBoolean();
       propOrder.add(prop.getName());
 

--- a/src/main/java/slimeknights/tconstruct/common/config/Config.java
+++ b/src/main/java/slimeknights/tconstruct/common/config/Config.java
@@ -277,7 +277,7 @@ public final class Config {
       propOrder.add(prop.getName());
 
       prop = configFile.get(cat, "slimeIslandsOnlyGenerateInSurfaceWorlds", slimeIslandsOnlyGenerateInSurfaceWorlds);
-      prop.setComment("If true, slime islands only generate in dimensions which are of type surface. This means they won't generate in modded cave dimensions like the deep dark.");
+      prop.setComment("If false, slime islands only generate in dimensions which are of type surface. This means they won't generate in modded cave dimensions like the Deep Dark. Note that the name of this property is inverted: It must be set to false to prevent slime islands from generating in non-surface dimensions.");
       slimeIslandsOnlyGenerateInSurfaceWorlds = prop.getBoolean();
       propOrder.add(prop.getName());
 

--- a/src/main/java/slimeknights/tconstruct/world/worldgen/SlimeIslandGenerator.java
+++ b/src/main/java/slimeknights/tconstruct/world/worldgen/SlimeIslandGenerator.java
@@ -120,7 +120,7 @@ public class SlimeIslandGenerator implements IWorldGenerator {
     if(world.getWorldType() == WorldType.FLAT && !Config.genIslandsInSuperflat) {
       return;
     }
-    if(!Config.slimeIslandsOnlyGenerateInSurfaceWorlds && !world.provider.isSurfaceWorld()) {
+    if(Config.slimeIslandsOnlyGenerateInSurfaceWorlds && !world.provider.isSurfaceWorld()) {
       return;
     }
     // should generate in this dimension?

--- a/src/main/java/slimeknights/tconstruct/world/worldgen/SlimeIslandGenerator.java
+++ b/src/main/java/slimeknights/tconstruct/world/worldgen/SlimeIslandGenerator.java
@@ -120,7 +120,7 @@ public class SlimeIslandGenerator implements IWorldGenerator {
     if(world.getWorldType() == WorldType.FLAT && !Config.genIslandsInSuperflat) {
       return;
     }
-    if(Config.slimeIslandsOnlyGenerateInSurfaceWorlds && !world.provider.isSurfaceWorld()) {
+    if(!Config.slimeIslandsOnlyGenerateInSurfaceWorlds && !world.provider.isSurfaceWorld()) {
       return;
     }
     // should generate in this dimension?


### PR DESCRIPTION
The 'slimeIslandsOnlyGenerateInSurfaceWorlds' config option was inverted in the code: to make slime islands only generate in surface worlds, 'slimeIslandsOnlyGenerateInSurfaceWorlds' had to be set to false.