### PR TITLE
Add minecraft:impermeable tag to clear class, fixes #4412

### DIFF
--- a/src/generated/resources/data/minecraft/tags/blocks/impermeable.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/impermeable.json
@@ -1,0 +1,22 @@
+{
+  "replace": false,
+  "values": [
+    "tconstruct:clear_glass",
+    "tconstruct:white_clear_stained_glass",
+    "tconstruct:orange_clear_stained_glass",
+    "tconstruct:magenta_clear_stained_glass",
+    "tconstruct:light_blue_clear_stained_glass",
+    "tconstruct:yellow_clear_stained_glass",
+    "tconstruct:lime_clear_stained_glass",
+    "tconstruct:pink_clear_stained_glass",
+    "tconstruct:gray_clear_stained_glass",
+    "tconstruct:light_gray_clear_stained_glass",
+    "tconstruct:cyan_clear_stained_glass",
+    "tconstruct:purple_clear_stained_glass",
+    "tconstruct:blue_clear_stained_glass",
+    "tconstruct:brown_clear_stained_glass",
+    "tconstruct:green_clear_stained_glass",
+    "tconstruct:red_clear_stained_glass",
+    "tconstruct:black_clear_stained_glass"
+  ]
+}


### PR DESCRIPTION
This commit adds the minecraft:impermeable tag to the variants of clear class, which puts them in line with vanilla glass. This fixes bug #4412.

The following is a screenshot demonstrating the fix. No particle effects from the water can be seen dripping from the bottom of the glass after this change.

![2021-04-28_21 06 42](https://user-images.githubusercontent.com/2759895/116466112-03dedd80-a866-11eb-995c-b813c1fdb1a3.png)
