### PR TITLE
Rename molten blaze to blazing blood

### DIFF
--- a/src/main/resources/assets/tconstruct/lang/en_us.json
+++ b/src/main/resources/assets/tconstruct/lang/en_us.json
@@ -355,10 +355,10 @@
 
     "fluid.tconstruct.milk": "Milk",
 
-    "block.tconstruct.molten_blaze_fluid": "Molten Blaze",
-    "fluid.tconstruct.molten_blaze": "Molten Blaze",
-    "fluid.tconstruct.flowing_molten_blaze": "Flowing Molten Blaze",
-    "item.tconstruct.molten_blaze_bucket": "Molten Blaze Bucket",
+    "block.tconstruct.molten_blaze_fluid": "Blazing Blood",
+    "fluid.tconstruct.molten_blaze": "Blazing Blood",
+    "fluid.tconstruct.flowing_molten_blaze": "Flowing Blazing Blood",
+    "item.tconstruct.molten_blaze_bucket": "Blazing Blood Bucket",
     
     "_comment": "Slime",
 


### PR DESCRIPTION
Molten blaze implies that blazes and their parts can be melted. Showing the liquid as blood should make this clearer