### PR TITLE
Add usage information to slurping modifier

### DIFF
--- a/src/main/resources/assets/tconstruct/book/encyclopedia/en_us/abilities/armor/slurping.json
+++ b/src/main/resources/assets/tconstruct/book/encyclopedia/en_us/abilities/armor/slurping.json
@@ -5,7 +5,7 @@
       "text": "Allows drinking fluid containing in the helmet to perform effects using the helmet keybind, mirroring effects from spilling."
     },
     {
-      "text": "Effects may include lighting yourself on fire, potion effects such as jump boost, or clearing status effects like milk.", "paragraph": true
+      "text": "Effects may include lighting yourself on fire, potion effects such as jump boost, or clearing status effects like milk. Fill by clicking on a tank.", "paragraph": true
     }
   ],
   "more_text_space": true,


### PR DESCRIPTION
The manual is very clear on what this effect does, but it is not clear to a new player how to fill the helmet.

I may have been a bit distracted, but had to come and look at the code to understand this. I think it should be part of the in-game documentation.