### PR TITLE
Skyslime Sling fixes

### DIFF
--- a/src/main/java/slimeknights/tconstruct/gadgets/item/slimesling/SkySlimeSlingItem.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/item/slimesling/SkySlimeSlingItem.java
@@ -45,7 +45,9 @@ public class SkySlimeSlingItem extends BaseSlimeSlingItem {
     }
 
     player.causeFoodExhaustion(0.2F);
-    player.setSprinting(true);
+    if (worldIn.isClientSide) {
+      player.setSprinting(true);
+    }
 
     float f = getForce(stack, timeLeft);
     float speed = f / 3F;

--- a/src/main/java/slimeknights/tconstruct/gadgets/item/slimesling/SkySlimeSlingItem.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/item/slimesling/SkySlimeSlingItem.java
@@ -52,7 +52,6 @@ public class SkySlimeSlingItem extends BaseSlimeSlingItem {
       (1 + look.y) * speed / 2f,
       (look.z * speed));
 
-    onSuccess(player, stack);
     SlimeBounceHandler.addBounceHandler(player);
     if (!worldIn.isClientSide) {
       player.getCooldowns().addCooldown(stack.getItem(), 3);

--- a/src/main/java/slimeknights/tconstruct/gadgets/item/slimesling/SkySlimeSlingItem.java
+++ b/src/main/java/slimeknights/tconstruct/gadgets/item/slimesling/SkySlimeSlingItem.java
@@ -3,15 +3,12 @@ package slimeknights.tconstruct.gadgets.item.slimesling;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 import slimeknights.tconstruct.library.utils.SlimeBounceHandler;
 import slimeknights.tconstruct.shared.block.SlimeType;
 
-import net.minecraft.world.item.Item.Properties;
-
 public class SkySlimeSlingItem extends BaseSlimeSlingItem {
-  private static final float DEGREE_TO_RAD = (float) Math.PI / 180.0F;
 
   public SkySlimeSlingItem(Properties props) {
     super(props, SlimeType.SKY);
@@ -33,11 +30,9 @@ public class SkySlimeSlingItem extends BaseSlimeSlingItem {
   /** Called when the player stops using an Item (stops holding the right mouse button). */
   @Override
   public void releaseUsing(ItemStack stack, Level worldIn, LivingEntity entityLiving, int timeLeft) {
-    if (!(entityLiving instanceof Player)) {
+    if (!(entityLiving instanceof Player player)) {
       return;
     }
-
-    Player player = (Player) entityLiving;
 
     // don't allow free flight when using an elytra, should use fireworks
     if (player.isFallFlying()) {


### PR DESCRIPTION
While debugging an odd interaction between TCon and my own mod, I discovered a possible desync state caused by Skyslime Sling in relation to the player's sprinting flag. This PR addresses the issue, while also fixing some of the oddities in the same file.

Skyslime Sling makes player sprint by calling `player.setSprinting(true)` on both client and server. This approach has possible point of failure, in which client side flag is ignored and only server side flag is set. This creates a state where server thinks player is sprinting but the client is not. This state has little to no effect on most of gameplay, but it caused some issues when it's coupled together with my mod.

This desync state can be prevented by setting the flag on client side only. It also keeps the auto-sprint feature unchanged.

Additionally there was a second `onSuccess()` call which made the Sling lose durability two times per use and play sound twice. I just removed the first call, since that one looked like it's put in by a mistake. Pardon me if this change was inappropriate.