### PR TITLE
Side buttons rework

### DIFF
--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -1,5 +1,6 @@
 package slimeknights.tconstruct.tables.client.inventory;
 
+import com.google.common.collect.Lists;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import lombok.Getter;
@@ -191,8 +192,16 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     super.init();
 
     int buttonsStyle = this.maxInputs > 3 ? TinkerStationButtonsWidget.METAL_STYLE : TinkerStationButtonsWidget.WOOD_STYLE;
+
+    List<StationSlotLayout> layouts = Lists.newArrayList();
+    // repair layout
+    layouts.add(this.defaultLayout);
+    // tool layouts
+    layouts.addAll(StationSlotLayoutLoader.getInstance().getSortedSlots().stream()
+      .filter(layout -> layout.getInputSlots().size() <= this.maxInputs).toList());
+
     this.buttonsScreen = new TinkerStationButtonsWidget(this, this.cornerX - TinkerStationButtonsWidget.width(COLUMN_COUNT) - 2,
-      this.cornerY + this.centerBeam.h + this.buttonDecorationTop.h, buttonsStyle);
+      this.cornerY + this.centerBeam.h + this.buttonDecorationTop.h, layouts, buttonsStyle);
 
     this.updateLayout();
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -196,8 +196,6 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     super.init();
 
     this.buttonsScreen.updatePosition(this.cornerX, this.cornerY, this.realWidth, this.realHeight);
-    this.buttonsScreen.getButtons().clear();
-    this.buttonsScreen.updatePosition(this.cornerX, this.cornerY, this.realWidth, this.realHeight);
 
     this.updateLayout();
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -108,7 +108,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
   @Nonnull @Getter
   private final StationSlotLayout defaultLayout;
   /** Currently selected tool */
-  @Nonnull
+  @Nonnull @Getter
   private StationSlotLayout currentLayout;
 
   // components
@@ -203,13 +203,6 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     }
 
     this.updateLayout();
-  }
-
-  @Override
-  public void resize(Minecraft mc, int width, int height) {
-    var selected = this.buttonsScreen.getSelected();
-    super.resize(mc, width, height);
-    this.buttonsScreen.restoreSelected(selected);
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -447,13 +447,11 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     this.rightBeam.draw(matrices, x, y);
 
     // draw the decoration for the buttons
-    for (Widget widget : this.buttonsScreen.getButtons()) {
-      if (widget instanceof SlotButtonItem button) {
-        this.buttonDecorationTop.draw(matrices, button.x, button.y - this.buttonDecorationTop.h);
-        // don't draw the bottom for the buttons in the last row
-        if (button.buttonId < this.buttonsScreen.getButtons().size() - COLUMN_COUNT) {
-          this.buttonDecorationBot.draw(matrices, button.x, button.y + button.getHeight());
-        }
+    for (SlotButtonItem button : this.buttonsScreen.getButtons()) {
+      this.buttonDecorationTop.draw(matrices, button.x, button.y - this.buttonDecorationTop.h);
+      // don't draw the bottom for the buttons in the last row
+      if (button.buttonId < this.buttonsScreen.getButtons().size() - COLUMN_COUNT) {
+        this.buttonDecorationBot.draw(matrices, button.x, button.y + button.getHeight());
       }
     }
 

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -38,7 +38,7 @@ import slimeknights.tconstruct.library.tools.nbt.ToolStack;
 import slimeknights.tconstruct.library.utils.TinkerTooltipFlags;
 import slimeknights.tconstruct.tables.block.entity.table.TinkerStationBlockEntity;
 import slimeknights.tconstruct.tables.client.inventory.module.InfoPanelScreen;
-import slimeknights.tconstruct.tables.client.inventory.module.TinkerStationButtonsWidget;
+import slimeknights.tconstruct.tables.client.inventory.widget.TinkerStationButtonsWidget;
 import slimeknights.tconstruct.tables.client.inventory.widget.SlotButtonItem;
 import slimeknights.tconstruct.tables.menu.TinkerStationContainerMenu;
 import slimeknights.tconstruct.tables.menu.slot.TinkerStationSlot;

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -5,7 +5,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import lombok.Getter;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.network.chat.Component;
@@ -127,8 +126,6 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
   public TinkerStationScreen(TinkerStationContainerMenu container, Inventory playerInventory, Component title) {
     super(container, playerInventory, title);
 
-    this.buttonsScreen = new TinkerStationButtonsWidget(this);
-
     this.tinkerInfo = new InfoPanelScreen(this, container, playerInventory, title);
     this.tinkerInfo.setTextScale(8/9f);
     this.addModule(this.tinkerInfo);
@@ -182,8 +179,6 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     //this.textField.setEnableBackgroundDrawing(false);
     //this.textField.setMaxStringLength(40);
 
-    this.buttonsScreen.xOffset = -2;
-    this.buttonsScreen.yOffset = this.centerBeam.h + this.buttonDecorationTop.h;
     this.tinkerInfo.xOffset = 2;
     this.tinkerInfo.yOffset = this.centerBeam.h + this.panelDecorationL.h;
     this.modifierInfo.xOffset = this.tinkerInfo.xOffset;
@@ -195,9 +190,26 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
 
     super.init();
 
+    this.buttonsScreen = new TinkerStationButtonsWidget(this);
+    this.buttonsScreen.xOffset = -2;
+    this.buttonsScreen.yOffset = this.centerBeam.h + this.buttonDecorationTop.h;
+
     this.buttonsScreen.updatePosition(this.cornerX, this.cornerY, this.realWidth, this.realHeight);
 
+    if (this.maxInputs > 3) {
+      this.buttonsScreen.shiftStyle(TinkerStationButtonsWidget.METAL_STYLE);
+    } else {
+      this.buttonsScreen.shiftStyle(TinkerStationButtonsWidget.WOOD_STYLE);
+    }
+
     this.updateLayout();
+  }
+
+  @Override
+  public void resize(Minecraft mc, int width, int height) {
+    var selected = this.buttonsScreen.getSelected();
+    super.resize(mc, width, height);
+    this.buttonsScreen.restoreSelected(selected);
   }
 
   @Override
@@ -636,8 +648,6 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     this.panelDecorationL = PANEL_SPACE_LEFT.shift(18, 0);
     this.panelDecorationR = PANEL_SPACE_RIGHT.shift(18, 0);
 
-    this.buttonsScreen.shiftStyle(TinkerStationButtonsWidget.WOOD_STYLE);
-
     this.leftBeam = LEFT_BEAM;
     this.rightBeam = RIGHT_BEAM;
     this.centerBeam = CENTER_BEAM;
@@ -651,8 +661,6 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     this.buttonDecorationBot = SLOT_SPACE_BOTTOM.shift(SLOT_SPACE_BOTTOM.w * 2, 0);
     this.panelDecorationL = PANEL_SPACE_LEFT.shift(18 * 2, 0);
     this.panelDecorationR = PANEL_SPACE_RIGHT.shift(18 * 2, 0);
-
-    this.buttonsScreen.shiftStyle(TinkerStationButtonsWidget.METAL_STYLE);
 
     this.leftBeam = LEFT_BEAM.shift(0, LEFT_BEAM.h);
     this.rightBeam = RIGHT_BEAM.shift(0, RIGHT_BEAM.h);

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Widget;
+import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -38,7 +39,7 @@ import slimeknights.tconstruct.library.tools.nbt.ToolStack;
 import slimeknights.tconstruct.library.utils.TinkerTooltipFlags;
 import slimeknights.tconstruct.tables.block.entity.table.TinkerStationBlockEntity;
 import slimeknights.tconstruct.tables.client.inventory.module.InfoPanelScreen;
-import slimeknights.tconstruct.tables.client.inventory.module.TinkerStationButtonsScreen;
+import slimeknights.tconstruct.tables.client.inventory.module.TinkerStationButtonsWidget;
 import slimeknights.tconstruct.tables.client.inventory.widget.SlotButtonItem;
 import slimeknights.tconstruct.tables.menu.TinkerStationContainerMenu;
 import slimeknights.tconstruct.tables.menu.slot.TinkerStationSlot;
@@ -115,7 +116,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
   //protected TextFieldWidget textField;
   protected InfoPanelScreen tinkerInfo;
   protected InfoPanelScreen modifierInfo;
-  protected TinkerStationButtonsScreen buttonsScreen;
+  protected TinkerStationButtonsWidget buttonsScreen;
 
   /** Maximum available slots */
   @Getter
@@ -126,8 +127,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
   public TinkerStationScreen(TinkerStationContainerMenu container, Inventory playerInventory, Component title) {
     super(container, playerInventory, title);
 
-    this.buttonsScreen = new TinkerStationButtonsScreen(this, container, playerInventory, title);
-    this.addModule(this.buttonsScreen);
+    this.buttonsScreen = new TinkerStationButtonsWidget(this);
 
     this.tinkerInfo = new InfoPanelScreen(this, container, playerInventory, title);
     this.tinkerInfo.setTextScale(8/9f);
@@ -194,6 +194,11 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     }
 
     super.init();
+
+    this.buttonsScreen.updatePosition(this.cornerX, this.cornerY, this.realWidth, this.realHeight);
+    this.buttonsScreen.getButtons().clear();
+    this.buttonsScreen.updatePosition(this.cornerX, this.cornerY, this.realWidth, this.realHeight);
+
     this.updateLayout();
   }
 
@@ -473,6 +478,8 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     RenderSystem.enableDepthTest();
 
     super.renderBg(matrices, partialTicks, mouseX, mouseY);
+
+    this.buttonsScreen.render(matrices, mouseX, mouseY, partialTicks);
   }
 
   @Override
@@ -633,7 +640,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     this.panelDecorationL = PANEL_SPACE_LEFT.shift(18, 0);
     this.panelDecorationR = PANEL_SPACE_RIGHT.shift(18, 0);
 
-    this.buttonsScreen.shiftStyle(TinkerStationButtonsScreen.WOOD_STYLE);
+    this.buttonsScreen.shiftStyle(TinkerStationButtonsWidget.WOOD_STYLE);
 
     this.leftBeam = LEFT_BEAM;
     this.rightBeam = RIGHT_BEAM;
@@ -649,7 +656,7 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     this.panelDecorationL = PANEL_SPACE_LEFT.shift(18 * 2, 0);
     this.panelDecorationR = PANEL_SPACE_RIGHT.shift(18 * 2, 0);
 
-    this.buttonsScreen.shiftStyle(TinkerStationButtonsScreen.METAL_STYLE);
+    this.buttonsScreen.shiftStyle(TinkerStationButtonsWidget.METAL_STYLE);
 
     this.leftBeam = LEFT_BEAM.shift(0, LEFT_BEAM.h);
     this.rightBeam = RIGHT_BEAM.shift(0, RIGHT_BEAM.h);
@@ -684,5 +691,18 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     // update the active slots and filter in the container
     // this.container.setToolSelection(layout); TODO: needed?
     TinkerNetwork.getInstance().sendToServer(new TinkerStationSelectionPacket(layout.getName()));
+  }
+
+  @Override
+  public List<Rect2i> getModuleAreas() {
+    List<Rect2i> list = super.getModuleAreas();
+    list.add(this.buttonsScreen.getArea());
+    return list;
+  }
+
+  @Override
+  protected boolean hasClickedOutside(double mouseX, double mouseY, int guiLeft, int guiTop, int mouseButton) {
+    return super.hasClickedOutside(mouseX, mouseY, guiLeft, guiTop, mouseButton)
+      && !this.buttonsScreen.isMouseOver(mouseX, mouseY);
   }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -190,17 +190,12 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
 
     super.init();
 
-    this.buttonsScreen = new TinkerStationButtonsWidget(this);
+    int buttonsStyle = this.maxInputs > 3 ? TinkerStationButtonsWidget.METAL_STYLE : TinkerStationButtonsWidget.WOOD_STYLE;
+    this.buttonsScreen = new TinkerStationButtonsWidget(this, buttonsStyle);
     this.buttonsScreen.xOffset = -2;
     this.buttonsScreen.yOffset = this.centerBeam.h + this.buttonDecorationTop.h;
 
     this.buttonsScreen.updatePosition(this.cornerX, this.cornerY, this.realWidth, this.realHeight);
-
-    if (this.maxInputs > 3) {
-      this.buttonsScreen.shiftStyle(TinkerStationButtonsWidget.METAL_STYLE);
-    } else {
-      this.buttonsScreen.shiftStyle(TinkerStationButtonsWidget.WOOD_STYLE);
-    }
 
     this.updateLayout();
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -191,11 +191,8 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     super.init();
 
     int buttonsStyle = this.maxInputs > 3 ? TinkerStationButtonsWidget.METAL_STYLE : TinkerStationButtonsWidget.WOOD_STYLE;
-    this.buttonsScreen = new TinkerStationButtonsWidget(this, buttonsStyle);
-    this.buttonsScreen.xOffset = -2;
-    this.buttonsScreen.yOffset = this.centerBeam.h + this.buttonDecorationTop.h;
-
-    this.buttonsScreen.updatePosition(this.cornerX, this.cornerY, this.realWidth, this.realHeight);
+    this.buttonsScreen = new TinkerStationButtonsWidget(this, this.cornerX - TinkerStationButtonsWidget.width(COLUMN_COUNT) - 2,
+      this.cornerY + this.centerBeam.h + this.buttonDecorationTop.h, buttonsStyle);
 
     this.updateLayout();
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/TinkerStationScreen.java
@@ -429,11 +429,11 @@ public class TinkerStationScreen extends BaseTabbedScreen<TinkerStationBlockEnti
     }
 
     // sidebar beams
-    x = this.buttonsScreen.leftPos - this.leftBeam.w;
+    x = this.buttonsScreen.getLeftPos() - this.leftBeam.w;
     y = this.cornerY;
     // draw the beams at the top
     x += this.leftBeam.draw(matrices, x, y);
-    x += this.centerBeam.drawScaledX(matrices, x, y, this.buttonsScreen.imageWidth);
+    x += this.centerBeam.drawScaledX(matrices, x, y, this.buttonsScreen.getImageWidth());
     this.rightBeam.draw(matrices, x, y);
 
     x = tinkerInfo.leftPos - this.leftBeam.w;

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
@@ -10,7 +10,7 @@ import slimeknights.mantle.client.screen.MultiModuleScreen;
 
 import java.util.List;
 
-public class SideButtonsWidget implements Widget, GuiEventListener {
+public class SideButtonsWidget<T extends Button> implements Widget, GuiEventListener {
 
   protected final MultiModuleScreen<?> parent;
 
@@ -25,7 +25,7 @@ public class SideButtonsWidget implements Widget, GuiEventListener {
   public int yOffset;
 
   private final int columns;
-  protected final List<Widget> renderables = Lists.newArrayList();
+  protected final List<T> buttons = Lists.newArrayList();
   private Button clickedButton;
   protected int buttonCount = 0;
 
@@ -67,7 +67,7 @@ public class SideButtonsWidget implements Widget, GuiEventListener {
     this.topPos += this.yOffset;
   }
 
-  public void addSideButton(Button button) {
+  public void addSideButton(T button) {
     int rows = (this.buttonCount - 1) / this.columns + 1;
 
     this.imageWidth = button.getWidth() * this.columns + this.spacing * (this.columns - 1);
@@ -84,7 +84,7 @@ public class SideButtonsWidget implements Widget, GuiEventListener {
       button.x += parent.imageWidth;
     }
 
-    this.renderables.add(button);
+    this.buttons.add(button);
     this.buttonCount++;
   }
 
@@ -95,13 +95,10 @@ public class SideButtonsWidget implements Widget, GuiEventListener {
 
   public boolean handleMouseClicked(double mouseX, double mouseY, int mouseButton) {
     if (mouseButton == 0) {
-      for (Widget widget : this.renderables) {
-        if (widget instanceof Button button) {
-
-          if (button.mouseClicked(mouseX, mouseY, mouseButton)) {
-            this.clickedButton = button;
-            return true;
-          }
+      for (T button : this.buttons) {
+        if (button.mouseClicked(mouseX, mouseY, mouseButton)) {
+          this.clickedButton = button;
+          return true;
         }
       }
     }
@@ -121,8 +118,8 @@ public class SideButtonsWidget implements Widget, GuiEventListener {
 
   @Override
   public void render(PoseStack matrices, int mouseX, int mouseY, float partialTicks) {
-    for (Widget widget : this.renderables) {
-      widget.render(matrices, mouseX, mouseY, partialTicks);
+    for (T button : this.buttons) {
+      button.render(matrices, mouseX, mouseY, partialTicks);
     }
   }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 public class SideButtonsWidget<T extends Button> implements Widget, GuiEventListener {
 
+  public static final int SPACING = 4;
+
   protected final MultiModuleScreen<?> parent;
 
   // left or right of the parent
@@ -19,8 +21,8 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
 
   public int leftPos;
   public int topPos;
-  public int imageWidth;
-  public int imageHeight;
+  public final int imageWidth;
+  public final int imageHeight;
   public int xOffset;
   public int yOffset;
 
@@ -28,17 +30,14 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
   protected final List<T> buttons = Lists.newArrayList();
   private Button clickedButton;
 
-  public int spacing = 4;
-
-  public SideButtonsWidget(MultiModuleScreen<?> parent, int columns) {
-    this(parent, columns, false);
-  }
-
-  public SideButtonsWidget(MultiModuleScreen<?> parent, int columns, boolean right) {
+  public SideButtonsWidget(MultiModuleScreen<?> parent, int columns, int rows, int buttonWidth, int buttonHeight, boolean right) {
     this.parent = parent;
     this.right = right;
 
     this.columns = columns;
+
+    this.imageWidth = buttonWidth * columns + SPACING * (columns - 1);
+    this.imageHeight = buttonHeight * rows + SPACING * (rows - 1);
   }
 
   public int guiRight() {
@@ -54,14 +53,6 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
   }
 
   public void updatePosition(int parentX, int parentY, int parentSizeX, int parentSizeY) {
-    if (!this.buttons.isEmpty()) {
-      int rows = (this.buttons.size() - 1) / this.columns + 1;
-      this.imageWidth = this.buttons.get(0).getWidth() * this.columns + this.spacing * (this.columns - 1);
-      this.imageHeight = this.buttons.get(0).getHeight() * rows + this.spacing * (rows - 1);
-    } else {
-      this.imageWidth = this.imageHeight = 0;
-    }
-
 
     if (this.right) {
       this.leftPos = parentX + parentSizeX;
@@ -76,8 +67,8 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
 
     for (int i = 0; i < this.buttons.size(); i++) {
       T button = this.buttons.get(i);
-      int x = (i % columns) * (button.getWidth() + this.spacing);
-      int y = (i / columns) * (button.getHeight() + this.spacing);
+      int x = (i % columns) * (button.getWidth() + SPACING);
+      int y = (i / columns) * (button.getHeight() + SPACING);
       button.x = leftPos + x;
       button.y = topPos + y;
     }
@@ -116,5 +107,9 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
     for (T button : this.buttons) {
       button.render(matrices, mouseX, mouseY, partialTicks);
     }
+  }
+
+  public static int rowsForCount(int columns, int count) {
+    return (count - 1) / columns + 1;
   }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
@@ -3,28 +3,68 @@ package slimeknights.tconstruct.tables.client.inventory.module;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Widget;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import slimeknights.mantle.client.screen.ModuleScreen;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.renderer.Rect2i;
+import org.apache.commons.compress.utils.Lists;
 import slimeknights.mantle.client.screen.MultiModuleScreen;
 
-// TODO: this is raw types
-public class SideButtonsScreen extends ModuleScreen {
+import java.util.List;
+
+public class SideButtonsWidget implements Widget, GuiEventListener {
+
+  protected final MultiModuleScreen<?> parent;
+
+  // left or right of the parent
+  protected final boolean right;
+
+  public int leftPos;
+  public int topPos;
+  public int imageWidth;
+  public int imageHeight;
+  public int xOffset;
+  public int yOffset;
 
   private final int columns;
+  protected final List<Widget> renderables = Lists.newArrayList();
   private Button clickedButton;
   protected int buttonCount = 0;
 
   public int spacing = 4;
 
-  public SideButtonsScreen(MultiModuleScreen parent, AbstractContainerMenu container, Inventory playerInventory, Component title, int columns) {
-    this(parent, container, playerInventory, title, columns, false);
+  public SideButtonsWidget(MultiModuleScreen<?> parent, int columns) {
+    this(parent, columns, false);
   }
 
-  public SideButtonsScreen(MultiModuleScreen parent, AbstractContainerMenu container, Inventory playerInventory, Component title, int columns, boolean right) {
-    super(parent, container, playerInventory, title, right, false);
+  public SideButtonsWidget(MultiModuleScreen<?> parent, int columns, boolean right) {
+    this.parent = parent;
+    this.right = right;
+
     this.columns = columns;
+  }
+
+  public int guiRight() {
+    return this.leftPos + this.imageWidth;
+  }
+
+  public int guiBottom() {
+    return this.topPos + this.imageHeight;
+  }
+
+  public Rect2i getArea() {
+    return new Rect2i(this.leftPos, this.topPos, this.imageWidth, this.imageHeight);
+  }
+
+  public void updatePosition(int parentX, int parentY, int parentSizeX, int parentSizeY) {
+    if (this.right) {
+      this.leftPos = parentX + parentSizeX;
+    } else {
+      this.leftPos = parentX - this.imageWidth;
+    }
+
+    this.topPos = parentY;
+
+    this.leftPos += this.xOffset;
+    this.topPos += this.yOffset;
   }
 
   public void addSideButton(Button button) {
@@ -44,11 +84,15 @@ public class SideButtonsScreen extends ModuleScreen {
       button.x += parent.imageWidth;
     }
 
-    this.addRenderableWidget(button);
+    this.renderables.add(button);
     this.buttonCount++;
   }
 
   @Override
+  public boolean isMouseOver(double mouseX, double mouseY) {
+    return this.leftPos <= mouseX && mouseX < this.guiRight() && this.topPos <= mouseY && mouseY < this.guiBottom();
+  }
+
   public boolean handleMouseClicked(double mouseX, double mouseY, int mouseButton) {
     if (mouseButton == 0) {
       for (Widget widget : this.renderables) {
@@ -65,7 +109,6 @@ public class SideButtonsScreen extends ModuleScreen {
     return false;
   }
 
-  @Override
   public boolean handleMouseReleased(double mouseX, double mouseY, int state) {
     if (clickedButton != null) {
       clickedButton.mouseReleased(mouseX, mouseY, state);
@@ -77,13 +120,9 @@ public class SideButtonsScreen extends ModuleScreen {
   }
 
   @Override
-  protected void renderBg(PoseStack matrices, float partialTicks, int mouseX, int mouseY) {
+  public void render(PoseStack matrices, int mouseX, int mouseY, float partialTicks) {
     for (Widget widget : this.renderables) {
       widget.render(matrices, mouseX, mouseY, partialTicks);
     }
-  }
-
-  @Override
-  protected void renderLabels(PoseStack matrixStack, int x, int y) {
   }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
@@ -16,28 +16,24 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
 
   protected final MultiModuleScreen<?> parent;
 
-  // left or right of the parent
-  protected final boolean right;
-
-  public int leftPos;
-  public int topPos;
+  public final int leftPos;
+  public final int topPos;
   public final int imageWidth;
   public final int imageHeight;
-  public int xOffset;
-  public int yOffset;
 
   private final int columns;
   protected final List<T> buttons = Lists.newArrayList();
   private Button clickedButton;
 
-  public SideButtonsWidget(MultiModuleScreen<?> parent, int columns, int rows, int buttonWidth, int buttonHeight, boolean right) {
+  public SideButtonsWidget(MultiModuleScreen<?> parent, int leftPos, int topPos, int columns, int rows, int buttonWidth, int buttonHeight) {
     this.parent = parent;
-    this.right = right;
 
+    this.leftPos = leftPos;
+    this.topPos = topPos;
     this.columns = columns;
 
-    this.imageWidth = buttonWidth * columns + SPACING * (columns - 1);
-    this.imageHeight = buttonHeight * rows + SPACING * (rows - 1);
+    this.imageWidth = size(columns, buttonWidth);
+    this.imageHeight = size(rows, buttonHeight);
   }
 
   public int guiRight() {
@@ -52,19 +48,7 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
     return new Rect2i(this.leftPos, this.topPos, this.imageWidth, this.imageHeight);
   }
 
-  public void updatePosition(int parentX, int parentY, int parentSizeX, int parentSizeY) {
-
-    if (this.right) {
-      this.leftPos = parentX + parentSizeX;
-    } else {
-      this.leftPos = parentX - this.imageWidth;
-    }
-
-    this.topPos = parentY;
-
-    this.leftPos += this.xOffset;
-    this.topPos += this.yOffset;
-
+  public void setButtonPositions() {
     for (int i = 0; i < this.buttons.size(); i++) {
       T button = this.buttons.get(i);
       int x = (i % columns) * (button.getWidth() + SPACING);
@@ -111,5 +95,9 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
 
   public static int rowsForCount(int columns, int count) {
     return (count - 1) / columns + 1;
+  }
+
+  public static int size(int buttonCount, int buttonSize) {
+    return buttonSize * buttonCount + SPACING * (buttonCount - 1);
   }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/SideButtonsWidget.java
@@ -27,7 +27,6 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
   private final int columns;
   protected final List<T> buttons = Lists.newArrayList();
   private Button clickedButton;
-  protected int buttonCount = 0;
 
   public int spacing = 4;
 
@@ -55,6 +54,15 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
   }
 
   public void updatePosition(int parentX, int parentY, int parentSizeX, int parentSizeY) {
+    if (!this.buttons.isEmpty()) {
+      int rows = (this.buttons.size() - 1) / this.columns + 1;
+      this.imageWidth = this.buttons.get(0).getWidth() * this.columns + this.spacing * (this.columns - 1);
+      this.imageHeight = this.buttons.get(0).getHeight() * rows + this.spacing * (rows - 1);
+    } else {
+      this.imageWidth = this.imageHeight = 0;
+    }
+
+
     if (this.right) {
       this.leftPos = parentX + parentSizeX;
     } else {
@@ -65,27 +73,14 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
 
     this.leftPos += this.xOffset;
     this.topPos += this.yOffset;
-  }
 
-  public void addSideButton(T button) {
-    int rows = (this.buttonCount - 1) / this.columns + 1;
-
-    this.imageWidth = button.getWidth() * this.columns + this.spacing * (this.columns - 1);
-    this.imageHeight = button.getHeight() * rows + this.spacing * (rows - 1);
-
-    int offset = this.buttonCount;
-    int x = (offset % columns) * (button.getWidth() + this.spacing);
-    int y = (offset / columns) * (button.getHeight() + this.spacing);
-
-    button.x = leftPos + x;
-    button.y = topPos + y;
-
-    if (this.right) {
-      button.x += parent.imageWidth;
+    for (int i = 0; i < this.buttons.size(); i++) {
+      T button = this.buttons.get(i);
+      int x = (i % columns) * (button.getWidth() + this.spacing);
+      int y = (i / columns) * (button.getHeight() + this.spacing);
+      button.x = leftPos + x;
+      button.y = topPos + y;
     }
-
-    this.buttons.add(button);
-    this.buttonCount++;
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -1,7 +1,6 @@
 package slimeknights.tconstruct.tables.client.inventory.module;
 
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.Widget;
 import slimeknights.tconstruct.library.client.Icons;
 import slimeknights.tconstruct.library.tools.layout.StationSlotLayout;
 import slimeknights.tconstruct.library.tools.layout.StationSlotLayoutLoader;
@@ -10,7 +9,7 @@ import slimeknights.tconstruct.tables.client.inventory.widget.SlotButtonItem;
 
 import java.util.List;
 
-public class TinkerStationButtonsWidget extends SideButtonsWidget {
+public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem> {
 
   protected final TinkerStationScreen parent;
   protected int selected = 0;
@@ -18,10 +17,8 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget {
 
   /** Logic to run when a button is pressed */
   private final Button.OnPress ON_BUTTON_PRESSED = self -> {
-    for (Widget widget : TinkerStationButtonsWidget.this.renderables) {
-      if (widget instanceof SlotButtonItem) {
-        ((SlotButtonItem) widget).pressed = false;
-      }
+    for (SlotButtonItem button : TinkerStationButtonsWidget.this.buttons) {
+      button.pressed = false;
     }
     if (self instanceof SlotButtonItem slotInformationButton) {
       slotInformationButton.pressed = true;
@@ -73,10 +70,8 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget {
   }
 
   public void shiftStyle(int style) {
-    for (Widget widget : this.renderables) {
-      if (widget instanceof SlotButtonItem) {
-        this.shiftButton((SlotButtonItem) widget, 0, -18);
-      }
+      for (SlotButtonItem button : this.buttons) {
+        this.shiftButton(button, 0, -18);
     }
 
     this.style = style;
@@ -89,7 +84,7 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget {
       Icons.ICONS);
   }
 
-  public List<Widget> getButtons() {
-    return this.renderables;
+  public List<SlotButtonItem> getButtons() {
+    return this.buttons;
   }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -86,4 +86,14 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
   public List<SlotButtonItem> getButtons() {
     return this.buttons;
   }
+
+  public int getSelected() {
+    return this.selected;
+  }
+
+  public void restoreSelected(int selected) {
+    this.buttons.forEach(button -> button.pressed = false);
+    this.buttons.get(selected).pressed = true;
+    this.selected = selected;
+  }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -1,5 +1,6 @@
 package slimeknights.tconstruct.tables.client.inventory.module;
 
+import com.google.common.collect.Lists;
 import net.minecraft.client.gui.components.Button;
 import slimeknights.tconstruct.library.client.Icons;
 import slimeknights.tconstruct.library.tools.layout.StationSlotLayout;
@@ -28,23 +29,21 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
       }
     };
 
-    // repair button
-    SlotButtonItem slotButtonItem = new SlotButtonItem(0, -1, -1, parent.getDefaultLayout(), onButtonPressed);
-    this.addInfoButton(slotButtonItem, style);
-    if (parent.getDefaultLayout() == parent.getCurrentLayout()) {
-      slotButtonItem.pressed = true;
-    }
+    List<StationSlotLayout> layouts = Lists.newArrayList();
+    // repair layout
+    layouts.add(parent.getDefaultLayout());
+    // tool layouts
+    layouts.addAll(StationSlotLayoutLoader.getInstance().getSortedSlots().stream()
+      .filter(layout -> layout.getInputSlots().size() <= parent.getMaxInputs()).toList());
 
-    // tool buttons
-    int index = 1;
-    for (StationSlotLayout layout : StationSlotLayoutLoader.getInstance().getSortedSlots()) {
-      if (layout.getInputSlots().size() <= parent.getMaxInputs()) {
-        slotButtonItem = new SlotButtonItem(index, -1, -1, layout, onButtonPressed);
-        this.addInfoButton(slotButtonItem, style);
-        if (layout == parent.getCurrentLayout()) {
-          slotButtonItem.pressed = true;
-        }
-        index++;
+    // create buttons for layouts
+    for (int index = 0; index < layouts.size(); index++) {
+      StationSlotLayout layout = layouts.get(index);
+
+      SlotButtonItem slotButtonItem = new SlotButtonItem(index, -1, -1, layout, onButtonPressed);
+      this.addInfoButton(slotButtonItem, style);
+      if (layout == parent.getCurrentLayout()) {
+        slotButtonItem.pressed = true;
       }
     }
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -11,12 +11,10 @@ import java.util.List;
 
 public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem> {
 
-  private int style = 0;
-
   public static final int WOOD_STYLE = 2;
   public static final int METAL_STYLE = 1;
 
-  public TinkerStationButtonsWidget(TinkerStationScreen parent) {
+  public TinkerStationButtonsWidget(TinkerStationScreen parent, int style) {
     super(parent, TinkerStationScreen.COLUMN_COUNT, false);
 
     // Logic to run when a button is pressed
@@ -32,7 +30,7 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
 
     // repair button
     SlotButtonItem slotButtonItem = new SlotButtonItem(0, -1, -1, parent.getDefaultLayout(), onButtonPressed);
-    this.addInfoButton(slotButtonItem);
+    this.addInfoButton(slotButtonItem, style);
     if (parent.getDefaultLayout() == parent.getCurrentLayout()) {
       slotButtonItem.pressed = true;
     }
@@ -42,7 +40,7 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
     for (StationSlotLayout layout : StationSlotLayoutLoader.getInstance().getSortedSlots()) {
       if (layout.getInputSlots().size() <= parent.getMaxInputs()) {
         slotButtonItem = new SlotButtonItem(index, -1, -1, layout, onButtonPressed);
-        this.addInfoButton(slotButtonItem);
+        this.addInfoButton(slotButtonItem, style);
         if (layout == parent.getCurrentLayout()) {
           slotButtonItem.pressed = true;
         }
@@ -51,24 +49,12 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
     }
   }
 
-  public void addInfoButton(SlotButtonItem slotButtonItem) {
-    this.shiftButton(slotButtonItem, 0, -18 * this.style);
-    this.buttons.add(slotButtonItem);
-  }
-
-  public void shiftStyle(int style) {
-      for (SlotButtonItem button : this.buttons) {
-        this.shiftButton(button, 0, -18);
-    }
-
-    this.style = style;
-  }
-
-  protected void shiftButton(SlotButtonItem button, int xd, int yd) {
-    button.setGraphics(Icons.BUTTON.shift(xd, yd),
-      Icons.BUTTON_HOVERED.shift(xd, yd),
-      Icons.BUTTON_PRESSED.shift(xd, yd),
+  private void addInfoButton(SlotButtonItem slotButtonItem, int style) {
+    slotButtonItem.setGraphics(Icons.BUTTON.shift(0, -18 * style),
+      Icons.BUTTON_HOVERED.shift(0, -18 * style),
+      Icons.BUTTON_PRESSED.shift(0, -18 * style),
       Icons.ICONS);
+    this.buttons.add(slotButtonItem);
   }
 
   public List<SlotButtonItem> getButtons() {

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -12,7 +12,6 @@ import java.util.List;
 public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem> {
 
   protected final TinkerStationScreen parent;
-  protected int selected = 0;
   private int style = 0;
 
   /** Logic to run when a button is pressed */
@@ -22,7 +21,6 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
     }
     if (self instanceof SlotButtonItem slotInformationButton) {
       slotInformationButton.pressed = true;
-      TinkerStationButtonsWidget.this.selected = slotInformationButton.buttonId;
       TinkerStationButtonsWidget.this.parent.onToolSelection(slotInformationButton.getLayout());
     }
   };
@@ -43,7 +41,7 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
     // repair button
     SlotButtonItem slotButtonItem = new SlotButtonItem(0, -1, -1, parent.getDefaultLayout(), ON_BUTTON_PRESSED);
     this.addInfoButton(slotButtonItem);
-    if (0 == selected) {
+    if (parent.getDefaultLayout() == parent.getCurrentLayout()) {
       slotButtonItem.pressed = true;
     }
 
@@ -53,7 +51,7 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
       if (layout.getInputSlots().size() <= parent.getMaxInputs()) {
         slotButtonItem = new SlotButtonItem(index, -1, -1, layout, ON_BUTTON_PRESSED);
         this.addInfoButton(slotButtonItem);
-        if (index == selected) {
+        if (layout == parent.getCurrentLayout()) {
           slotButtonItem.pressed = true;
         }
         index++;
@@ -85,15 +83,5 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
 
   public List<SlotButtonItem> getButtons() {
     return this.buttons;
-  }
-
-  public int getSelected() {
-    return this.selected;
-  }
-
-  public void restoreSelected(int selected) {
-    this.buttons.forEach(button -> button.pressed = false);
-    this.buttons.get(selected).pressed = true;
-    this.selected = selected;
   }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -2,9 +2,6 @@ package slimeknights.tconstruct.tables.client.inventory.module;
 
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Widget;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.inventory.AbstractContainerMenu;
 import slimeknights.tconstruct.library.client.Icons;
 import slimeknights.tconstruct.library.tools.layout.StationSlotLayout;
 import slimeknights.tconstruct.library.tools.layout.StationSlotLayoutLoader;
@@ -13,7 +10,7 @@ import slimeknights.tconstruct.tables.client.inventory.widget.SlotButtonItem;
 
 import java.util.List;
 
-public class TinkerStationButtonsScreen extends SideButtonsScreen {
+public class TinkerStationButtonsWidget extends SideButtonsWidget {
 
   protected final TinkerStationScreen parent;
   protected int selected = 0;
@@ -21,23 +18,23 @@ public class TinkerStationButtonsScreen extends SideButtonsScreen {
 
   /** Logic to run when a button is pressed */
   private final Button.OnPress ON_BUTTON_PRESSED = self -> {
-    for (Widget widget : TinkerStationButtonsScreen.this.renderables) {
+    for (Widget widget : TinkerStationButtonsWidget.this.renderables) {
       if (widget instanceof SlotButtonItem) {
         ((SlotButtonItem) widget).pressed = false;
       }
     }
     if (self instanceof SlotButtonItem slotInformationButton) {
       slotInformationButton.pressed = true;
-      TinkerStationButtonsScreen.this.selected = slotInformationButton.buttonId;
-      TinkerStationButtonsScreen.this.parent.onToolSelection(slotInformationButton.getLayout());
+      TinkerStationButtonsWidget.this.selected = slotInformationButton.buttonId;
+      TinkerStationButtonsWidget.this.parent.onToolSelection(slotInformationButton.getLayout());
     }
   };
 
   public static final int WOOD_STYLE = 2;
   public static final int METAL_STYLE = 1;
 
-  public TinkerStationButtonsScreen(TinkerStationScreen parent, AbstractContainerMenu container, Inventory playerInventory, Component title) {
-    super(parent, container, playerInventory, title, TinkerStationScreen.COLUMN_COUNT, false);
+  public TinkerStationButtonsWidget(TinkerStationScreen parent) {
+    super(parent, TinkerStationScreen.COLUMN_COUNT, false);
 
     this.parent = parent;
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -16,7 +16,12 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
   public static final int METAL_STYLE = 1;
 
   public TinkerStationButtonsWidget(TinkerStationScreen parent, int style) {
-    super(parent, TinkerStationScreen.COLUMN_COUNT, false);
+    this(parent, createLayoutsList(parent), style);
+  }
+
+  public TinkerStationButtonsWidget(TinkerStationScreen parent, List<StationSlotLayout> layouts, int style) {
+    super(parent, TinkerStationScreen.COLUMN_COUNT, rowsForCount(TinkerStationScreen.COLUMN_COUNT, layouts.size()),
+      SlotButtonItem.WIDTH, SlotButtonItem.HEIGHT, false);
 
     // Logic to run when a button is pressed
     Button.OnPress onButtonPressed = self -> {
@@ -29,13 +34,6 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
       }
     };
 
-    List<StationSlotLayout> layouts = Lists.newArrayList();
-    // repair layout
-    layouts.add(parent.getDefaultLayout());
-    // tool layouts
-    layouts.addAll(StationSlotLayoutLoader.getInstance().getSortedSlots().stream()
-      .filter(layout -> layout.getInputSlots().size() <= parent.getMaxInputs()).toList());
-
     // create buttons for layouts
     for (int index = 0; index < layouts.size(); index++) {
       StationSlotLayout layout = layouts.get(index);
@@ -46,6 +44,16 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
         slotButtonItem.pressed = true;
       }
     }
+  }
+
+  public static List<StationSlotLayout> createLayoutsList(TinkerStationScreen parent) {
+    List<StationSlotLayout> layouts = Lists.newArrayList();
+    // repair layout
+    layouts.add(parent.getDefaultLayout());
+    // tool layouts
+    layouts.addAll(StationSlotLayoutLoader.getInstance().getSortedSlots().stream()
+      .filter(layout -> layout.getInputSlots().size() <= parent.getMaxInputs()).toList());
+    return layouts;
   }
 
   private void addInfoButton(SlotButtonItem slotButtonItem, int style) {

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -38,8 +38,7 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
 
   @Override
   public void updatePosition(int parentX, int parentY, int parentSizeX, int parentSizeY) {
-    super.updatePosition(parentX, parentY, parentSizeX, parentSizeY);
-    this.buttonCount = 0;
+    this.buttons.clear();
 
     // repair button
     SlotButtonItem slotButtonItem = new SlotButtonItem(0, -1, -1, parent.getDefaultLayout(), ON_BUTTON_PRESSED);
@@ -66,7 +65,7 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
 
   public void addInfoButton(SlotButtonItem slotButtonItem) {
     this.shiftButton(slotButtonItem, 0, -18 * this.style);
-    this.addSideButton(slotButtonItem);
+    this.buttons.add(slotButtonItem);
   }
 
   public void shiftStyle(int style) {

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -15,13 +15,13 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
   public static final int WOOD_STYLE = 2;
   public static final int METAL_STYLE = 1;
 
-  public TinkerStationButtonsWidget(TinkerStationScreen parent, int style) {
-    this(parent, createLayoutsList(parent), style);
+  public TinkerStationButtonsWidget(TinkerStationScreen parent, int leftPos, int topPos, int style) {
+    this(parent, leftPos, topPos, createLayoutsList(parent), style);
   }
 
-  public TinkerStationButtonsWidget(TinkerStationScreen parent, List<StationSlotLayout> layouts, int style) {
-    super(parent, TinkerStationScreen.COLUMN_COUNT, rowsForCount(TinkerStationScreen.COLUMN_COUNT, layouts.size()),
-      SlotButtonItem.WIDTH, SlotButtonItem.HEIGHT, false);
+  public TinkerStationButtonsWidget(TinkerStationScreen parent, int leftPos, int topPos, List<StationSlotLayout> layouts, int style) {
+    super(parent, leftPos, topPos, TinkerStationScreen.COLUMN_COUNT, rowsForCount(TinkerStationScreen.COLUMN_COUNT, layouts.size()),
+      SlotButtonItem.WIDTH, SlotButtonItem.HEIGHT);
 
     // Logic to run when a button is pressed
     Button.OnPress onButtonPressed = self -> {
@@ -44,6 +44,8 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
         slotButtonItem.pressed = true;
       }
     }
+
+    this.setButtonPositions();
   }
 
   public static List<StationSlotLayout> createLayoutsList(TinkerStationScreen parent) {
@@ -66,5 +68,9 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
 
   public List<SlotButtonItem> getButtons() {
     return this.buttons;
+  }
+
+  public static int width(int columns) {
+    return size(columns, SlotButtonItem.WIDTH);
   }
 }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/module/TinkerStationButtonsWidget.java
@@ -11,19 +11,7 @@ import java.util.List;
 
 public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem> {
 
-  protected final TinkerStationScreen parent;
   private int style = 0;
-
-  /** Logic to run when a button is pressed */
-  private final Button.OnPress ON_BUTTON_PRESSED = self -> {
-    for (SlotButtonItem button : TinkerStationButtonsWidget.this.buttons) {
-      button.pressed = false;
-    }
-    if (self instanceof SlotButtonItem slotInformationButton) {
-      slotInformationButton.pressed = true;
-      TinkerStationButtonsWidget.this.parent.onToolSelection(slotInformationButton.getLayout());
-    }
-  };
 
   public static final int WOOD_STYLE = 2;
   public static final int METAL_STYLE = 1;
@@ -31,15 +19,19 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
   public TinkerStationButtonsWidget(TinkerStationScreen parent) {
     super(parent, TinkerStationScreen.COLUMN_COUNT, false);
 
-    this.parent = parent;
-  }
-
-  @Override
-  public void updatePosition(int parentX, int parentY, int parentSizeX, int parentSizeY) {
-    this.buttons.clear();
+    // Logic to run when a button is pressed
+    Button.OnPress onButtonPressed = self -> {
+      for (SlotButtonItem button : TinkerStationButtonsWidget.this.buttons) {
+        button.pressed = false;
+      }
+      if (self instanceof SlotButtonItem slotInformationButton) {
+        slotInformationButton.pressed = true;
+        parent.onToolSelection(slotInformationButton.getLayout());
+      }
+    };
 
     // repair button
-    SlotButtonItem slotButtonItem = new SlotButtonItem(0, -1, -1, parent.getDefaultLayout(), ON_BUTTON_PRESSED);
+    SlotButtonItem slotButtonItem = new SlotButtonItem(0, -1, -1, parent.getDefaultLayout(), onButtonPressed);
     this.addInfoButton(slotButtonItem);
     if (parent.getDefaultLayout() == parent.getCurrentLayout()) {
       slotButtonItem.pressed = true;
@@ -49,7 +41,7 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
     int index = 1;
     for (StationSlotLayout layout : StationSlotLayoutLoader.getInstance().getSortedSlots()) {
       if (layout.getInputSlots().size() <= parent.getMaxInputs()) {
-        slotButtonItem = new SlotButtonItem(index, -1, -1, layout, ON_BUTTON_PRESSED);
+        slotButtonItem = new SlotButtonItem(index, -1, -1, layout, onButtonPressed);
         this.addInfoButton(slotButtonItem);
         if (layout == parent.getCurrentLayout()) {
           slotButtonItem.pressed = true;
@@ -57,8 +49,6 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
         index++;
       }
     }
-
-    super.updatePosition(parentX, parentY, parentSizeX, parentSizeY);
   }
 
   public void addInfoButton(SlotButtonItem slotButtonItem) {

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/SideButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/SideButtonsWidget.java
@@ -1,6 +1,7 @@
 package slimeknights.tconstruct.tables.client.inventory.widget;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import lombok.Getter;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Widget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -12,14 +13,16 @@ import java.util.List;
 
 public class SideButtonsWidget<T extends Button> implements Widget, GuiEventListener {
 
-  public static final int SPACING = 4;
+  private static final int SPACING = 4;
 
   protected final MultiModuleScreen<?> parent;
 
-  public final int leftPos;
-  public final int topPos;
-  public final int imageWidth;
-  public final int imageHeight;
+  @Getter
+  private final int leftPos;
+  private final int topPos;
+  @Getter
+  private final int imageWidth;
+  private final int imageHeight;
 
   private final int columns;
   protected final List<T> buttons = Lists.newArrayList();

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/SideButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/SideButtonsWidget.java
@@ -1,4 +1,4 @@
-package slimeknights.tconstruct.tables.client.inventory.module;
+package slimeknights.tconstruct.tables.client.inventory.widget;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.components.Button;

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/SideButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/SideButtonsWidget.java
@@ -96,10 +96,16 @@ public class SideButtonsWidget<T extends Button> implements Widget, GuiEventList
     }
   }
 
+  /**
+   * Calculates the number of rows of buttons when fitting the given number of buttons within the given number of columns.
+   */
   public static int rowsForCount(int columns, int count) {
     return (count - 1) / columns + 1;
   }
 
+  /**
+   * Calculates the width or height of this widget given the width or height of a button and the number of buttons along the same axis.
+   */
   public static int size(int buttonCount, int buttonSize) {
     return buttonSize * buttonCount + SPACING * (buttonCount - 1);
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/SlotButtonItem.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/SlotButtonItem.java
@@ -11,9 +11,12 @@ import slimeknights.tconstruct.library.tools.layout.StationSlotLayout;
 import slimeknights.tconstruct.tables.client.inventory.TinkerStationScreen;
 
 public class SlotButtonItem extends Button {
-  protected static final ElementScreen BUTTON_PRESSED_GUI = new ElementScreen(144, 216, 18, 18, 256, 256);
-  protected static final ElementScreen BUTTON_NORMAL_GUI = new ElementScreen(144 + 18 * 2, 216, 18, 18, 256, 256);
-  protected static final ElementScreen BUTTON_HOVER_GUI = new ElementScreen(144 + 18 * 4, 216, 18, 18, 256, 256);
+
+  public static int WIDTH = 18, HEIGHT = 18;
+
+  protected static final ElementScreen BUTTON_PRESSED_GUI = new ElementScreen(144, 216, WIDTH, HEIGHT, 256, 256);
+  protected static final ElementScreen BUTTON_NORMAL_GUI = new ElementScreen(144 + WIDTH * 2, 216, WIDTH, HEIGHT, 256, 256);
+  protected static final ElementScreen BUTTON_HOVER_GUI = new ElementScreen(144 + WIDTH * 4, 216, WIDTH, HEIGHT, 256, 256);
 
   @Getter
   private final StationSlotLayout layout;
@@ -26,7 +29,7 @@ public class SlotButtonItem extends Button {
   private ResourceLocation backgroundLocation = Icons.ICONS;
 
   public SlotButtonItem(int buttonId, int x, int y, StationSlotLayout layout, OnPress onPress) {
-    super(x, y, 18, 18, layout.getDisplayName(), onPress);
+    super(x, y, WIDTH, HEIGHT, layout.getDisplayName(), onPress);
     this.layout = layout;
     this.buttonId = buttonId;
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerStationButtonsWidget.java
@@ -1,10 +1,8 @@
 package slimeknights.tconstruct.tables.client.inventory.widget;
 
-import com.google.common.collect.Lists;
 import net.minecraft.client.gui.components.Button;
 import slimeknights.tconstruct.library.client.Icons;
 import slimeknights.tconstruct.library.tools.layout.StationSlotLayout;
-import slimeknights.tconstruct.library.tools.layout.StationSlotLayoutLoader;
 import slimeknights.tconstruct.tables.client.inventory.TinkerStationScreen;
 
 import java.util.List;
@@ -13,10 +11,6 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
 
   public static final int WOOD_STYLE = 2;
   public static final int METAL_STYLE = 1;
-
-  public TinkerStationButtonsWidget(TinkerStationScreen parent, int leftPos, int topPos, int style) {
-    this(parent, leftPos, topPos, createLayoutsList(parent), style);
-  }
 
   public TinkerStationButtonsWidget(TinkerStationScreen parent, int leftPos, int topPos, List<StationSlotLayout> layouts, int style) {
     super(parent, leftPos, topPos, TinkerStationScreen.COLUMN_COUNT, rowsForCount(TinkerStationScreen.COLUMN_COUNT, layouts.size()),
@@ -45,16 +39,6 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
     }
 
     this.setButtonPositions();
-  }
-
-  public static List<StationSlotLayout> createLayoutsList(TinkerStationScreen parent) {
-    List<StationSlotLayout> layouts = Lists.newArrayList();
-    // repair layout
-    layouts.add(parent.getDefaultLayout());
-    // tool layouts
-    layouts.addAll(StationSlotLayoutLoader.getInstance().getSortedSlots().stream()
-      .filter(layout -> layout.getInputSlots().size() <= parent.getMaxInputs()).toList());
-    return layouts;
   }
 
   private void addInfoButton(SlotButtonItem slotButtonItem, int style) {

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerStationButtonsWidget.java
@@ -53,6 +53,9 @@ public class TinkerStationButtonsWidget extends SideButtonsWidget<SlotButtonItem
     return this.buttons;
   }
 
+  /**
+   * Calculates the width of this widget given the number of columns.
+   */
   public static int width(int columns) {
     return size(columns, SlotButtonItem.WIDTH);
   }

--- a/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerStationButtonsWidget.java
+++ b/src/main/java/slimeknights/tconstruct/tables/client/inventory/widget/TinkerStationButtonsWidget.java
@@ -1,4 +1,4 @@
-package slimeknights.tconstruct.tables.client.inventory.module;
+package slimeknights.tconstruct.tables.client.inventory.widget;
 
 import com.google.common.collect.Lists;
 import net.minecraft.client.gui.components.Button;
@@ -6,7 +6,6 @@ import slimeknights.tconstruct.library.client.Icons;
 import slimeknights.tconstruct.library.tools.layout.StationSlotLayout;
 import slimeknights.tconstruct.library.tools.layout.StationSlotLayoutLoader;
 import slimeknights.tconstruct.tables.client.inventory.TinkerStationScreen;
-import slimeknights.tconstruct.tables.client.inventory.widget.SlotButtonItem;
 
 import java.util.List;
 


### PR DESCRIPTION
Related to #4841 and #4988.

Reworks `SideButtonsScreen` to not use `ModuleScreen`, and does some minor additional cleanup.

- The class no longer uses any inheritance to function. Because it no longer extends `AbstractContainerScreen` or `Screen`, it will no longer be treated as a screen by other mods. For example, the side buttons will no longer have an `InitScreenEvent` posted for it. THIS FIXES kirderf1/InventoryFree#9.
- The side buttons widget implements `Widget` and `GuiEventListener` but is not added to the parent screen as a screen widget. Instead, render and mouse input functions are called by the parent class directly.
- The parent class no longer has its size (as defined by `leftPos` and `imageWidth` etc) expanded to include the the side buttons that normally happens in `MultiModuleScreen.updateSubmodule()`. With how `MultiModuleScreen.render()` works, this will not affect any render functions. The size of the widget is still accounted for jei and when dropping items from the screen.
- The side buttons widget now get recreated during the `screen.init()` call, instead of created in the constructor. This is more inline with how vanilla widgets are handled, and allows us to make the position immutable (which has not been done at this time).
- To remove somenot strictly neccessary instanceof checks and casts in `TinkerStationButtonsWidget`, `SideButtonsWidget`was made generic for the button type.
- `TinkerStationButtonsWidget.selected` was replaced by instead checking `TinkerStationScreen.currentLayout`. Doing so removed any need to copy over data when the widget was recreated during a window resize.