### PR TITLE
Fix soul glass being washed away by water

### DIFF
--- a/src/main/java/slimeknights/tconstruct/shared/TinkerCommons.java
+++ b/src/main/java/slimeknights/tconstruct/shared/TinkerCommons.java
@@ -117,7 +117,7 @@ public final class TinkerCommons extends TinkerModule {
   public static final ItemObject<ClearGlassPaneBlock> clearGlassPane = BLOCKS.register("clear_glass_pane", () -> new ClearGlassPaneBlock(glassBuilder(MapColor.NONE)), BLOCK_ITEM);
   public static final EnumObject<GlassColor,ClearStainedGlassBlock> clearStainedGlass = BLOCKS.registerEnum(GlassColor.values(), "clear_stained_glass", (color) -> new ClearStainedGlassBlock(glassBuilder(color.getDye().getMapColor()), color), BLOCK_ITEM);
   public static final EnumObject<GlassColor,ClearStainedGlassPaneBlock> clearStainedGlassPane = BLOCKS.registerEnum(GlassColor.values(), "clear_stained_glass_pane", (color) -> new ClearStainedGlassPaneBlock(glassBuilder(color.getDye().getMapColor()), color), BLOCK_ITEM);
-  public static final ItemObject<GlassBlock> soulGlass = BLOCKS.register("soul_glass", () -> new SoulGlassBlock(glassBuilder(MapColor.COLOR_BROWN).speedFactor(0.2F).noCollission().isViewBlocking((state, getter, pos) -> true)), TOOLTIP_BLOCK_ITEM);
+  public static final ItemObject<GlassBlock> soulGlass = BLOCKS.register("soul_glass", () -> new SoulGlassBlock(glassBuilder(MapColor.COLOR_BROWN).speedFactor(0.2F).noCollission().forceSolidOn().isViewBlocking((state, getter, pos) -> true)), TOOLTIP_BLOCK_ITEM);
   public static final ItemObject<ClearGlassPaneBlock> soulGlassPane = BLOCKS.register("soul_glass_pane", () -> new SoulGlassPaneBlock(glassBuilder(MapColor.COLOR_BROWN).speedFactor(0.2F)), TOOLTIP_BLOCK_ITEM);
   // panes
   public static final ItemObject<IronBarsBlock> goldBars = BLOCKS.register("gold_bars", () -> new IronBarsBlock(builder(MapColor.NONE, SoundType.METAL).requiresCorrectToolForDrops().strength(3.0F, 6.0F).noOcclusion()), TOOLTIP_BLOCK_ITEM);


### PR DESCRIPTION
Placing soul glass where flowing water can reach it destroys the block and drops it as an item. Seared soul glass and scorched soul glass are unaffected.

soul_glass is missing forceSolidOn() in its block properties. It has noCollission() like its seared/scorched siblings, but without forceSolidOn() to compensate it reads as non-solid, so water treats the space as free to flow into. The seared and scorched variants build off structureNonSolid(), which already calls forceSolidOn(), so they're fine. This adds forceSolidOn() to soul_glass to match.

Tested in game, same rig on both builds, water flowing into the block rather than setblock (which would skip the bug entirely):

before: the glass pops as an item and water flows straight through
![before](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/5667-before-destroyed.png)

after: water just stops beside it
![after](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/5667-after-survives.png)

Also checked you still sink through it same as before — forceSolidOn() only changes whether the block reads as solid, not its collision shape. Soul glass panes were never affected by this bug in the first place since they already waterlog instead of getting destroyed.

Fixes #5667
