### PR TITLE
Fix some grammar, spelling, and capitalization errors in en_us.lang

### DIFF
--- a/src/main/resources/assets/tconstruct/lang/en_us.json
+++ b/src/main/resources/assets/tconstruct/lang/en_us.json
@@ -162,7 +162,7 @@
     "item.tconstruct.puny_smelting": "Puny Smelting",
     "item.tconstruct.puny_smelting.tooltip": "Smelting and casting guidebook for beginners\nby Thruul M'Gon",
     "item.tconstruct.mighty_smelting": "Mighty Smelting",
-    "item.tconstruct.mighty_smelting.tooltip": "textbook for mastery of melting, casting, and alloying\nby Thruul M'Gon",
+    "item.tconstruct.mighty_smelting.tooltip": "Textbook for mastery of melting, casting, and alloying\nby Thruul M'Gon",
 
     "item.tconstruct.sky_slime_ball": "Skyslime Ball",
     "item.tconstruct.ender_slime_ball": "Enderslime Ball",
@@ -735,7 +735,7 @@
     "item.tconstruct.scythe.description": "The Scythe is a broad reaping tool, mowing down plants in a wide area.\nRight Click: Harvest and replant crops",
     
     "item.tconstruct.broad_sword.description": "The Broadsword is a universal weapon. Sweep attacks keep enemy hordes at bay.\nAlso good against cobwebs!",
-    "item.tconstruct.cleaver.description": "The Cleaver is a weapon for a smeltery master. High range attacks keep cut though the toughest of foes.",
+    "item.tconstruct.cleaver.description": "The Cleaver is a weapon for a smeltery master. High-range attacks keep cutting - even through the toughest of foes.",
  
  
     "_comment": "Tinkers Smeltery",


### PR DESCRIPTION
Capitalizes the first letter in Mighty Smelting's description, and fixes up the Tinker's Anvil description for the Cleaver. I'll probably do a more in-depth look at en_us.lang in the future when I get a longer period to work on it, I just did a cursory scroll-down this time around.

I did make sure the Cleaver description didn't escape any bounds on multiple different resolutions and all four GUI scales before I submitted this pull request.