### PR TITLE
multi Level Cache

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModule.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModule.java
@@ -10,12 +10,10 @@ import net.minecraftforge.items.ItemHandlerHelper;
 import slimeknights.mantle.block.entity.MantleBlockEntity;
 import slimeknights.tconstruct.common.network.InventorySlotSyncPacket;
 import slimeknights.tconstruct.common.network.TinkerNetwork;
-import slimeknights.tconstruct.library.recipe.TinkerRecipeTypes;
 import slimeknights.tconstruct.library.recipe.melting.IMeltingContainer;
 import slimeknights.tconstruct.library.recipe.melting.IMeltingRecipe;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -33,7 +31,9 @@ public class MeltingModule implements IMeltingContainer, ContainerData {
   private static final int REQUIRED_TEMP = 2;
 
   /** Tile entity containing this melting module */
-  private final MeltingModuleInventory parent;
+  private final MantleBlockEntity be;
+  /** Melting Inventory containing this melting module */
+  private final MeltingModuleInventory inventory;
   /** Function that accepts fluid output from this module */
   private final Predicate<IMeltingRecipe> outputFunction;
   /** Function that boosts the ores based on the rate type */
@@ -78,9 +78,9 @@ public class MeltingModule implements IMeltingContainer, ContainerData {
    */
   public void setStack(ItemStack newStack) {
     // send a slot update to the client when items change, so we can update the TESR
-    Level world = parent.getParent().getLevel();
+    Level world = be.getLevel();
     if (slotIndex != -1 && world != null && !world.isClientSide && !ItemStack.matches(stack, newStack)) {
-      TinkerNetwork.getInstance().sendToClientsAround(new InventorySlotSyncPacket(newStack, slotIndex, parent.getParent().getBlockPos()), world, parent.getParent().getBlockPos());
+      TinkerNetwork.getInstance().sendToClientsAround(new InventorySlotSyncPacket(newStack, slotIndex, be.getBlockPos()), world, be.getBlockPos());
     }
 
     // clear progress if setting to empty or the items do not match
@@ -103,7 +103,7 @@ public class MeltingModule implements IMeltingContainer, ContainerData {
     }
     requiredTime = newTime;
     requiredTemp = newTemp;
-    parent.getParent().setChangedFast();
+    be.setChangedFast();
   }
 
 
@@ -165,7 +165,7 @@ public class MeltingModule implements IMeltingContainer, ContainerData {
    */
   @Nullable
   private IMeltingRecipe findRecipe() {
-    Level world = parent.getParent().getLevel();
+    Level world = be.getLevel();
     if (world == null) {
       return null;
     }
@@ -173,22 +173,13 @@ public class MeltingModule implements IMeltingContainer, ContainerData {
     // first, try last recipe for the slot
     IMeltingRecipe last = lastRecipe;
     if (last != null && last.matches(this, world)) {
-      parent.setLastInventoryRecipe(lastRecipe);
-      return last;
-    }
-
-    // second, try the last recipe from the inventory
-    last = parent.getLastInventoryRecipe();
-    if (last != null && last.matches(this, world)) {
-      lastRecipe = last;
       return last;
     }
 
     // if that fails, try to find a new recipe
-    Optional<IMeltingRecipe> newRecipe = world.getRecipeManager().getRecipeFor(TinkerRecipeTypes.MELTING.get(), this, world);
-    if (newRecipe.isPresent()) {
-      lastRecipe = newRecipe.get();
-      parent.setLastInventoryRecipe(lastRecipe);
+    IMeltingRecipe newRecipe = inventory.findRecipe(this, lastRecipe);
+    if (newRecipe != null) {
+      lastRecipe = newRecipe;
       return lastRecipe;
     }
     return null;

--- a/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModule.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModule.java
@@ -40,6 +40,8 @@ public class MeltingModule implements IMeltingContainer, ContainerData {
   private final IOreRate oreRate;
   /** Slot index for updates */
   private final int slotIndex;
+  /** Last recipe the inventory */
+  private final IMeltingRecipe[] lastInventoryRecipe;
 
   /** Current time of the item in the slot */
   @Getter
@@ -173,12 +175,22 @@ public class MeltingModule implements IMeltingContainer, ContainerData {
     // first, try last recipe for the slot
     IMeltingRecipe last = lastRecipe;
     if (last != null && last.matches(this, world)) {
+      lastInventoryRecipe[0] = lastRecipe;
       return last;
     }
+
+    // second, try the last recipe from the inventory
+    last = lastInventoryRecipe[0];
+    if (last != null && last.matches(this, world)) {
+      lastRecipe = last;
+      return last;
+    }
+
     // if that fails, try to find a new recipe
     Optional<IMeltingRecipe> newRecipe = world.getRecipeManager().getRecipeFor(TinkerRecipeTypes.MELTING.get(), this, world);
     if (newRecipe.isPresent()) {
       lastRecipe = newRecipe.get();
+      lastInventoryRecipe[0] = lastRecipe;
       return lastRecipe;
     }
     return null;

--- a/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModuleInventory.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModuleInventory.java
@@ -31,7 +31,7 @@ public class MeltingModuleInventory implements IItemHandlerModifiable {
   private static final String TAG_SIZE = "size";
 
   /** Last used recipe by any slot in the inventory */
-  private IMeltingRecipe lastInventoryRecipe;
+  private IMeltingRecipe lastRecipe;
   /** Parent tile entity */
   private final MantleBlockEntity parent;
   /** Fluid handler for outputs */
@@ -138,11 +138,15 @@ public class MeltingModuleInventory implements IItemHandlerModifiable {
     if (world == null) {
       return null;
     }
-    if (lastInventoryRecipe != null && slotRecipe != lastInventoryRecipe && lastInventoryRecipe.matches(module, world)) {
-        return lastInventoryRecipe;
+    if (lastRecipe != null && slotRecipe != lastRecipe && lastRecipe.matches(module, world)) {
+        return lastRecipe;
     }
     Optional<IMeltingRecipe> newRecipe = world.getRecipeManager().getRecipeFor(TinkerRecipeTypes.MELTING.get(), module, world);
-    return newRecipe.orElse(null);
+    if (newRecipe.isPresent()) {
+      lastRecipe = newRecipe.get();
+      return lastRecipe;
+    }
+    return null;
   }
 
 

--- a/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModuleInventory.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModuleInventory.java
@@ -26,6 +26,8 @@ public class MeltingModuleInventory implements IItemHandlerModifiable {
   private static final String TAG_ITEMS = "items";
   private static final String TAG_SIZE = "size";
 
+  /** Last used recipe by any slot in the inventory */
+  private IMeltingRecipe[] lastInventoryRecipe = new IMeltingRecipe[1];
   /** Parent tile entity */
   private final MantleBlockEntity parent;
   /** Fluid handler for outputs */
@@ -134,7 +136,7 @@ public class MeltingModuleInventory implements IItemHandlerModifiable {
       throw new IndexOutOfBoundsException();
     }
     if (modules[slot] == null) {
-      modules[slot] = new MeltingModule(parent, recipe -> tryFillTank(slot, recipe), oreRate, slot);
+      modules[slot] = new MeltingModule(parent, recipe -> tryFillTank(slot, recipe), oreRate, slot, lastInventoryRecipe);
     }
     return modules[slot];
   }

--- a/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModuleInventory.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MeltingModuleInventory.java
@@ -1,5 +1,7 @@
 package slimeknights.tconstruct.smeltery.block.entity.module;
 
+import lombok.Getter;
+import lombok.Setter;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -27,8 +29,11 @@ public class MeltingModuleInventory implements IItemHandlerModifiable {
   private static final String TAG_SIZE = "size";
 
   /** Last used recipe by any slot in the inventory */
-  private IMeltingRecipe[] lastInventoryRecipe = new IMeltingRecipe[1];
+  @Getter
+  @Setter
+  private IMeltingRecipe lastInventoryRecipe;
   /** Parent tile entity */
+  @Getter
   private final MantleBlockEntity parent;
   /** Fluid handler for outputs */
   protected final IFluidHandler fluidHandler;
@@ -136,7 +141,7 @@ public class MeltingModuleInventory implements IItemHandlerModifiable {
       throw new IndexOutOfBoundsException();
     }
     if (modules[slot] == null) {
-      modules[slot] = new MeltingModule(parent, recipe -> tryFillTank(slot, recipe), oreRate, slot, lastInventoryRecipe);
+      modules[slot] = new MeltingModule(this, recipe -> tryFillTank(slot, recipe), oreRate, slot);
     }
     return modules[slot];
   }


### PR DESCRIPTION
Adds a second level cache to the melting inventory. 
The constructor of a melting module now takes the parent inventory instead of the block entity. If the Block entity is needed, it can be gotten from the inventory.