### PR TITLE
Skip circle attack on extra attacks

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/tools/definition/module/weapon/CircleWeaponAttack.java
+++ b/src/main/java/slimeknights/tconstruct/library/tools/definition/module/weapon/CircleWeaponAttack.java
@@ -37,6 +37,7 @@ public record CircleWeaponAttack(float diameter) implements MeleeHitToolHook, To
 
   @Override
   public void afterMeleeHit(IToolStackView tool, ToolAttackContext context, float damage) {
+    if (context.isExtraAttack()) return;
     // no need for fully charged for scythe sweep, easier than sword sweep
     // basically sword sweep logic, just deals full damage to all entities (and full effects)
     // but also takes more durability loss


### PR DESCRIPTION
The circle attack was triggering on extra attack procs (like from enchantments), which caused it to hit way more mobs than intended. This just adds a check to skip the circle attack entirely when it's an extra attack.

Fixes #5662