### PR TITLE
TinkerTabsScreen rework

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
@@ -3,31 +3,21 @@ package slimeknights.tconstruct.tables.client.inventory;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.Rect2i;
-import net.minecraft.client.resources.sounds.SimpleSoundInstance;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
-import org.apache.commons.lang3.tuple.Pair;
 import slimeknights.mantle.client.screen.ElementScreen;
 import slimeknights.mantle.client.screen.MultiModuleScreen;
 import slimeknights.tconstruct.TConstruct;
-import slimeknights.tconstruct.common.network.TinkerNetwork;
 import slimeknights.tconstruct.library.client.Icons;
-import slimeknights.tconstruct.tables.block.ITabbedBlock;
 import slimeknights.tconstruct.tables.client.inventory.module.SideInventoryScreen;
 import slimeknights.tconstruct.tables.client.inventory.widget.TinkerTabsWidget;
 import slimeknights.tconstruct.tables.menu.TabbedContainerMenu;
 import slimeknights.tconstruct.tables.menu.module.SideInventoryContainer;
-import slimeknights.tconstruct.tables.network.StationTabPacket;
 
 import java.util.List;
 
@@ -50,24 +40,8 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
   @Override
   protected void init() {
     super.init();
-    TinkerTabsWidget.Builder tabsBuilder = new TinkerTabsWidget.Builder();
 
-    if (this.tile != null) {
-      Level world = this.tile.getLevel();
-
-      if (world != null) {
-        for (Pair<BlockPos, BlockState> pair : container.stationBlocks) {
-          BlockState state = pair.getRight();
-          BlockPos blockPos = pair.getLeft();
-          ItemStack stack = state.getBlock().getCloneItemStack(state, null, world, blockPos, this.getMinecraft().player);
-          tabsBuilder.addTab(stack, blockPos);
-        }
-      }
-    }
-
-    this.tabsScreen = addRenderableWidget(new TinkerTabsWidget(this, tabsBuilder));
-    // preselect the correct tab
-    tabsScreen.selectTabForPos(this.tile != null ? this.tile.getBlockPos() : null);
+    this.tabsScreen = addRenderableWidget(new TinkerTabsWidget(this));
   }
 
   public TILE getTileEntity() {
@@ -85,26 +59,6 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
     }
 
     this.drawIcon(matrices, slot, element);
-  }
-
-  public void onTabSelection(BlockPos pos) {
-
-    Level world = this.tile.getLevel();
-
-    if (world == null) {
-      return;
-    }
-
-    BlockState state = world.getBlockState(pos);
-
-    if (state.getBlock() instanceof ITabbedBlock) {
-//      BlockEntity te = this.tile.getLevel().getBlockEntity(pos);
-      TinkerNetwork.getInstance().sendToServer(new StationTabPacket(pos));
-
-      // sound!
-      assert this.minecraft != null;
-      this.minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
-    }
   }
 
   public void error(Component message) {

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
@@ -24,7 +24,7 @@ import slimeknights.tconstruct.common.network.TinkerNetwork;
 import slimeknights.tconstruct.library.client.Icons;
 import slimeknights.tconstruct.tables.block.ITabbedBlock;
 import slimeknights.tconstruct.tables.client.inventory.module.SideInventoryScreen;
-import slimeknights.tconstruct.tables.client.inventory.module.TinkerTabsScreen;
+import slimeknights.tconstruct.tables.client.inventory.widget.TinkerTabsWidget;
 import slimeknights.tconstruct.tables.menu.TabbedContainerMenu;
 import slimeknights.tconstruct.tables.menu.module.SideInventoryContainer;
 import slimeknights.tconstruct.tables.network.StationTabPacket;
@@ -39,7 +39,7 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
 
   protected final TILE tile;
   protected final CONTAINER container;
-  protected TinkerTabsScreen tabsScreen;
+  protected TinkerTabsWidget tabsScreen;
 
   public BaseTabbedScreen(CONTAINER container, Inventory playerInventory, Component title) {
     super(container, playerInventory, title);
@@ -50,7 +50,7 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
   @Override
   protected void init() {
     super.init();
-    this.tabsScreen = addRenderableWidget(new TinkerTabsScreen(this));
+    this.tabsScreen = addRenderableWidget(new TinkerTabsWidget(this));
 
     if (this.tile != null) {
       Level world = this.tile.getLevel();

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
@@ -50,7 +50,7 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
   @Override
   protected void init() {
     super.init();
-    this.tabsScreen = addRenderableWidget(new TinkerTabsWidget(this));
+    TinkerTabsWidget.Builder tabsBuilder = new TinkerTabsWidget.Builder();
 
     if (this.tile != null) {
       Level world = this.tile.getLevel();
@@ -60,13 +60,14 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
           BlockState state = pair.getRight();
           BlockPos blockPos = pair.getLeft();
           ItemStack stack = state.getBlock().getCloneItemStack(state, null, world, blockPos, this.getMinecraft().player);
-          this.tabsScreen.addTab(stack, blockPos);
+          tabsBuilder.addTab(stack, blockPos);
         }
       }
-
-      // preselect the correct tab
-      tabsScreen.selectTabForPos(this.tile.getBlockPos());
     }
+
+    this.tabsScreen = addRenderableWidget(new TinkerTabsWidget(this, tabsBuilder));
+    // preselect the correct tab
+    tabsScreen.selectTabForPos(this.tile != null ? this.tile.getBlockPos() : null);
   }
 
   public TILE getTileEntity() {

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
@@ -65,11 +65,7 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
       }
 
       // preselect the correct tab
-      for (int i = 0; i < this.tabsScreen.tabData.size(); i++) {
-        if (this.tabsScreen.tabData.get(i).equals(this.tile.getBlockPos())) {
-          this.tabsScreen.tabs.selected = i;
-        }
-      }
+      tabsScreen.selectTabForPos(this.tile.getBlockPos());
     }
   }
 
@@ -90,10 +86,7 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
     this.drawIcon(matrices, slot, element);
   }
 
-  public void onTabSelection(int selection) {
-    if (selection < 0 || selection > this.tabsScreen.tabData.size()) {
-      return;
-    }
+  public void onTabSelection(BlockPos pos) {
 
     Level world = this.tile.getLevel();
 
@@ -101,7 +94,6 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
       return;
     }
 
-    BlockPos pos = this.tabsScreen.tabData.get(selection);
     BlockState state = world.getBlockState(pos);
 
     if (state.getBlock() instanceof ITabbedBlock) {

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
@@ -19,6 +19,7 @@ import slimeknights.tconstruct.tables.client.inventory.widget.TinkerTabsWidget;
 import slimeknights.tconstruct.tables.menu.TabbedContainerMenu;
 import slimeknights.tconstruct.tables.menu.module.SideInventoryContainer;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends TabbedContainerMenu<TILE>> extends MultiModuleScreen<CONTAINER> {
@@ -27,6 +28,7 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
 
   public static final ResourceLocation BLANK_BACK = TConstruct.getResource("textures/gui/blank.png");
 
+  @Nullable
   protected final TILE tile;
   protected final CONTAINER container;
   protected TinkerTabsWidget tabsScreen;
@@ -44,6 +46,7 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
     this.tabsScreen = addRenderableWidget(new TinkerTabsWidget(this));
   }
 
+  @Nullable
   public TILE getTileEntity() {
     return this.tile;
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/BaseTabbedScreen.java
@@ -30,13 +30,11 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
 
   @Nullable
   protected final TILE tile;
-  protected final CONTAINER container;
   protected TinkerTabsWidget tabsScreen;
 
   public BaseTabbedScreen(CONTAINER container, Inventory playerInventory, Component title) {
     super(container, playerInventory, title);
     this.tile = container.getTile();
-    this.container = container;
   }
 
   @Override
@@ -74,7 +72,7 @@ public class BaseTabbedScreen<TILE extends BlockEntity, CONTAINER extends Tabbed
   }
 
   protected void addChestSideInventory(Inventory inventory) {
-    SideInventoryContainer<?> sideInventoryContainer = container.getSubContainer(SideInventoryContainer.class);
+    SideInventoryContainer<?> sideInventoryContainer = getMenu().getSubContainer(SideInventoryContainer.class);
     if (sideInventoryContainer != null) {
       // no title if missing one
       Component sideInventoryName = TextComponent.EMPTY;

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/PartBuilderScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/PartBuilderScreen.java
@@ -74,8 +74,8 @@ public class PartBuilderScreen extends BaseTabbedScreen<PartBuilderBlockEntity,P
     this.drawRecipesBackground(matrices, mouseX, mouseY, this.cornerX + 51, this.cornerY + 15);
 
     // draw slot icons
-    this.drawIconEmpty(matrices, this.container.getPatternSlot(), Icons.PATTERN);
-    this.drawIconEmpty(matrices, this.container.getInputSlot(), Icons.INGOT);
+    this.drawIconEmpty(matrices, this.getMenu().getPatternSlot(), Icons.PATTERN);
+    this.drawIconEmpty(matrices, this.getMenu().getInputSlot(), Icons.INGOT);
     this.drawRecipesItems(matrices, this.cornerX + 51, this.cornerY + 15);
 
     super.renderBg(matrices, partialTicks, mouseX, mouseY);
@@ -267,10 +267,10 @@ public class PartBuilderScreen extends BaseTabbedScreen<PartBuilderBlockEntity,P
       // handle button click
       int index = getButtonAt((int)mouseX, (int)mouseY);
       assert this.minecraft != null && this.minecraft.player != null;
-      if (index >= 0 && this.container.clickMenuButton(this.minecraft.player, index)) {
+      if (index >= 0 && this.getMenu().clickMenuButton(this.minecraft.player, index)) {
         this.minecraft.getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_STONECUTTER_SELECT_RECIPE, 1.0F));
         assert this.minecraft.gameMode != null;
-        this.minecraft.gameMode.handleInventoryButtonClick(this.container.containerId, index);
+        this.minecraft.gameMode.handleInventoryButtonClick(this.getMenu().containerId, index);
         return true;
       }
 

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -209,7 +209,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
   public void updateLayout() {
     int stillFilled = 0;
     for (int i = 0; i <= maxInputs; i++) {
-      Slot slot = this.container.getSlot(i);
+      Slot slot = this.getMenu().getSlot(i);
       LayoutSlot layoutSlot = currentLayout.getSlot(i);
       if (layoutSlot.isHidden()) {
         // put the position in the still filled line
@@ -237,7 +237,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
       return;
     }
 
-    ItemStack toolStack = this.container.getResult();
+    ItemStack toolStack = this.getMenu().getResult();
 
     // if we have a message, display instead of refreshing the tool
     ValidatedResult currentError = tile.getCurrentError();
@@ -248,7 +248,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
 
     // normal refresh
     if (toolStack.isEmpty()) {
-      toolStack = this.container.getSlot(TINKER_SLOT).getItem();
+      toolStack = this.getMenu().getSlot(TINKER_SLOT).getItem();
     }
 
     // if the contained stack is modifiable, display some information
@@ -321,7 +321,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
         if (!layout.isHidden() && !key.isEmpty()) {
           hasComponents = true;
           MutableComponent textComponent = new TextComponent(" * ");
-          ItemStack slotStack = this.container.getSlot(i).getItem();
+          ItemStack slotStack = this.getMenu().getSlot(i).getItem();
           if (!layout.isValid(slotStack)) {
             textComponent.withStyle(ChatFormatting.RED);
           }
@@ -411,18 +411,18 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     // slot backgrounds, are transparent
     RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 0.28f);
     if (!this.currentLayout.getToolSlot().isHidden()) {
-      Slot slot = this.container.getSlot(TINKER_SLOT);
+      Slot slot = this.getMenu().getSlot(TINKER_SLOT);
       SLOT_BACKGROUND.draw(matrices, x + this.cornerX + slot.x - 1, y + this.cornerY + slot.y - 1);
     }
     for (int i = 0; i < this.activeInputs; i++) {
-      Slot slot = this.container.getSlot(i + INPUT_SLOT);
+      Slot slot = this.getMenu().getSlot(i + INPUT_SLOT);
       SLOT_BACKGROUND.draw(matrices, x + this.cornerX + slot.x - 1, y + this.cornerY + slot.y - 1);
     }
 
     // slot borders, are opaque
     RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
     for (int i = 0; i <= maxInputs; i++) {
-      Slot slot = this.container.getSlot(i);
+      Slot slot = this.getMenu().getSlot(i);
       if ((slot instanceof TinkerStationSlot && (!((TinkerStationSlot) slot).isDormant() || slot.hasItem()))) {
         SLOT_BORDER.draw(matrices, x + this.cornerX + slot.x - 1, y + this.cornerY + slot.y - 1);
       }
@@ -461,7 +461,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     // render slot background icons
     RenderSystem.setShaderTexture(0, InventoryMenu.BLOCK_ATLAS);
     for (int i = 0; i <= maxInputs; i++) {
-      Slot slot = this.container.getSlot(i);
+      Slot slot = this.getMenu().getSlot(i);
       if (!slot.hasItem()) {
         Pattern icon = currentLayout.getSlot(i).getIcon();
         if (icon != null) {

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerTabsScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerTabsScreen.java
@@ -3,39 +3,42 @@ package slimeknights.tconstruct.tables.client.inventory.module;
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.Widget;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.MenuProvider;
-import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import slimeknights.mantle.client.screen.ElementScreen;
-import slimeknights.mantle.client.screen.ModuleScreen;
 import slimeknights.mantle.client.screen.TabsWidget;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.tables.client.inventory.BaseTabbedScreen;
 
 import java.util.List;
 
-public class TinkerTabsScreen extends ModuleScreen {
+public class TinkerTabsScreen implements Widget, GuiEventListener, NarratableEntry {
   private static final ResourceLocation TAB_IMAGE = TConstruct.getResource("textures/gui/icons.png");
   protected static final ElementScreen TAB_ELEMENT = new ElementScreen(0, 18, 26, 30, 256, 256);
   protected static final ElementScreen ACTIVE_TAB_L_ELEMENT = new ElementScreen(26, 18, 26, 30, 256, 256);
   protected static final ElementScreen ACTIVE_TAB_C_ELEMENT = new ElementScreen(52, 18, 26, 30, 256, 256);
   protected static final ElementScreen ACTIVE_TAB_R_ELEMENT = new ElementScreen(78, 18, 26, 30, 256, 256);
 
-  public TabsWidget tabs;
-  public List<BlockPos> tabData;
+  private final int leftPos;
+  private final int topPos;
+  private int imageWidth;
+  private final int imageHeight;
 
-  public final BaseTabbedScreen parent;
+  public final TabsWidget tabs;
+  public final List<BlockPos> tabData = Lists.newArrayList();
+  private final BaseTabbedScreen<?, ?> parent;
 
-  public TinkerTabsScreen(BaseTabbedScreen parent, AbstractContainerMenu container, Inventory playerInventory, Component title) {
-    super(parent, container, playerInventory, title, false, false);
-
+  public TinkerTabsScreen(BaseTabbedScreen<?, ?> parent) {
     this.parent = parent;
 
     this.imageWidth = ACTIVE_TAB_C_ELEMENT.w;
@@ -43,7 +46,11 @@ public class TinkerTabsScreen extends ModuleScreen {
 
     this.tabs = new TabsWidget(parent, TAB_ELEMENT, TAB_ELEMENT, TAB_ELEMENT, ACTIVE_TAB_L_ELEMENT, ACTIVE_TAB_C_ELEMENT, ACTIVE_TAB_R_ELEMENT);
     this.tabs.tabsResource = TAB_IMAGE;
-    this.tabData = Lists.newArrayList();
+
+    this.leftPos = parent.cornerX;
+    this.topPos = parent.cornerY - this.imageHeight;
+
+    this.tabs.setPosition(this.leftPos + 4, this.topPos);
   }
 
   public void addTab(ItemStack icon, BlockPos data) {
@@ -53,47 +60,57 @@ public class TinkerTabsScreen extends ModuleScreen {
   }
 
   @Override
-  public boolean handleMouseClicked(double mouseX, double mouseY, int mouseButton) {
-    this.tabs.handleMouseClicked((int) mouseX, (int) mouseY, mouseButton);
-
-    return super.handleMouseClicked(mouseX, mouseY, mouseButton);
+  public boolean isMouseOver(double mouseX, double mouseY) {
+    return mouseX >= this.leftPos - 1 && mouseX < this.guiRight() + 1 && mouseY >= this.topPos - 1 && mouseY < this.guiBottom() + 1;
   }
 
   @Override
-  public boolean handleMouseReleased(double mouseX, double mouseY, int state) {
+  public boolean mouseClicked(double mouseX, double mouseY, int mouseButton) {
+    if (isMouseOver(mouseX, mouseY)) {
+      this.tabs.handleMouseClicked((int) mouseX, (int) mouseY, mouseButton);
+      return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean mouseReleased(double mouseX, double mouseY, int mouseButton) {
     this.tabs.handleMouseReleased();
 
-    return super.handleMouseReleased(mouseX, mouseY, state);
+    return true;
+  }
+
+  public int guiRight() {
+    return this.leftPos + this.imageWidth;
+  }
+
+  public int guiBottom() {
+    return this.topPos + this.imageHeight;
+  }
+
+  public Rect2i getArea() {
+    return new Rect2i(this.leftPos, this.topPos, this.imageWidth, this.imageHeight);
   }
 
   @Override
-  public void updatePosition(int parentX, int parentY, int parentSizeX, int parentSizeY) {
-    super.updatePosition(parentX, parentY, parentSizeX, parentSizeY);
-
-    // we actually want to be on top of the parent
-    this.leftPos = parentX;
-    this.topPos = parentY - this.imageHeight;
-
-    this.tabs.setPosition(this.leftPos + 4, this.topPos);
-  }
-
-  @Override
-  protected void renderBg(PoseStack matrices, float partialTicks, int mouseX, int mouseY) {
+  public void render(PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
     RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
     int sel = this.tabs.selected;
     this.tabs.update(mouseX, mouseY);
-    this.tabs.draw(matrices);
+    this.tabs.draw(poseStack);
 
     // new selection
     if (sel != this.tabs.selected) {
       this.parent.onTabSelection(this.tabs.selected);
     }
+
+    renterTooltip(poseStack, mouseX, mouseY);
   }
 
-  @Override
-  protected void renderLabels(PoseStack matrices, int mouseX, int mouseY) {
+  protected void renterTooltip(PoseStack poseStack, int mouseX, int mouseY) {
     // highlighted tooltip
-    Level world = Minecraft.getInstance().level;
+    Level world = parent.getMinecraft().level;
     if (this.tabs.highlighted > -1 && world != null) {
       BlockPos pos = this.tabData.get(this.tabs.highlighted);
       Component title;
@@ -104,9 +121,16 @@ public class TinkerTabsScreen extends ModuleScreen {
         title = world.getBlockState(pos).getBlock().getName();
       }
 
-      // the origin has been translated to the top left of this gui rather than the screen, so we have to adjust
       // TODO: renderComponentTooltip->renderTooltip
-      this.renderComponentTooltip(matrices, Lists.newArrayList(title), mouseX - this.leftPos, mouseY - this.topPos);
+      parent.renderComponentTooltip(poseStack, Lists.newArrayList(title), mouseX, mouseY);
     }
   }
+
+  @Override
+  public NarrationPriority narrationPriority() {
+    return NarrationPriority.NONE;
+  }
+
+  @Override
+  public void updateNarration(NarrationElementOutput pNarrationElementOutput) {}
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
@@ -34,8 +34,8 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
   private int imageWidth;
   private final int imageHeight;
 
-  public final TabsWidget tabs;
-  public final List<BlockPos> tabData = Lists.newArrayList();
+  private final TabsWidget tabs;
+  private final List<BlockPos> tabData = Lists.newArrayList();
   private final BaseTabbedScreen<?, ?> parent;
 
   public TinkerTabsWidget(BaseTabbedScreen<?, ?> parent) {
@@ -58,6 +58,15 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
     this.tabs.addTab(icon);
     int count = tabData.size();
     this.imageWidth = count * ACTIVE_TAB_C_ELEMENT.w + (count - 1) * this.tabs.spacing;
+  }
+
+  public void selectTabForPos(BlockPos pos) {
+    for (int i = 0; i < this.tabData.size(); i++) {
+      if (this.tabData.get(i).equals(pos)) {
+        this.tabs.selected = i;
+        return;
+      }
+    }
   }
 
   @Override
@@ -103,7 +112,8 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
 
     // new selection
     if (sel != this.tabs.selected) {
-      this.parent.onTabSelection(this.tabs.selected);
+      if (0 <= this.tabs.selected && this.tabs.selected < this.tabData.size())
+        this.parent.onTabSelection(this.tabData.get(this.tabs.selected));
     }
 
     renterTooltip(poseStack, mouseX, mouseY);

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
@@ -41,22 +41,23 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
   public TinkerTabsWidget(BaseTabbedScreen<?, ?> parent) {
     this.parent = parent;
 
-    this.imageWidth = ACTIVE_TAB_C_ELEMENT.w;
+    this.imageWidth = 0;
     this.imageHeight = ACTIVE_TAB_C_ELEMENT.h;
 
     this.tabs = new TabsWidget(parent, TAB_ELEMENT, TAB_ELEMENT, TAB_ELEMENT, ACTIVE_TAB_L_ELEMENT, ACTIVE_TAB_C_ELEMENT, ACTIVE_TAB_R_ELEMENT);
     this.tabs.tabsResource = TAB_IMAGE;
 
-    this.leftPos = parent.cornerX;
+    this.leftPos = parent.cornerX + 4;
     this.topPos = parent.cornerY - this.imageHeight;
 
-    this.tabs.setPosition(this.leftPos + 4, this.topPos);
+    this.tabs.setPosition(this.leftPos, this.topPos);
   }
 
   public void addTab(ItemStack icon, BlockPos data) {
     this.tabData.add(data);
     this.tabs.addTab(icon);
-    this.imageWidth += ACTIVE_TAB_C_ELEMENT.w + this.tabs.spacing;
+    int count = tabData.size();
+    this.imageWidth = count * ACTIVE_TAB_C_ELEMENT.w + (count - 1) * this.tabs.spacing;
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
@@ -3,23 +3,31 @@ package slimeknights.tconstruct.tables.client.inventory.widget;
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.datafixers.util.Pair;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.apache.commons.lang3.tuple.Pair;
 import slimeknights.mantle.client.screen.ElementScreen;
 import slimeknights.mantle.client.screen.TabsWidget;
 import slimeknights.tconstruct.TConstruct;
+import slimeknights.tconstruct.common.network.TinkerNetwork;
+import slimeknights.tconstruct.tables.block.ITabbedBlock;
 import slimeknights.tconstruct.tables.client.inventory.BaseTabbedScreen;
+import slimeknights.tconstruct.tables.menu.TabbedContainerMenu;
+import slimeknights.tconstruct.tables.network.StationTabPacket;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -40,13 +48,15 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
   private final List<BlockPos> tabData;
   private final BaseTabbedScreen<?, ?> parent;
 
-  public TinkerTabsWidget(BaseTabbedScreen<?, ?> parent, Builder builder) {
+  public TinkerTabsWidget(BaseTabbedScreen<?, ?> parent) {
     this.parent = parent;
+
+    var tabs = collectTabs(this.parent.getMinecraft(), this.parent.getMenu());
 
     this.tabs = new TabsWidget(parent, TAB_ELEMENT, TAB_ELEMENT, TAB_ELEMENT, ACTIVE_TAB_L_ELEMENT, ACTIVE_TAB_C_ELEMENT, ACTIVE_TAB_R_ELEMENT);
     this.tabs.tabsResource = TAB_IMAGE;
 
-    int count = builder.tabs.size();
+    int count = tabs.size();
     this.imageWidth = count * ACTIVE_TAB_C_ELEMENT.w + (count - 1) * this.tabs.spacing;
     this.imageHeight = ACTIVE_TAB_C_ELEMENT.h;
 
@@ -55,18 +65,51 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
 
     this.tabs.setPosition(this.leftPos, this.topPos);
 
-    builder.tabs.stream().map(Pair::getFirst).forEach(this.tabs::addTab);
-    tabData = builder.tabs.stream().map(Pair::getSecond).toList();
+    tabs.stream().map(Pair::getLeft).forEach(this.tabs::addTab);
+    tabData = tabs.stream().map(Pair::getRight).toList();
 
+    // preselect the correct tab
+    BlockEntity tile = this.parent.getTileEntity();
+    selectTabForPos(tile != null ? tile.getBlockPos() : null);
   }
 
-  public void selectTabForPos(@Nullable BlockPos pos) {
+  private static List<Pair<ItemStack, BlockPos>> collectTabs(Minecraft minecraft, TabbedContainerMenu<?> menu) {
+    List<Pair<ItemStack, BlockPos>> tabs = Lists.newArrayList();
+
+    Level level = minecraft.level;
+    if (level != null) {
+      for (Pair<BlockPos, BlockState> pair : menu.stationBlocks) {
+        BlockState state = pair.getRight();
+        BlockPos blockPos = pair.getLeft();
+        ItemStack stack = state.getBlock().getCloneItemStack(state, null, level, blockPos, minecraft.player);
+        tabs.add(Pair.of(stack, blockPos));
+      }
+    }
+    return tabs;
+  }
+
+  private void selectTabForPos(@Nullable BlockPos pos) {
     if (pos != null) {
       for (int i = 0; i < this.tabData.size(); i++) {
         if (this.tabData.get(i).equals(pos)) {
           this.tabs.selected = i;
           return;
         }
+      }
+    }
+  }
+
+  private void onNewTabSelection(BlockPos pos) {
+    assert this.parent.getMinecraft() != null;
+    Level level = this.parent.getMinecraft().level;
+
+    if (level != null) {
+      BlockState state = level.getBlockState(pos);
+      if (state.getBlock() instanceof ITabbedBlock) {
+        TinkerNetwork.getInstance().sendToServer(new StationTabPacket(pos));
+
+        // sound!
+        this.parent.getMinecraft().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_BUTTON_CLICK, 1.0F));
       }
     }
   }
@@ -115,7 +158,7 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
     // new selection
     if (sel != this.tabs.selected) {
       if (0 <= this.tabs.selected && this.tabs.selected < this.tabData.size())
-        this.parent.onTabSelection(this.tabData.get(this.tabs.selected));
+        onNewTabSelection(this.tabData.get(this.tabs.selected));
     }
 
     renterTooltip(poseStack, mouseX, mouseY);
@@ -146,11 +189,4 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
 
   @Override
   public void updateNarration(NarrationElementOutput pNarrationElementOutput) {}
-
-  public static class Builder {
-    private final List<Pair<ItemStack, BlockPos>> tabs = Lists.newArrayList();
-    public void addTab(ItemStack icon, BlockPos data) {
-      tabs.add(new Pair<>(icon, data));
-    }
-  }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
@@ -1,4 +1,4 @@
-package slimeknights.tconstruct.tables.client.inventory.module;
+package slimeknights.tconstruct.tables.client.inventory.widget;
 
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -22,7 +22,7 @@ import slimeknights.tconstruct.tables.client.inventory.BaseTabbedScreen;
 
 import java.util.List;
 
-public class TinkerTabsScreen implements Widget, GuiEventListener, NarratableEntry {
+public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEntry {
   private static final ResourceLocation TAB_IMAGE = TConstruct.getResource("textures/gui/icons.png");
   protected static final ElementScreen TAB_ELEMENT = new ElementScreen(0, 18, 26, 30, 256, 256);
   protected static final ElementScreen ACTIVE_TAB_L_ELEMENT = new ElementScreen(26, 18, 26, 30, 256, 256);
@@ -38,7 +38,7 @@ public class TinkerTabsScreen implements Widget, GuiEventListener, NarratableEnt
   public final List<BlockPos> tabData = Lists.newArrayList();
   private final BaseTabbedScreen<?, ?> parent;
 
-  public TinkerTabsScreen(BaseTabbedScreen<?, ?> parent) {
+  public TinkerTabsWidget(BaseTabbedScreen<?, ?> parent) {
     this.parent = parent;
 
     this.imageWidth = ACTIVE_TAB_C_ELEMENT.w;

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
@@ -186,5 +186,5 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
   }
 
   @Override
-  public void updateNarration(NarrationElementOutput pNarrationElementOutput) {}
+  public void updateNarration(NarrationElementOutput narrationOutput) {}
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerTabsWidget.java
@@ -29,7 +29,6 @@ import slimeknights.tconstruct.tables.client.inventory.BaseTabbedScreen;
 import slimeknights.tconstruct.tables.menu.TabbedContainerMenu;
 import slimeknights.tconstruct.tables.network.StationTabPacket;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEntry {
@@ -69,8 +68,9 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
     tabData = tabs.stream().map(Pair::getRight).toList();
 
     // preselect the correct tab
-    BlockEntity tile = this.parent.getTileEntity();
-    selectTabForPos(tile != null ? tile.getBlockPos() : null);
+    BlockEntity blockEntity = this.parent.getTileEntity();
+    if (blockEntity != null)
+      selectTabForPos(blockEntity.getBlockPos());
   }
 
   private static List<Pair<ItemStack, BlockPos>> collectTabs(Minecraft minecraft, TabbedContainerMenu<?> menu) {
@@ -88,13 +88,11 @@ public class TinkerTabsWidget implements Widget, GuiEventListener, NarratableEnt
     return tabs;
   }
 
-  private void selectTabForPos(@Nullable BlockPos pos) {
-    if (pos != null) {
-      for (int i = 0; i < this.tabData.size(); i++) {
-        if (this.tabData.get(i).equals(pos)) {
-          this.tabs.selected = i;
-          return;
-        }
+  private void selectTabForPos(BlockPos pos) {
+    for (int i = 0; i < this.tabData.size(); i++) {
+      if (this.tabData.get(i).equals(pos)) {
+        this.tabs.selected = i;
+        return;
       }
     }
   }


### PR DESCRIPTION
The primary goal of this and some future PRs is to rework certain gui objects that extend `ModuleScreen`, but are ill-fit to do so. Extending `Screen` or `AbstractContainerScreen` are ill-suited for many module screens, as the interface functions (such as `screen.render()` and `screen.mouseClicked()`) and other functionality (container menu slots) appear to be deliberately avoided.
I therefore want to convert several of these gui objects off `ModuleScreen`, to instead be based on interfaces such as `Widget` and `GuiEventListener`. In particular, I am targeting gui objects that extend `ModuleScren`, and by extension `AbstractContainerScreen`, while also not using any slots.

For this PR, I have done so for `TinkerTabsScreen`, now renamed to `TinkerTabsWidget`.
Effects of this are:
- The class no longer uses any inheritance to function. Because it no longer extends `AbstractContainerScreen` or `Screen`, it will no longer be treated as a screen by other mods. For example, the tabs will no longer have an `InitScreenEvent` posted for it.
- It implements `Widget` and `GuiEventListener` and is thus added to the parent screen as a screen widget instead of as a module screen. `NarratableEntry` is also implemented in order to make the tabs usable with `screen.addRenderableWidget()`, however it is set to not have any narration for now.
- The parent class no longer has its size (as defined by `leftPos` and `imageWidth` etc) expanded to include the tabs that normally happens in `MultiModuleScreen.updateSubmodule()`. With how `MultiModuleScreen.render()` works, this will not affect any render functions. After an usage search, I concluded that it was fine outside of that after manually adding the tabs area in `screen.getModuleAreas()` to be used by jei, and checking for the area in `screen.hasClickedOutside()` (both functions in the parent screen). With this, the area considered outside the screen is now more closely fitted to the screen and its tabs.
- Background and and tooltip rendering is now done in the same `render()` call. This is done to fit everything in the `Widget` interface, and because the rendering order wouldn't differ much by doing so (and more importantly, doesn't cause a problem with the tabs). It should not be difficult at all to update the class if we later decide that we need a "render tooltip" interface for some widgets.
- The return values for mouse function calls have changed, and should now be more in line with vanilla, where "true" is returned for handled mouse input, and "false" for unhandled mouse input.
- The priority order for handling mouse input has now shiften. This should be fine as the tabs doesn't overlap with anything else, and should thus not change which gui component that gets to handle the mouse input.

There are also some additional changes that were made on top of this:
- The tabs widget now get recreated during the `screen.init()` call, instead of created in the constructor and getting its position updated in `screen.init()`. This is more inline with how vanilla widgets are handled, and allows us to make the tabs position immutable (which they now also are).
- `TinkerTabsWidget` has now taken over more responsibilities from `BaseTabbedScreen`. Tabs from the container menu is now prepared in the widget, and tab selection is now fully handled by the widget. Following this, a lot more widget fields are now private and immutable.
- In `BaseTabbedScreen`, remove the container field because the same container menu already exists by the same type in `AbstractContainerScreen`. I also added nullable annotations to the tile field and getter to reflect it also being nullable in the container menu.
- Improved accuracy of the size of the tabs widget to be more narrow along the X-axis. For comparison:
![size_before](https://user-images.githubusercontent.com/5451660/164990904-64edf3de-9949-4c30-a1cc-7915d04cdc99.png)
is now narrowed down to
![size_after](https://user-images.githubusercontent.com/5451660/164990915-d6a31187-f9a0-4450-a007-7a2a9fba2607.png)
(Illustrated with `Screen.fill(poseStack, widget.leftPos, widget.topPos, widget.guiRight(), widget.guiBottom(), 0x77FF0000);`)
