### PR TITLE
Render Type Registrations Move to Json

### DIFF
--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/bottom_left.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/bottom_left.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_left",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/bloodshroom/door_bottom",
     "top": "tconstruct:block/wood/bloodshroom/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/bottom_left_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/bottom_left_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_left_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/bloodshroom/door_bottom",
     "top": "tconstruct:block/wood/bloodshroom/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/bottom_right.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/bottom_right.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_right",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/bloodshroom/door_bottom",
     "top": "tconstruct:block/wood/bloodshroom/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/bottom_right_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/bottom_right_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_right_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/bloodshroom/door_bottom",
     "top": "tconstruct:block/wood/bloodshroom/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/top_left.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/top_left.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_left",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/bloodshroom/door_bottom",
     "top": "tconstruct:block/wood/bloodshroom/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/top_left_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/top_left_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_left_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/bloodshroom/door_bottom",
     "top": "tconstruct:block/wood/bloodshroom/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/top_right.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/top_right.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_right",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/bloodshroom/door_bottom",
     "top": "tconstruct:block/wood/bloodshroom/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/top_right_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/door/top_right_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_right_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/bloodshroom/door_bottom",
     "top": "tconstruct:block/wood/bloodshroom/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/trapdoor_bottom.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/trapdoor_bottom.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_orientable_trapdoor_bottom",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/bloodshroom/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/trapdoor_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/trapdoor_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_orientable_trapdoor_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/bloodshroom/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/trapdoor_top.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/bloodshroom/trapdoor_top.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_orientable_trapdoor_top",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/bloodshroom/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/bottom_left.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/bottom_left.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_left",
+  "render_type": "minecraft:solid",
   "textures": {
     "bottom": "tconstruct:block/wood/enderbark/door_bottom",
     "top": "tconstruct:block/wood/enderbark/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/bottom_left_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/bottom_left_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_left_open",
+  "render_type": "minecraft:solid",
   "textures": {
     "bottom": "tconstruct:block/wood/enderbark/door_bottom",
     "top": "tconstruct:block/wood/enderbark/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/bottom_right.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/bottom_right.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_right",
+  "render_type": "minecraft:solid",
   "textures": {
     "bottom": "tconstruct:block/wood/enderbark/door_bottom",
     "top": "tconstruct:block/wood/enderbark/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/bottom_right_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/bottom_right_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_right_open",
+  "render_type": "minecraft:solid",
   "textures": {
     "bottom": "tconstruct:block/wood/enderbark/door_bottom",
     "top": "tconstruct:block/wood/enderbark/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/top_left.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/top_left.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_left",
+  "render_type": "minecraft:solid",
   "textures": {
     "bottom": "tconstruct:block/wood/enderbark/door_bottom",
     "top": "tconstruct:block/wood/enderbark/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/top_left_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/top_left_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_left_open",
+  "render_type": "minecraft:solid",
   "textures": {
     "bottom": "tconstruct:block/wood/enderbark/door_bottom",
     "top": "tconstruct:block/wood/enderbark/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/top_right.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/top_right.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_right",
+  "render_type": "minecraft:solid",
   "textures": {
     "bottom": "tconstruct:block/wood/enderbark/door_bottom",
     "top": "tconstruct:block/wood/enderbark/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/top_right_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/door/top_right_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_right_open",
+  "render_type": "minecraft:solid",
   "textures": {
     "bottom": "tconstruct:block/wood/enderbark/door_bottom",
     "top": "tconstruct:block/wood/enderbark/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/roots/empty.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/roots/empty.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/mangrove_roots",
+  "render_type": "minecraft:cutout",
   "textures": {
     "side": "tconstruct:block/wood/enderbark/roots",
     "top": "tconstruct:block/wood/enderbark/roots_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/trapdoor_bottom.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/trapdoor_bottom.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_orientable_trapdoor_bottom",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/enderbark/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/trapdoor_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/trapdoor_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_orientable_trapdoor_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/enderbark/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/trapdoor_top.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/enderbark/trapdoor_top.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_orientable_trapdoor_top",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/enderbark/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/bottom_left.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/bottom_left.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_left",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/greenheart/door_bottom",
     "top": "tconstruct:block/wood/greenheart/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/bottom_left_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/bottom_left_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_left_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/greenheart/door_bottom",
     "top": "tconstruct:block/wood/greenheart/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/bottom_right.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/bottom_right.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_right",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/greenheart/door_bottom",
     "top": "tconstruct:block/wood/greenheart/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/bottom_right_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/bottom_right_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_right_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/greenheart/door_bottom",
     "top": "tconstruct:block/wood/greenheart/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/top_left.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/top_left.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_left",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/greenheart/door_bottom",
     "top": "tconstruct:block/wood/greenheart/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/top_left_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/top_left_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_left_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/greenheart/door_bottom",
     "top": "tconstruct:block/wood/greenheart/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/top_right.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/top_right.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_right",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/greenheart/door_bottom",
     "top": "tconstruct:block/wood/greenheart/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/top_right_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/door/top_right_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_right_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/greenheart/door_bottom",
     "top": "tconstruct:block/wood/greenheart/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/trapdoor_bottom.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/trapdoor_bottom.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_trapdoor_bottom",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/greenheart/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/trapdoor_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/trapdoor_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_trapdoor_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/greenheart/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/trapdoor_top.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/greenheart/trapdoor_top.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_trapdoor_top",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/greenheart/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/bottom_left.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/bottom_left.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_left",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/skyroot/door_bottom",
     "top": "tconstruct:block/wood/skyroot/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/bottom_left_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/bottom_left_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_left_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/skyroot/door_bottom",
     "top": "tconstruct:block/wood/skyroot/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/bottom_right.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/bottom_right.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_right",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/skyroot/door_bottom",
     "top": "tconstruct:block/wood/skyroot/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/bottom_right_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/bottom_right_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_bottom_right_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/skyroot/door_bottom",
     "top": "tconstruct:block/wood/skyroot/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/top_left.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/top_left.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_left",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/skyroot/door_bottom",
     "top": "tconstruct:block/wood/skyroot/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/top_left_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/top_left_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_left_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/skyroot/door_bottom",
     "top": "tconstruct:block/wood/skyroot/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/top_right.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/top_right.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_right",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/skyroot/door_bottom",
     "top": "tconstruct:block/wood/skyroot/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/top_right_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/door/top_right_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/door_top_right_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "bottom": "tconstruct:block/wood/skyroot/door_bottom",
     "top": "tconstruct:block/wood/skyroot/door_top"

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/trapdoor_bottom.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/trapdoor_bottom.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_orientable_trapdoor_bottom",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/skyroot/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/trapdoor_open.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/trapdoor_open.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_orientable_trapdoor_open",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/skyroot/trapdoor"
   }

--- a/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/trapdoor_top.json
+++ b/src/generated/resources/assets/tconstruct/models/block/wood/skyroot/trapdoor_top.json
@@ -1,5 +1,6 @@
 {
   "parent": "minecraft:block/template_orientable_trapdoor_top",
+  "render_type": "minecraft:cutout",
   "textures": {
     "texture": "tconstruct:block/wood/skyroot/trapdoor"
   }

--- a/src/main/java/slimeknights/tconstruct/shared/CommonsClientEvents.java
+++ b/src/main/java/slimeknights/tconstruct/shared/CommonsClientEvents.java
@@ -20,7 +20,6 @@ import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.common.ClientEventBase;
 import slimeknights.tconstruct.library.client.book.TinkerBook;
 import slimeknights.tconstruct.library.utils.DomainDisplayName;
-import slimeknights.tconstruct.shared.block.ClearStainedGlassBlock;
 import slimeknights.tconstruct.shared.block.ClearStainedGlassBlock.GlassColor;
 import slimeknights.tconstruct.shared.client.FluidParticle;
 
@@ -35,20 +34,9 @@ public class CommonsClientEvents extends ClientEventBase {
 
   @SubscribeEvent
   static void clientSetup(final FMLClientSetupEvent event) {
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.glow.get(), RenderType.translucent());
-
     // glass
     ItemBlockRenderTypes.setRenderLayer(TinkerCommons.clearGlass.get(), RenderType.cutout());
     ItemBlockRenderTypes.setRenderLayer(TinkerCommons.clearGlassPane.get(), RenderType.cutout());
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.clearTintedGlass.get(), RenderType.translucent());
-    for (ClearStainedGlassBlock.GlassColor color : ClearStainedGlassBlock.GlassColor.values()) {
-      ItemBlockRenderTypes.setRenderLayer(TinkerCommons.clearStainedGlass.get(color), RenderType.translucent());
-      ItemBlockRenderTypes.setRenderLayer(TinkerCommons.clearStainedGlassPane.get(color), RenderType.translucent());
-    }
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.soulGlass.get(), RenderType.translucent());
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.soulGlassPane.get(), RenderType.translucent());
-    ItemBlockRenderTypes.setRenderLayer(TinkerMaterials.soulsteel.get(), RenderType.translucent());
-    ItemBlockRenderTypes.setRenderLayer(TinkerMaterials.slimesteel.get(), RenderType.translucent());
 
     RenderType cutout = RenderType.cutout();
     ItemBlockRenderTypes.setRenderLayer(TinkerCommons.cheeseBlock.get(), cutout);

--- a/src/main/java/slimeknights/tconstruct/shared/CommonsClientEvents.java
+++ b/src/main/java/slimeknights/tconstruct/shared/CommonsClientEvents.java
@@ -5,8 +5,6 @@ import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.color.item.ItemColors;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.font.FontManager;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
@@ -23,8 +21,6 @@ import slimeknights.tconstruct.library.utils.DomainDisplayName;
 import slimeknights.tconstruct.shared.block.ClearStainedGlassBlock.GlassColor;
 import slimeknights.tconstruct.shared.client.FluidParticle;
 
-import java.util.function.Consumer;
-
 @EventBusSubscriber(modid = TConstruct.MOD_ID, value = Dist.CLIENT, bus = Bus.MOD)
 public class CommonsClientEvents extends ClientEventBase {
   @SubscribeEvent
@@ -34,20 +30,6 @@ public class CommonsClientEvents extends ClientEventBase {
 
   @SubscribeEvent
   static void clientSetup(final FMLClientSetupEvent event) {
-    // glass
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.clearGlass.get(), RenderType.cutout());
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.clearGlassPane.get(), RenderType.cutout());
-
-    RenderType cutout = RenderType.cutout();
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.cheeseBlock.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.goldBars.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.goldPlatform.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.ironPlatform.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerCommons.cobaltPlatform.get(), cutout);
-    Consumer<Block> setCutout = block -> ItemBlockRenderTypes.setRenderLayer(block, cutout);
-    TinkerCommons.copperPlatform.forEach(setCutout);
-    TinkerCommons.waxedCopperPlatform.forEach(setCutout);
-
     Font unicode = unicodeFontRender();
     TinkerBook.MATERIALS_AND_YOU.fontRenderer = unicode;
     TinkerBook.TINKERS_GADGETRY.fontRenderer = unicode;

--- a/src/main/java/slimeknights/tconstruct/smeltery/SmelteryClientEvents.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/SmelteryClientEvents.java
@@ -56,16 +56,9 @@ public class SmelteryClientEvents extends ClientEventBase {
     // render layers
     RenderType cutout = RenderType.cutout();
     RenderType translucent = RenderType.translucent();
+
     // seared
-    // casting
     // TODO: migrate
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedFaucet.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedBasin.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedTable.get(), cutout);
-    // controller
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedMelter.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.smelteryController.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.foundryController.get(), cutout);
     // peripherals
     ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedDrain.get(), cutout);
     ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedDuct.get(), cutout);
@@ -76,13 +69,8 @@ public class SmelteryClientEvents extends ClientEventBase {
     ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedTintedGlass.get(), translucent);
     ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedGlassPane.get(), cutout);
     ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedSoulGlassPane.get(), translucent);
+
     // scorched
-    // casting
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedFaucet.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedBasin.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedTable.get(), cutout);
-    // controller
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedAlloyer.get(), cutout);
     // peripherals
     ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedDrain.get(), cutout);
     ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedDuct.get(), cutout);

--- a/src/main/java/slimeknights/tconstruct/smeltery/SmelteryClientEvents.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/SmelteryClientEvents.java
@@ -1,8 +1,6 @@
 package slimeknights.tconstruct.smeltery;
 
 import net.minecraft.client.gui.screens.MenuScreens;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.ModelEvent.RegisterGeometryLoaders;
@@ -53,36 +51,6 @@ public class SmelteryClientEvents extends ClientEventBase {
 
   @SubscribeEvent
   static void clientSetup(final FMLClientSetupEvent event) {
-    // render layers
-    RenderType cutout = RenderType.cutout();
-    RenderType translucent = RenderType.translucent();
-
-    // seared
-    // TODO: migrate
-    // peripherals
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedDrain.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedDuct.get(), cutout);
-    TinkerSmeltery.searedTank.forEach(tank -> ItemBlockRenderTypes.setRenderLayer(tank, cutout));
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedLantern.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedGlass.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedSoulGlass.get(), translucent);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedTintedGlass.get(), translucent);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedGlassPane.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.searedSoulGlassPane.get(), translucent);
-
-    // scorched
-    // peripherals
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedDrain.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedDuct.get(), cutout);
-    TinkerSmeltery.scorchedTank.forEach(tank -> ItemBlockRenderTypes.setRenderLayer(tank, cutout));
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedLantern.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedGlass.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedSoulGlass.get(), translucent);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedTintedGlass.get(), translucent);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedGlassPane.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerSmeltery.scorchedSoulGlassPane.get(), translucent);
-
-    // screens
     MenuScreens.register(TinkerSmeltery.melterContainer.get(), MelterScreen::new);
     MenuScreens.register(TinkerSmeltery.smelteryContainer.get(), HeatingStructureScreen::new);
     MenuScreens.register(TinkerSmeltery.singleItemContainer.get(), new SingleItemScreenFactory());

--- a/src/main/java/slimeknights/tconstruct/world/WorldClientEvents.java
+++ b/src/main/java/slimeknights/tconstruct/world/WorldClientEvents.java
@@ -104,23 +104,6 @@ public class WorldClientEvents extends ClientEventBase {
     RenderType cutoutMipped = RenderType.cutoutMipped();
 
     // render types - slime plants
-    for (FoliageType type : FoliageType.values()) {
-      if (type != FoliageType.BLOOD) {
-        ItemBlockRenderTypes.setRenderLayer(TinkerWorld.slimeLeaves.get(type), cutoutMipped);
-      }
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.vanillaSlimeGrass.get(type), cutoutMipped);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.earthSlimeGrass.get(type), cutoutMipped);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.skySlimeGrass.get(type), cutoutMipped);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.enderSlimeGrass.get(type), cutoutMipped);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.ichorSlimeGrass.get(type), cutoutMipped);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.slimeFern.get(type), cutout);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.pottedSlimeFern.get(type), cutout);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.slimeTallGrass.get(type), cutout);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.slimeSapling.get(type), cutout);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.pottedSlimeSapling.get(type), cutout);
-    }
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.enderSlimeVine.get(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.skySlimeVine.get(), cutout);
     ItemBlockRenderTypes.setRenderLayer(TinkerWorld.enderbarkRoots.get(), cutout);
 
     // render types - slime blocks

--- a/src/main/java/slimeknights/tconstruct/world/WorldClientEvents.java
+++ b/src/main/java/slimeknights/tconstruct/world/WorldClientEvents.java
@@ -9,8 +9,6 @@ import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.model.geom.ModelLayers;
 import net.minecraft.client.model.geom.builders.LayerDefinition;
 import net.minecraft.client.particle.ParticleEngine;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.SkullBlockRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
@@ -27,7 +25,6 @@ import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.common.ClientEventBase;
-import slimeknights.tconstruct.common.registration.GeodeItemObject.BudSize;
 import slimeknights.tconstruct.library.client.particle.SlimeParticle;
 import slimeknights.tconstruct.library.materials.definition.MaterialId;
 import slimeknights.tconstruct.shared.block.SlimeType;
@@ -100,35 +97,6 @@ public class WorldClientEvents extends ClientEventBase {
 
   @SubscribeEvent
   static void clientSetup(FMLClientSetupEvent event) {
-    RenderType cutout = RenderType.cutout();
-    RenderType cutoutMipped = RenderType.cutoutMipped();
-
-    // render types - slime plants
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.enderbarkRoots.get(), cutout);
-
-    // render types - slime blocks
-    RenderType translucent = RenderType.translucent();
-    for (SlimeType type : SlimeType.TINKER) {
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.slime.get(type), translucent);
-    }
-
-    // doors
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.greenheart.getDoor(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.greenheart.getTrapdoor(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.skyroot.getDoor(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.skyroot.getTrapdoor(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.bloodshroom.getDoor(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.bloodshroom.getTrapdoor(), cutout);
-    ItemBlockRenderTypes.setRenderLayer(TinkerWorld.enderbark.getTrapdoor(), cutout);
-
-    // geodes
-    for (BudSize size : BudSize.values()) {
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.earthGeode.getBud(size), cutout);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.skyGeode.getBud(size),   cutout);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.ichorGeode.getBud(size), cutout);
-      ItemBlockRenderTypes.setRenderLayer(TinkerWorld.enderGeode.getBud(size), cutout);
-    }
-
     // skull textures
     event.enqueueWork(() -> {
       registerHeadModel(TinkerHeadType.BLAZE, MaterialIds.blazingBone, new ResourceLocation("textures/entity/blaze.png"));

--- a/src/main/resources/assets/tconstruct/models/block/clear_glass/block.json
+++ b/src/main/resources/assets/tconstruct/models/block/clear_glass/block.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "mantle:connected",
   "parent": "block/cube_all",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/block.json
+++ b/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/block.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_noside.json
+++ b/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_noside.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "ambientocclusion": false,
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_noside_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_noside_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "ambientocclusion": false,
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_post.json
+++ b/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_post.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "ambientocclusion": false,
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_side.json
+++ b/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_side.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "ambientocclusion": false,
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_side_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/clear_stained_glass/pane_side_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "ambientocclusion": false,
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/clear_tinted_glass.json
+++ b/src/main/resources/assets/tconstruct/models/block/clear_tinted_glass.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "block/cube_all",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/flat_in.json
+++ b/src/main/resources/assets/tconstruct/models/block/flat_in.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:translucent",
     "parent": "block/cube_all",
     "ambientocclusion": false,
     "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/foundry/controller/alloyer.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/controller/alloyer.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:tank",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/foundry/glass/block.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/glass/block.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "mantle:connected",
   "parent": "block/cube_all",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/block.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/block.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "block/cube_all",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_noside.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_noside.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/noside",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_noside_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_noside_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/noside_alt",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_noside_edge.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_noside_edge.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "parent": "tconstruct:block/template/pane/noside_edge",
   "textures": {
     "pane": "tconstruct:block/foundry/soul_glass",

--- a/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_post.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_post.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/post",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_side.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_side.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/side",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_side_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/soul_glass/pane_side_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/side_alt",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/foundry/tinted_glass.json
+++ b/src/main/resources/assets/tconstruct/models/block/foundry/tinted_glass.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "block/cube_all",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/geode/earth/budding.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/earth/budding.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cube_all",
   "textures": {
     "all": "tconstruct:block/geode/earth/budding"

--- a/src/main/resources/assets/tconstruct/models/block/geode/earth/cluster.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/earth/cluster.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/earth/cluster"

--- a/src/main/resources/assets/tconstruct/models/block/geode/earth/large_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/earth/large_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/earth/large_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/earth/medium_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/earth/medium_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/earth/medium_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/earth/small_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/earth/small_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/earth/small_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ender/budding.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ender/budding.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cube_all",
   "textures": {
     "all": "tconstruct:block/geode/ender/budding"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ender/cluster.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ender/cluster.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/ender/cluster"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ender/large_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ender/large_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/ender/large_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ender/medium_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ender/medium_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/ender/medium_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ender/small_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ender/small_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/ender/small_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ichor/budding.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ichor/budding.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cube_all",
   "textures": {
     "all": "tconstruct:block/geode/ichor/budding"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ichor/cluster.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ichor/cluster.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/ichor/cluster"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ichor/large_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ichor/large_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/ichor/large_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ichor/medium_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ichor/medium_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/ichor/medium_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/ichor/small_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/ichor/small_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/ichor/small_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/sky/budding.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/sky/budding.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cube_all",
   "textures": {
     "all": "tconstruct:block/geode/sky/budding"

--- a/src/main/resources/assets/tconstruct/models/block/geode/sky/cluster.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/sky/cluster.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/sky/cluster"

--- a/src/main/resources/assets/tconstruct/models/block/geode/sky/large_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/sky/large_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/sky/large_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/sky/medium_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/sky/medium_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/sky/medium_bud"

--- a/src/main/resources/assets/tconstruct/models/block/geode/sky/small_bud.json
+++ b/src/main/resources/assets/tconstruct/models/block/geode/sky/small_bud.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/cross",
   "textures": {
     "cross": "tconstruct:block/geode/sky/small_bud"

--- a/src/main/resources/assets/tconstruct/models/block/gold_bars/cap.json
+++ b/src/main/resources/assets/tconstruct/models/block/gold_bars/cap.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:cutout",
     "parent": "block/iron_bars_cap",
     "textures": {
         "particle": "tconstruct:block/gold_bars",

--- a/src/main/resources/assets/tconstruct/models/block/gold_bars/cap_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/gold_bars/cap_alt.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:cutout",
     "parent": "block/iron_bars_cap_alt",
     "textures": {
         "particle": "tconstruct:block/gold_bars",

--- a/src/main/resources/assets/tconstruct/models/block/gold_bars/post.json
+++ b/src/main/resources/assets/tconstruct/models/block/gold_bars/post.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:cutout",
     "parent": "block/iron_bars_post",
     "textures": {
         "particle": "tconstruct:block/gold_bars",

--- a/src/main/resources/assets/tconstruct/models/block/gold_bars/post_ends.json
+++ b/src/main/resources/assets/tconstruct/models/block/gold_bars/post_ends.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:cutout",
     "parent": "block/iron_bars_post_ends",
     "textures": {
         "particle": "tconstruct:block/gold_bars",

--- a/src/main/resources/assets/tconstruct/models/block/gold_bars/side.json
+++ b/src/main/resources/assets/tconstruct/models/block/gold_bars/side.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:cutout",
     "parent": "block/iron_bars_side",
     "textures": {
         "particle": "tconstruct:block/gold_bars",

--- a/src/main/resources/assets/tconstruct/models/block/gold_bars/side_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/gold_bars/side_alt.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:cutout",
     "parent": "block/iron_bars_side_alt",
     "textures": {
         "particle": "tconstruct:block/gold_bars",

--- a/src/main/resources/assets/tconstruct/models/block/platform/both.json
+++ b/src/main/resources/assets/tconstruct/models/block/platform/both.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
 	"textures": {
 		"particle": "#top"
 	},

--- a/src/main/resources/assets/tconstruct/models/block/platform/bottom.json
+++ b/src/main/resources/assets/tconstruct/models/block/platform/bottom.json
@@ -1,5 +1,6 @@
 {
-    "parent": "block/block",
+  "render_type": "minecraft:cutout",
+  "parent": "block/block",
 	"textures": {
 		"particle": "#top"
 	},

--- a/src/main/resources/assets/tconstruct/models/block/platform/neither.json
+++ b/src/main/resources/assets/tconstruct/models/block/platform/neither.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
 	"textures": {
 		"particle": "#top"
 	},

--- a/src/main/resources/assets/tconstruct/models/block/platform/side.json
+++ b/src/main/resources/assets/tconstruct/models/block/platform/side.json
@@ -1,5 +1,6 @@
 {
-    "ambientocclusion": false,
+  "render_type": "minecraft:cutout",
+  "ambientocclusion": false,
 	"textures": {
 		"particle": "#top"
 	},

--- a/src/main/resources/assets/tconstruct/models/block/platform/top.json
+++ b/src/main/resources/assets/tconstruct/models/block/platform/top.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
 	"textures": {
 		"particle": "#top"
 	},

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/earth/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/earth/grass.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/earth/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/earth/grass.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/earth/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/earth/nylium.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/earth/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/earth/nylium.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/ender/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/ender/grass.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/ender/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/ender/grass.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/ender/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/ender/nylium.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/ender/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/ender/nylium.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/ichor/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/ichor/grass.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/ichor/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/ichor/grass.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/ichor/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/ichor/nylium.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/ichor/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/ichor/nylium.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/sky/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/sky/grass.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/sky/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/sky/grass.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/sky/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/sky/nylium.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/sky/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/sky/nylium.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/vanilla/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/vanilla/grass.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/vanilla/grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/vanilla/grass.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/grass_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/vanilla/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/vanilla/nylium.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/dirt/vanilla/nylium.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/dirt/vanilla/nylium.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/grass_block",
     "textures": {
         "top":      "tconstruct:block/slime/dirt/nylium_top",

--- a/src/main/resources/assets/tconstruct/models/block/slime/leaves.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/leaves.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout_mipped",
     "parent": "block/leaves",
     "textures": {
         "all": "tconstruct:block/slime/foliage/leaves"

--- a/src/main/resources/assets/tconstruct/models/block/slime/leaves.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/leaves.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout_mipped",
+    "render_type": "minecraft:cutout_mipped",
     "parent": "block/leaves",
     "textures": {
         "all": "tconstruct:block/slime/foliage/leaves"

--- a/src/main/resources/assets/tconstruct/models/block/slime/nether_grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/nether_grass.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "block/tinted_cross",
     "textures": {
         "cross": "tconstruct:block/slime/foliage/nether_grass"

--- a/src/main/resources/assets/tconstruct/models/block/slime/nether_grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/nether_grass.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "block/tinted_cross",
     "textures": {
         "cross": "tconstruct:block/slime/foliage/nether_grass"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_fern.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_fern.json
@@ -1,5 +1,5 @@
 {
-  "render_type": "cutout",
+  "render_type": "minecraft:cutout",
   "parent": "minecraft:block/tinted_flower_pot_cross",
   "textures": {
     "plant": "minecraft:block/fern"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_fern.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_fern.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "cutout",
   "parent": "minecraft:block/tinted_flower_pot_cross",
   "textures": {
     "plant": "minecraft:block/fern"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/blood.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/blood.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/blood"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/blood.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/blood.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/blood"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/earth.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/earth.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/earth"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/earth.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/earth.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/earth"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/ender.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/ender.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/ender"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/ender.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/ender.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/ender"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/ichor.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/ichor.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/ichor"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/ichor.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/ichor.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/ichor"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/sky.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/sky.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/sky"

--- a/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/sky.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/potted_sapling/sky.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "minecraft:block/flower_pot_cross",
     "textures": {
         "plant": "tconstruct:block/slime/sapling/sky"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/blood.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/blood.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/blood"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/blood.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/blood.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/blood"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/earth.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/earth.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/earth"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/earth.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/earth.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/earth"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/ender.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/ender.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/ender"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/ender.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/ender.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/ender"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/ichor.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/ichor.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/ichor"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/ichor.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/ichor.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/ichor"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/sky.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/sky.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/sky"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sapling/sky.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sapling/sky.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "block/cross",
     "textures": {
         "cross": "tconstruct:block/slime/sapling/sky"

--- a/src/main/resources/assets/tconstruct/models/block/slime/sticky/ender.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sticky/ender.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:translucent",
     "parent": "block/slime_block",
     "textures": {
         "particle": "tconstruct:block/slime/storage/ender",

--- a/src/main/resources/assets/tconstruct/models/block/slime/sticky/ichor.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sticky/ichor.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "parent": "block/block",
   "textures": {
     "particle": "tconstruct:block/slime/storage/ichor",

--- a/src/main/resources/assets/tconstruct/models/block/slime/sticky/sky.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/sticky/sky.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:translucent",
     "parent": "block/slime_block",
     "textures": {
         "particle": "tconstruct:block/slime/storage/sky",

--- a/src/main/resources/assets/tconstruct/models/block/slime/tall_grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/tall_grass.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "cutout",
     "parent": "block/tinted_cross",
     "textures": {
         "cross": "tconstruct:block/slime/foliage/tall_grass"

--- a/src/main/resources/assets/tconstruct/models/block/slime/tall_grass.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/tall_grass.json
@@ -1,5 +1,5 @@
 {
-    "render_type": "cutout",
+    "render_type": "minecraft:cutout",
     "parent": "block/tinted_cross",
     "textures": {
         "cross": "tconstruct:block/slime/foliage/tall_grass"

--- a/src/main/resources/assets/tconstruct/models/block/slime/vine/side.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/vine/side.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "#vine"

--- a/src/main/resources/assets/tconstruct/models/block/slime/vine/side.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/vine/side.json
@@ -1,5 +1,5 @@
 {
-  "render_type": "cutout",
+  "render_type": "minecraft:cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "#vine"

--- a/src/main/resources/assets/tconstruct/models/block/slime/vine/top.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/vine/top.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "tconstruct:block/slime/foliage/vine_end",

--- a/src/main/resources/assets/tconstruct/models/block/slime/vine/top.json
+++ b/src/main/resources/assets/tconstruct/models/block/slime/vine/top.json
@@ -1,5 +1,5 @@
 {
-  "render_type": "cutout",
+  "render_type": "minecraft:cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "tconstruct:block/slime/foliage/vine_end",

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/controller/melter.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/controller/melter.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:melter",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/glass/block.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/glass/block.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "mantle:connected",
   "parent": "block/cube_all",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/block.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/block.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "block/cube_all",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_noside.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_noside.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/noside",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_noside_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_noside_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/noside_alt",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_noside_edge.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_noside_edge.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "parent": "tconstruct:block/template/pane/noside_edge",
   "textures": {
     "pane": "tconstruct:block/smeltery/soul_glass",

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_post.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_post.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/post",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_side.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_side.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/side",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_side_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/soul_glass/pane_side_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/side_alt",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/smeltery/tinted_glass.json
+++ b/src/main/resources/assets/tconstruct/models/block/smeltery/tinted_glass.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "block/cube_all",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/soul_glass/block.json
+++ b/src/main/resources/assets/tconstruct/models/block/soul_glass/block.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "block/cube_all",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_noside.json
+++ b/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_noside.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/noside",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_noside_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_noside_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/noside_alt",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_noside_edge.json
+++ b/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_noside_edge.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "parent": "tconstruct:block/template/pane/noside_edge",
   "textures": {
     "pane": "tconstruct:block/soul_glass",

--- a/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_post.json
+++ b/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_post.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/post",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_side.json
+++ b/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_side.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/side",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_side_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/soul_glass/pane_side_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:translucent",
   "loader": "mantle:connected",
   "parent": "tconstruct:block/template/pane/side_alt",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/storage/cheese.json
+++ b/src/main/resources/assets/tconstruct/models/block/storage/cheese.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
 	"parent": "block/block",
 	"textures": {
 		"inner": "tconstruct:block/storage/cheese_block_inner",

--- a/src/main/resources/assets/tconstruct/models/block/storage/slimesteel.json
+++ b/src/main/resources/assets/tconstruct/models/block/storage/slimesteel.json
@@ -1,4 +1,6 @@
-{   "parent": "block/block",
+{
+    "render_type": "minecraft:translucent",
+    "parent": "block/block",
     "textures": {
         "particle": "tconstruct:block/storage/slimesteel",
         "slime": "tconstruct:block/storage/slimesteel_slime",

--- a/src/main/resources/assets/tconstruct/models/block/storage/soulsteel.json
+++ b/src/main/resources/assets/tconstruct/models/block/storage/soulsteel.json
@@ -1,4 +1,5 @@
 {
+    "render_type": "minecraft:translucent",
     "parent": "block/cube_all",
     "textures": {
         "all": "tconstruct:block/storage/soulsteel"

--- a/src/main/resources/assets/tconstruct/models/block/template/basin.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/basin.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:casting",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/template/controller.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/controller.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "mantle:retextured",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/template/controller_fluid.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/controller_fluid.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:fluid_texture",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/template/faucet.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/faucet.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "mantle:fluids",
   "comment": "Model is facing South (as in: the block it's connected to is south of it)",
   "parent": "minecraft:block/block",

--- a/src/main/resources/assets/tconstruct/models/block/template/faucet_up.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/faucet_up.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "mantle:fluids",
   "textures": {
     "particle": "#tex"

--- a/src/main/resources/assets/tconstruct/models/block/template/io.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/io.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "mantle:retextured",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/template/io_fluid.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/io_fluid.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:fluid_texture",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/template/lantern.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/lantern.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:tank",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/template/lantern_hanging.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/lantern_hanging.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:tank",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/template/pane/noside.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/pane/noside.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "#pane"

--- a/src/main/resources/assets/tconstruct/models/block/template/pane/noside_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/pane/noside_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "#pane"

--- a/src/main/resources/assets/tconstruct/models/block/template/pane/noside_edge.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/pane/noside_edge.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "#pane"

--- a/src/main/resources/assets/tconstruct/models/block/template/pane/post.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/pane/post.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "#pane"

--- a/src/main/resources/assets/tconstruct/models/block/template/pane/side.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/pane/side.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "#pane"

--- a/src/main/resources/assets/tconstruct/models/block/template/pane/side_alt.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/pane/side_alt.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "ambientocclusion": false,
   "textures": {
     "particle": "#pane"

--- a/src/main/resources/assets/tconstruct/models/block/template/table.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/table.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:casting",
   "parent": "block/block",
   "textures": {

--- a/src/main/resources/assets/tconstruct/models/block/template/tank.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/tank.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:tank",
   "parent": "block/block",
   "fluid": {

--- a/src/main/resources/assets/tconstruct/models/block/template/tank_knob.json
+++ b/src/main/resources/assets/tconstruct/models/block/template/tank_knob.json
@@ -1,4 +1,5 @@
 {
+  "render_type": "minecraft:cutout",
   "loader": "tconstruct:tank",
   "parent": "block/block",
   "textures": {


### PR DESCRIPTION
Removes all render type registrations for blocks from code and moves them into appropriate json model files.