### PR TITLE
add com.google.code.findbugs to remove '@Nullable' errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Anything that is not possible via IMC has to be integrated via Code through the 
 (old 1.7.10 IMCs can be found here: https://gist.github.com/bonii-xx/e46f9d9e81e29d796b1b)
 
 ## Setting up a Workspace/Compiling from Source
-Note: Git MUST be installed and in the system path to use our scripts.
+Note: Git MUST be installed and in the system path to use our scripts. Java 18 must be used.
 * Setup: Run [gradle]in the repository root: `gradlew[.bat] [setupDevWorkspace|setupDecompWorkspace] [eclipse|idea]`
 * Build: Run [gradle]in the repository root: `gradlew[.bat] build`
 * If obscure Gradle issues are found try running `gradlew clean` and `gradlew cleanCache`

--- a/build.gradle
+++ b/build.gradle
@@ -229,6 +229,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     testImplementation 'org.mockito:mockito-inline:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 test {


### PR DESCRIPTION
When I loaded the project in Intellij, it complained about "@Nullable" for example in https://github.com/SlimeKnights/TinkersConstruct/blob/62dc631581963e32397dff774c477363b9c77a39/src/main/java/slimeknights/tconstruct/tables/block/TinkerStationBlock.java#L9

Also noted in the readme that java 18 must be used