### PR TITLE
Added more modded Alloys to the anvil_metal tag

### DIFF
--- a/src/generated/resources/data/tconstruct/tags/items/anvil_metal.json
+++ b/src/generated/resources/data/tconstruct/tags/items/anvil_metal.json
@@ -36,6 +36,50 @@
     {
       "id": "#forge:storage_blocks/steel",
       "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/refined_obsidian",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/refined_glowstone",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/alfsteel",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/energized_steel",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/enderium",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/lumium",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/signalum",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/arcane_gold",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/terminite",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/aeternium",
+      "required": false
+    },
+    {
+      "id": "#forge:storage_blocks/terrasteel",
+      "required": false
     }
   ]
 }


### PR DESCRIPTION
This PR updates the `tconstruct:anvil_metal` tag to include all alloys available in the modpack Enigmatica 6.

Full disclosure: I have not compiled the mod and verified that this PR works, due to it being a simple json change.