### PR TITLE
Add minecraft:impermeable tag to glass blocks, fixes #4412

### DIFF
--- a/src/generated/resources/data/minecraft/tags/blocks/impermeable.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/impermeable.json
@@ -1,0 +1,24 @@
+{
+  "replace": false,
+  "values": [
+    "tconstruct:clear_glass",
+    "tconstruct:soul_glass",
+    "tconstruct:seared_glass",
+    "tconstruct:white_clear_stained_glass",
+    "tconstruct:orange_clear_stained_glass",
+    "tconstruct:magenta_clear_stained_glass",
+    "tconstruct:light_blue_clear_stained_glass",
+    "tconstruct:yellow_clear_stained_glass",
+    "tconstruct:lime_clear_stained_glass",
+    "tconstruct:pink_clear_stained_glass",
+    "tconstruct:gray_clear_stained_glass",
+    "tconstruct:light_gray_clear_stained_glass",
+    "tconstruct:cyan_clear_stained_glass",
+    "tconstruct:purple_clear_stained_glass",
+    "tconstruct:blue_clear_stained_glass",
+    "tconstruct:brown_clear_stained_glass",
+    "tconstruct:green_clear_stained_glass",
+    "tconstruct:red_clear_stained_glass",
+    "tconstruct:black_clear_stained_glass"
+  ]
+}

--- a/src/main/java/slimeknights/tconstruct/common/data/tags/TConstructBlockTagsProvider.java
+++ b/src/main/java/slimeknights/tconstruct/common/data/tags/TConstructBlockTagsProvider.java
@@ -74,6 +74,17 @@ public class TConstructBlockTagsProvider extends BlockTagsProvider {
     this.getOrCreateBuilder(BlockTags.SOUL_SPEED_BLOCKS).add(TinkerCommons.soulGlass.get(), TinkerCommons.soulGlassPane.get());
     this.getOrCreateBuilder(BlockTags.SOUL_FIRE_BASE_BLOCKS).add(TinkerCommons.soulGlass.get());
 
+    // impermeable blocks
+    this.getOrCreateBuilder(BlockTags.IMPERMEABLE)
+      .add(TinkerCommons.clearGlass.get())
+      .add(TinkerCommons.soulGlass.get())
+      .add(TinkerSmeltery.searedGlass.get());
+    for (DyeColor color : DyeColor.values()) {
+      ResourceLocation key = new ResourceLocation("tconstruct", color.getTranslationKey() + "_clear_stained_glass");
+      Block block = ForgeRegistries.BLOCKS.getValue(key);
+      getOrCreateBuilder(BlockTags.IMPERMEABLE).add(block);
+    }
+
     TagsProvider.Builder<Block> builder = this.getOrCreateBuilder(TinkerTags.Blocks.ANVIL_METAL)
         // tier 3
         .addTag(TinkerMaterials.slimesteel.getBlockTag())


### PR DESCRIPTION
This commit adds the minecraft:impermeable tag to the various glass blocks added by Tinkers. This puts the glass variants in line with vanilla glass, preventing fluids from "dripping" through the block. This fixes bug #4412.

This is attempt #2, this time using generators! I have included the output JSON file, which was generated using the Gradle runData command.

Note: there were a bunch of other JSON files created or modified, but I have only included the one that relates to this commit.

![2021-05-03_16 24 23](https://user-images.githubusercontent.com/2759895/116897452-2d648400-ac2d-11eb-964d-ca407b4d2c51.png)
