### PR TITLE
Add 90 degree rotation to longbow arrow rendering

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/client/model/tools/ToolModel.java
+++ b/src/main/java/slimeknights/tconstruct/library/client/model/tools/ToolModel.java
@@ -512,7 +512,8 @@ public class ToolModel implements IUnbakedGeometry<ToolModel> {
     if (ammoKey != null) {
       // flipping rotates it 180 degrees, but because the origin is 0,0 instead of 0.5,0,5 it gets shifted
       // I could do some composition to shift the orgin, but its faster to just correct for it below
-      Quaternionf ammoRotation = flipAmmo ? Axis.YP.rotationDegrees(-180) : null;
+      // Additional 90 degree rotation around Z axis is applied after the flip
+      Quaternionf ammoRotation = flipAmmo ? Axis.YP.rotationDegrees(-180).mul(Axis.ZP.rotationDegrees(90)) : null;
       float flipOffset = flipAmmo ? 1 : 0;
 
       // left if requested is based on either small or right, reusing a variable allows us to keep the one that ended up used.


### PR DESCRIPTION
Modified the arrow rendering to apply an additional 90 degree rotation around the Z axis after the existing 180 degree flip. This changes how the arrow appears when drawn on the longbow.

Changes:
- Updated ToolModel.java to compose Y-axis 180° flip with Z-axis 90° rotation
- Arrow now renders flipped 180 degrees and then rotated 90 degrees