### PR TITLE
[1.18] Update to JEI 9.7, make compatible with JEI 10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,8 @@ mantle_version=1.9.25
 mantle_range=1.9.25,)
 
 # Optional compat
-jei_version=9.5.3.153
-jei_range=[9.5.3,)
+jei_version=9.7.1.255
+jei_range=[9.7.0,)
 probe_version=5.1.0
 crt_version=7.1.0.307
 crt_range=[7.1.0.245,)

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/AlloyRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/AlloyRecipeCategory.java
@@ -3,6 +3,7 @@ package slimeknights.tconstruct.plugin.jei;
 import com.mojang.blaze3d.vertex.PoseStack;
 import lombok.Getter;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated.StartDirection;
@@ -41,12 +42,12 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
 
   /** Tooltip for fluid inputs */
   private static final IRecipeTooltipReplacement FLUID_TOOLTIP = (slot, list) ->
-    slot.getDisplayedIngredient(VanillaTypes.FLUID).ifPresent(stack -> FluidTooltipHandler.appendMaterial(stack, list));
+    slot.getDisplayedIngredient(ForgeTypes.FLUID_STACK).ifPresent(stack -> FluidTooltipHandler.appendMaterial(stack, list));
 
   /** Tooltip for fuel display */
   public static final IRecipeTooltipReplacement FUEL_TOOLTIP = (slot, tooltip) -> {
     //noinspection SimplifyOptionalCallChains  Not for int streams
-    slot.getDisplayedIngredient(VanillaTypes.FLUID)
+    slot.getDisplayedIngredient(ForgeTypes.FLUID_STACK)
         .ifPresent(stack -> MeltingFuelHandler.getTemperature(stack.getFluid())
                                               .ifPresent(temperature -> tooltip.add(new TranslatableComponent(KEY_TEMPERATURE, temperature).withStyle(ChatFormatting.GRAY))));
   };
@@ -60,7 +61,7 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
 
   public AlloyRecipeCategory(IGuiHelper helper) {
     this.background = helper.createDrawable(BACKGROUND_LOC, 0, 0, 172, 62);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(TinkerSmeltery.smelteryController));
+    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerSmeltery.smelteryController));
     this.arrow = helper.drawableBuilder(BACKGROUND_LOC, 172, 0, 24, 17).buildAnimated(200, StartDirection.LEFT, false);
     this.tank = helper.createDrawable(BACKGROUND_LOC, 172, 17, 16, 16);
   }
@@ -130,14 +131,14 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
         builder.addSlot(role, fluidX, y)
                .addTooltipCallback(tooltip)
                .setFluidRenderer(maxAmount, false, w, height)
-               .addIngredients(VanillaTypes.FLUID, fluids.get(i));
+               .addIngredients(ForgeTypes.FLUID_STACK, fluids.get(i));
       }
       // for the last, the width is the full remaining width
       int fluidX = x + max * w;
       builder.addSlot(role, fluidX, y)
              .addTooltipCallback(tooltip)
              .setFluidRenderer(maxAmount, false, totalWidth - (w * max), height)
-             .addIngredients(VanillaTypes.FLUID, fluids.get(max));
+             .addIngredients(ForgeTypes.FLUID_STACK, fluids.get(max));
     }
     return maxAmount;
   }
@@ -151,13 +152,13 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
     builder.addSlot(RecipeIngredientRole.OUTPUT, 137, 11)
            .addTooltipCallback(FLUID_TOOLTIP)
            .setFluidRenderer(maxAmount, false, 16, 32)
-           .addIngredient(VanillaTypes.FLUID, recipe.getOutput());
+           .addIngredient(ForgeTypes.FLUID_STACK, recipe.getOutput());
 
     // fuel
     builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 94, 43)
            .addTooltipCallback(FUEL_TOOLTIP)
            .setFluidRenderer(1, false, 16, 16)
            .setOverlay(tank, 0, 0)
-           .addIngredients(VanillaTypes.FLUID, MeltingFuelHandler.getUsableFuels(recipe.getTemperature()));
+           .addIngredients(ForgeTypes.FLUID_STACK, MeltingFuelHandler.getUsableFuels(recipe.getTemperature()));
   }
 }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
@@ -5,6 +5,7 @@ import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.RecipeTypes;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.handlers.IGuiContainerHandler;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.ingredients.subtypes.IIngredientSubtypeInterpreter;
@@ -259,12 +260,12 @@ public class JEIPlugin implements IModPlugin {
       }
       return IIngredientSubtypeInterpreter.NONE;
     };
-    registry.registerSubtypeInterpreter(TinkerTables.craftingStation.asItem(), tables);
-    registry.registerSubtypeInterpreter(TinkerTables.partBuilder.asItem(), tables);
-    registry.registerSubtypeInterpreter(TinkerTables.tinkerStation.asItem(), tables);
-    registry.registerSubtypeInterpreter(TinkerTables.tinkersAnvil.asItem(), tables);
-    registry.registerSubtypeInterpreter(TinkerTables.scorchedAnvil.asItem(), tables);
-    registry.registerSubtypeInterpreter(TinkerFluids.potionBucket.asItem(), (stack, context) -> {
+    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.craftingStation.asItem(), tables);
+    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.partBuilder.asItem(), tables);
+    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.tinkerStation.asItem(), tables);
+    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.tinkersAnvil.asItem(), tables);
+    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.scorchedAnvil.asItem(), tables);
+    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerFluids.potionBucket.asItem(), (stack, context) -> {
       if (!stack.hasTag()) {
         return IIngredientSubtypeInterpreter.NONE;
       }
@@ -288,20 +289,20 @@ public class JEIPlugin implements IModPlugin {
 
     // parts
     for (Item item : getTag(TinkerTags.Items.TOOL_PARTS)) {
-      registry.registerSubtypeInterpreter(item, toolPartInterpreter);
+      registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, item, toolPartInterpreter);
     }
 
     // tools
     Item slimeskull = TinkerTools.slimesuit.get(ArmorSlotType.HELMET);
-    registry.registerSubtypeInterpreter(slimeskull, ToolSubtypeInterpreter.ALWAYS);
+    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, slimeskull, ToolSubtypeInterpreter.ALWAYS);
     for (Item item : getTag(TinkerTags.Items.MULTIPART_TOOL)) {
       if (item != slimeskull) {
-        registry.registerSubtypeInterpreter(item, ToolSubtypeInterpreter.INGREDIENT);
+        registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, item, ToolSubtypeInterpreter.INGREDIENT);
       }
     }
 
-    registry.registerSubtypeInterpreter(TinkerSmeltery.copperCan.get(), (stack, context) -> CopperCanItem.getSubtype(stack));
-    registry.registerSubtypeInterpreter(TinkerModifiers.creativeSlotItem.get(), (stack, context) -> {
+    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.copperCan.get(), (stack, context) -> CopperCanItem.getSubtype(stack));
+    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerModifiers.creativeSlotItem.get(), (stack, context) -> {
       SlotType slotType = CreativeSlotItem.getSlot(stack);
       return slotType != null ? slotType.getName() : "";
     });
@@ -326,8 +327,8 @@ public class JEIPlugin implements IModPlugin {
    * @param bucket   Fluid bucket to remove
    */
   private static void removeFluid(IIngredientManager manager, Fluid fluid, Item bucket) {
-    manager.removeIngredientsAtRuntime(VanillaTypes.FLUID, Collections.singleton(new FluidStack(fluid, FluidAttributes.BUCKET_VOLUME)));
-    manager.removeIngredientsAtRuntime(VanillaTypes.ITEM, Collections.singleton(new ItemStack(bucket)));
+    manager.removeIngredientsAtRuntime(ForgeTypes.FLUID_STACK, Collections.singleton(new FluidStack(fluid, FluidAttributes.BUCKET_VOLUME)));
+    manager.removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK, Collections.singleton(new ItemStack(bucket)));
   }
 
   /** Helper to get an item tag */
@@ -350,7 +351,7 @@ public class JEIPlugin implements IModPlugin {
   private static void optionalItem(IIngredientManager manager, ItemLike item, String tagName) {
     ITag<Item> tag = getTag(new ResourceLocation("forge", tagName));
     if (tag.isEmpty()) {
-      manager.removeIngredientsAtRuntime(VanillaTypes.ITEM, Collections.singletonList(new ItemStack(item)));
+      manager.removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK, Collections.singletonList(new ItemStack(item)));
     }
   }
 
@@ -362,7 +363,7 @@ public class JEIPlugin implements IModPlugin {
   private static void optionalCast(IIngredientManager manager, CastItemObject cast) {
     ITag<Item> tag = getTag(new ResourceLocation("forge", cast.getName().getPath() + "s"));
     if (tag.isEmpty()) {
-      manager.removeIngredientsAtRuntime(VanillaTypes.ITEM, cast.values().stream().map(ItemStack::new).collect(Collectors.toList()));
+      manager.removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK, cast.values().stream().map(ItemStack::new).collect(Collectors.toList()));
     }
   }
 

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/MoldingRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/MoldingRecipeCategory.java
@@ -39,7 +39,7 @@ public class MoldingRecipeCategory implements IRecipeCategory<MoldingRecipe> {
   private final IDrawable table, basin, downArrow, upArrow;
   public MoldingRecipeCategory(IGuiHelper helper) {
     this.background = helper.createDrawable(BACKGROUND_LOC, 0, 55, 70, 57);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(TinkerSmeltery.blankSandCast.get()));
+    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerSmeltery.blankSandCast.get()));
     this.table = helper.createDrawable(BACKGROUND_LOC, 117, 0, 16, 16);
     this.basin = helper.createDrawable(BACKGROUND_LOC, 117, 16, 16, 16);
     this.downArrow = helper.createDrawable(BACKGROUND_LOC, 70, 55, 6, 6);

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/casting/AbstractCastingCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/casting/AbstractCastingCategory.java
@@ -6,6 +6,7 @@ import com.google.common.cache.LoadingCache;
 import com.mojang.blaze3d.vertex.PoseStack;
 import lombok.Getter;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -53,7 +54,7 @@ public abstract class AbstractCastingCategory implements IRecipeCategory<IDispla
 
   protected AbstractCastingCategory(IGuiHelper guiHelper, Block icon, IDrawable block) {
     this.background = guiHelper.createDrawable(BACKGROUND_LOC, 0, 0, 117, 54);
-    this.icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(icon));
+    this.icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(icon));
     this.tankOverlay = guiHelper.createDrawable(BACKGROUND_LOC, 133, 0, 32, 32);
     this.castConsumed = guiHelper.createDrawable(BACKGROUND_LOC, 141, 32, 13, 11);
     this.castKept = guiHelper.createDrawable(BACKGROUND_LOC, 141, 43, 13, 11);
@@ -116,7 +117,7 @@ public abstract class AbstractCastingCategory implements IRecipeCategory<IDispla
            .addTooltipCallback(this)
            .setFluidRenderer(capacity, false, 32, 32)
            .setOverlay(tankOverlay, 0, 0)
-           .addIngredients(VanillaTypes.FLUID, recipe.getFluids());
+           .addIngredients(ForgeTypes.FLUID_STACK, recipe.getFluids());
     // pouring fluid
     int h = 11;
     if (!recipe.hasCast()) {
@@ -125,11 +126,11 @@ public abstract class AbstractCastingCategory implements IRecipeCategory<IDispla
     builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 43, 8)
            .addTooltipCallback(this)
            .setFluidRenderer(1, false, 6, h)
-           .addIngredients(VanillaTypes.FLUID, recipe.getFluids());
+           .addIngredients(ForgeTypes.FLUID_STACK, recipe.getFluids());
   }
 
   @Override
   public void addMiddleLines(IRecipeSlotView slot, List<Component> list) {
-    slot.getDisplayedIngredient(VanillaTypes.FLUID).ifPresent(stack -> FluidTooltipHandler.appendMaterial(stack, list));
+    slot.getDisplayedIngredient(ForgeTypes.FLUID_STACK).ifPresent(stack -> FluidTooltipHandler.appendMaterial(stack, list));
   }
 }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/entity/EntityIngredientHelper.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/entity/EntityIngredientHelper.java
@@ -85,7 +85,7 @@ public class EntityIngredientHelper implements IIngredientHelper<EntityType> {
 
   /** Applies the item focuses to the list of entities */
   public static List<EntityType> applyFocus(RecipeIngredientRole role, List<EntityType> displayInputs, IFocusGroup focuses) {
-    return focuses.getFocuses(VanillaTypes.ITEM)
+    return focuses.getFocuses(VanillaTypes.ITEM_STACK)
                   .filter(focus -> focus.getRole() == role)
                   .map(focus -> focus.getTypedValue().getIngredient().getItem())
                   .filter(item -> item instanceof SpawnEggItem)

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/entity/EntityMeltingRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/entity/EntityMeltingRecipeCategory.java
@@ -4,7 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import lombok.Getter;
-import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated.StartDirection;
@@ -111,14 +111,14 @@ public class EntityMeltingRecipeCategory implements IRecipeCategory<EntityMeltin
     builder.addSlot(RecipeIngredientRole.OUTPUT, 115, 11)
            .setFluidRenderer(FluidValues.INGOT * 2, false, 16, 32)
            .addTooltipCallback(TOOLTIP_MAP.computeIfAbsent(recipe.getDamage(), FluidTooltip::new))
-           .addIngredient(VanillaTypes.FLUID, recipe.getOutput());
+           .addIngredient(ForgeTypes.FLUID_STACK, recipe.getOutput());
 
     // show fuels that are valid for this recipe
     builder.addSlot(RecipeIngredientRole.CATALYST, 75, 43)
            .setFluidRenderer(1, false, 16, 16)
            .setOverlay(tank, 0, 0)
            .addTooltipCallback(IRecipeTooltipReplacement.EMPTY)
-           .addIngredients(VanillaTypes.FLUID, MeltingFuelHandler.getUsableFuels(1));
+           .addIngredients(ForgeTypes.FLUID_STACK, MeltingFuelHandler.getUsableFuels(1));
   }
 
   /** Tooltip for relevant damage on the fluid */
@@ -126,7 +126,7 @@ public class EntityMeltingRecipeCategory implements IRecipeCategory<EntityMeltin
     @Override
     public void addMiddleLines(IRecipeSlotView recipeSlotView, List<Component> list) {
       // add fluid units
-      recipeSlotView.getDisplayedIngredient(VanillaTypes.FLUID).ifPresent(fluid -> FluidTooltipHandler.appendMaterial(fluid, list));
+      recipeSlotView.getDisplayedIngredient(ForgeTypes.FLUID_STACK).ifPresent(fluid -> FluidTooltipHandler.appendMaterial(fluid, list));
       // output rate
       if (damage == 2) {
         list.add(TOOLTIP_PER_HEART);

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/entity/SeveringCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/entity/SeveringCategory.java
@@ -29,7 +29,7 @@ public class SeveringCategory implements IRecipeCategory<SeveringRecipe> {
   private final IDrawable icon;
   public SeveringCategory(IGuiHelper helper) {
     this.background = helper.createDrawable(BACKGROUND_LOC, 0, 78, 100, 38);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM, TinkerTools.cleaver.get().getRenderTool());
+    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, TinkerTools.cleaver.get().getRenderTool());
   }
 
   @SuppressWarnings("removal")

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/melting/AbstractMeltingCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/melting/AbstractMeltingCategory.java
@@ -6,7 +6,7 @@ import com.google.common.cache.LoadingCache;
 import com.mojang.blaze3d.vertex.PoseStack;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
 import mezz.jei.api.gui.drawable.IDrawableAnimated.StartDirection;
@@ -44,7 +44,7 @@ public abstract class AbstractMeltingCategory implements IRecipeCategory<Melting
   /** Tooltip for fuel display */
   public static final IRecipeTooltipReplacement FUEL_TOOLTIP = (slot, tooltip) -> {
     //noinspection SimplifyOptionalCallChains  Not for int streams
-    slot.getDisplayedIngredient(VanillaTypes.FLUID).ifPresent(stack -> {
+    slot.getDisplayedIngredient(ForgeTypes.FLUID_STACK).ifPresent(stack -> {
       MeltingFuelHandler.getTemperature(stack.getFluid()).ifPresent(temperature -> {
         tooltip.add(new TranslatableComponent(KEY_TEMPERATURE, temperature).withStyle(ChatFormatting.GRAY));
         tooltip.add(new TranslatableComponent(KEY_MULTIPLIER, temperature / 1000f).withStyle(ChatFormatting.GRAY));
@@ -124,7 +124,7 @@ public abstract class AbstractMeltingCategory implements IRecipeCategory<Melting
 
     @Override
     public void addMiddleLines(IRecipeSlotView slot, List<Component> list) {
-      slot.getDisplayedIngredient(VanillaTypes.FLUID).ifPresent(stack -> {
+      slot.getDisplayedIngredient(ForgeTypes.FLUID_STACK).ifPresent(stack -> {
         if (appendMaterial(stack, list)) {
           FluidTooltipHandler.appendShift(list);
         }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/melting/FoundryCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/melting/FoundryCategory.java
@@ -3,6 +3,7 @@ package slimeknights.tconstruct.plugin.jei.melting;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.ingredient.IRecipeSlotTooltipCallback;
@@ -38,7 +39,7 @@ public class FoundryCategory extends AbstractMeltingCategory {
 
   public FoundryCategory(IGuiHelper helper) {
     super(helper);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(TinkerSmeltery.foundryController));
+    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerSmeltery.foundryController));
   }
 
   @SuppressWarnings("removal")
@@ -78,7 +79,7 @@ public class FoundryCategory extends AbstractMeltingCategory {
     builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 4, 4)
            .addTooltipCallback(FUEL_TOOLTIP)
            .setFluidRenderer(1, false, 12, 32)
-           .addIngredients(VanillaTypes.FLUID, MeltingFuelHandler.getUsableFuels(recipe.getTemperature()));
+           .addIngredients(ForgeTypes.FLUID_STACK, MeltingFuelHandler.getUsableFuels(recipe.getTemperature()));
   }
 
   /** Adds amounts to outputs and temperatures to fuels */

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/melting/MeltingCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/melting/MeltingCategory.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableStatic;
@@ -59,7 +60,7 @@ public class MeltingCategory extends AbstractMeltingCategory {
 
   public MeltingCategory(IGuiHelper helper) {
     super(helper);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(TinkerSmeltery.searedMelter));
+    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerSmeltery.searedMelter));
     this.solidFuel = helper.drawableBuilder(BACKGROUND_LOC, 164, 0, 18, 20).build();
   }
 
@@ -109,7 +110,7 @@ public class MeltingCategory extends AbstractMeltingCategory {
       .addTooltipCallback(tooltip)
       .setFluidRenderer(FluidValues.METAL_BLOCK, false, 32, 32)
       .setOverlay(tankOverlay, 0, 0)
-      .addIngredient(VanillaTypes.FLUID, recipe.getOutput());
+      .addIngredient(ForgeTypes.FLUID_STACK, recipe.getOutput());
 
     // show fuels that are valid for this recipe
     int fuelHeight = 32;
@@ -125,7 +126,7 @@ public class MeltingCategory extends AbstractMeltingCategory {
     builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 4, 4)
            .addTooltipCallback(FUEL_TOOLTIP)
            .setFluidRenderer(1, false, 12, fuelHeight)
-           .addIngredients(VanillaTypes.FLUID, MeltingFuelHandler.getUsableFuels(recipe.getTemperature()));
+           .addIngredients(ForgeTypes.FLUID_STACK, MeltingFuelHandler.getUsableFuels(recipe.getTemperature()));
   }
 
   /** Adds amounts to outputs and temperatures to fuels */

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/modifiers/ModifierRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/modifiers/ModifierRecipeCategory.java
@@ -68,7 +68,7 @@ public class ModifierRecipeCategory implements IRecipeCategory<IDisplayModifierR
   public ModifierRecipeCategory(IGuiHelper helper) {
     this.maxPrefix = ForgeI18n.getPattern(KEY_MAX);
     this.background = helper.createDrawable(BACKGROUND_LOC, 0, 0, 128, 77);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM, CreativeSlotItem.withSlot(new ItemStack(TinkerModifiers.creativeSlotItem), SlotType.UPGRADE));
+    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, CreativeSlotItem.withSlot(new ItemStack(TinkerModifiers.creativeSlotItem), SlotType.UPGRADE));
     this.slotIcons = new IDrawable[6];
     for (int i = 0; i < 6; i++) {
       slotIcons[i] = helper.createDrawable(BACKGROUND_LOC, 128 + i * 16, 0, 16, 16);
@@ -212,7 +212,7 @@ public class ModifierRecipeCategory implements IRecipeCategory<IDisplayModifierR
 
     // TODO: still needed?
     // if focusing on a tool, filter out other tools
-//    IFocus<ItemStack> focus = layout.getFocus(VanillaTypes.ITEM);
+//    IFocus<ItemStack> focus = layout.getFocus(VanillaTypes.ITEM_STACK);
 //    List<ItemStack> output = recipe.getToolWithModifier();
 //    items.set(-1, output);
 //    if (focus != null) {

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/partbuilder/PartBuilderCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/partbuilder/PartBuilderCategory.java
@@ -38,7 +38,7 @@ public class PartBuilderCategory implements IRecipeCategory<IDisplayPartBuilderR
   private final IDrawable icon;
   public PartBuilderCategory(IGuiHelper helper) {
     this.background = helper.createDrawable(BACKGROUND_LOC, 0, 117, 121, 46);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM, new ItemStack(TinkerTables.partBuilder));
+    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerTables.partBuilder));
   }
 
   @SuppressWarnings("removal")


### PR DESCRIPTION
This updates the minimum JEI version to 9.7, and updates away from using deprecated methods.
These changes maximize compatibility by allowing TConstruct to be forward-compatible with JEI version 10.