### PR TITLE
Fix water updates for waterlogged tables

### DIFF
--- a/src/main/java/slimeknights/tconstruct/shared/block/TableBlock.java
+++ b/src/main/java/slimeknights/tconstruct/shared/block/TableBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.LevelAccessor;
 import slimeknights.mantle.block.InventoryBlock;
 
 import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
@@ -54,6 +55,16 @@ public abstract class TableBlock extends InventoryBlock implements SimpleWaterlo
   public BlockState getStateForPlacement(BlockPlaceContext context) {
     boolean flag = context.getLevel().getFluidState(context.getClickedPos()).getType() == Fluids.WATER;
     return this.defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite()).setValue(WATERLOGGED, flag);
+  }
+
+  @SuppressWarnings("deprecation")
+  @Deprecated
+  @Override
+  public BlockState updateShape(BlockState state, Direction direction, BlockState neighbor, LevelAccessor level, BlockPos pos, BlockPos neighborPos) {
+    if (state.getValue(WATERLOGGED)) {
+      level.scheduleTick(pos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
+    }
+    return super.updateShape(state, direction, neighbor, level, pos, neighborPos);
   }
 
   @Deprecated


### PR DESCRIPTION
Fixes #5689

Waterlogged table blocks did not schedule a water fluid tick when a neighboring block changed. This caused water to remain inside the table after surrounding blocks were removed instead of flowing outward.

This adds `updateShape` to `TableBlock` and schedules a water tick whenever the table is waterlogged.

Testing:
- Built successfully with Java 17
- Confirmed water flows after removing blocks surrounding a waterlogged Crafting Station
- Confirmed with Tinker Station
- Confirmed with Part Builder