### PR TITLE
Fix spitting draining the tank in creative mode

### DIFF
--- a/src/main/java/slimeknights/tconstruct/library/tools/helper/ModifierUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/tools/helper/ModifierUtil.java
@@ -91,7 +91,17 @@ public final class ModifierUtil {
    * @return  True if resources should be consumed.
    */
   public static boolean consumesResources(@Nullable LivingEntity entity) {
-    return !(entity instanceof Player player && player.isCreative());
+    return !(entity instanceof Player player) || consumesResources(player);
+  }
+
+  /**
+   * Checks if the given player pays the resource costs of using a tool, such as draining the tank or consuming ammo.
+   * Creative players get their resources for free, matching {@link ToolDamageUtil#directDamage(IToolStackView, int, LivingEntity, ItemStack)} skipping durability for them.
+   * @param player  Player using the tool. Null consumes, as only creative players get their resources for free.
+   * @return  True if resources should be consumed.
+   */
+  public static boolean consumesResources(@Nullable Player player) {
+    return player == null || !player.isCreative();
   }
 
   /**

--- a/src/main/java/slimeknights/tconstruct/library/tools/helper/ModifierUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/tools/helper/ModifierUtil.java
@@ -85,6 +85,16 @@ public final class ModifierUtil {
   }
 
   /**
+   * Checks if the given entity pays the resource costs of using a tool, such as draining the tank or consuming ammo.
+   * Creative players get their resources for free, matching {@link ToolDamageUtil#directDamage(IToolStackView, int, LivingEntity, ItemStack)} skipping durability for them.
+   * @param entity  Entity using the tool. Anything that is not a creative player consumes, including mobs and null.
+   * @return  True if resources should be consumed.
+   */
+  public static boolean consumesResources(@Nullable LivingEntity entity) {
+    return !(entity instanceof Player player && player.isCreative());
+  }
+
+  /**
    * Direct method to get the level of a modifier from a stack. If you need to get multiple modifier levels, using {@link ToolStack} is faster
    * @param stack     Stack to check
    * @param modifier  Modifier to search for

--- a/src/main/java/slimeknights/tconstruct/library/tools/helper/ToolDamageUtil.java
+++ b/src/main/java/slimeknights/tconstruct/library/tools/helper/ToolDamageUtil.java
@@ -6,7 +6,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.item.ItemStack;
 import slimeknights.tconstruct.common.TinkerTags;
@@ -70,7 +69,7 @@ public class ToolDamageUtil {
    * @return  True if the tool is broken now
    */
   public static boolean directDamage(IToolStackView tool, int amount, @Nullable LivingEntity entity, @Nullable ItemStack stack) {
-    if (entity instanceof Player player && player.isCreative()) {
+    if (!ModifierUtil.consumesResources(entity)) {
       return false;
     }
 

--- a/src/main/java/slimeknights/tconstruct/tools/modifiers/ability/fluid/UseFluidOnHitModifier.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modifiers/ability/fluid/UseFluidOnHitModifier.java
@@ -18,6 +18,7 @@ import slimeknights.tconstruct.library.modifiers.modules.build.StatBoostModule;
 import slimeknights.tconstruct.library.module.ModuleHookMap.Builder;
 import slimeknights.tconstruct.library.tools.capability.fluid.ToolTankHelper;
 import slimeknights.tconstruct.library.tools.context.EquipmentContext;
+import slimeknights.tconstruct.library.tools.helper.ModifierUtil;
 import slimeknights.tconstruct.library.tools.nbt.IToolStackView;
 import slimeknights.tconstruct.shared.TinkerCommons;
 import slimeknights.tconstruct.shared.particle.FluidParticleData;
@@ -62,7 +63,7 @@ public abstract class UseFluidOnHitModifier extends Modifier {
           int consumed = recipe.applyToEntity(fluid, 1, fluidContext, FluidAction.EXECUTE);
           if (consumed > 0) {
             spawnParticles(fluidContext.getTarget(), fluid);
-            if (player == null || !player.isCreative()) {
+            if (ModifierUtil.consumesResources(player)) {
               fluid.shrink(consumed);
               TANK_HELPER.setFluid(tool, fluid);
             }

--- a/src/main/java/slimeknights/tconstruct/tools/modules/combat/SpillingModule.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modules/combat/SpillingModule.java
@@ -54,7 +54,7 @@ public record SpillingModule(LevelingValue level, ModifierCondition<IToolStackVi
         FluidEffects recipe = FluidEffectManager.INSTANCE.find(fluid.getFluid());
         if (recipe.hasEntityEffects()) {
           int consumed = recipe.applyToEntity(fluid, this.level.compute(modifier.getEffectiveLevel()), FluidEffectContext.builder(attacker.level()).user(attacker, playerAttacker).projectile(projectile).target(target, livingTarget), FluidAction.EXECUTE);
-          if (consumed > 0 && (playerAttacker == null || !playerAttacker.isCreative())) {
+          if (consumed > 0 && ModifierUtil.consumesResources(playerAttacker)) {
             spawnParticles(target, fluid);
             fluid.shrink(consumed);
             TANK_HELPER.setFluid(tool, fluid);

--- a/src/main/java/slimeknights/tconstruct/tools/modules/interaction/SlurpingModule.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modules/interaction/SlurpingModule.java
@@ -44,6 +44,7 @@ import java.util.List;
 
 import static slimeknights.tconstruct.library.tools.capability.fluid.ToolTankHelper.TANK_HELPER;
 import static slimeknights.tconstruct.library.tools.helper.ModifierUtil.asPlayer;
+import static slimeknights.tconstruct.library.tools.helper.ModifierUtil.consumesResources;
 
 /** Modifier that after a short time applies a fluid effect to the holder. */
 public record SlurpingModule(LevelingValue strength, LevelingInt duration) implements ModifierModule, GeneralInteractionModifierHook, UsingToolModifierHook, KeybindInteractModifierHook, InventoryTickModifierHook, EquipmentChangeModifierHook {
@@ -88,7 +89,7 @@ public record SlurpingModule(LevelingValue strength, LevelingInt duration) imple
       if (!entity.level().isClientSide) {
         Player player = asPlayer(entity);
         int consumed = slurp(fluid, modifier, entity, player, FluidAction.EXECUTE);
-        if (consumed > 0 && (player == null || !player.isCreative())) {
+        if (consumed > 0 && consumesResources(player)) {
           fluid.shrink(consumed);
           TANK_HELPER.setFluid(tool, fluid);
         }

--- a/src/main/java/slimeknights/tconstruct/tools/modules/interaction/SpittingModule.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modules/interaction/SpittingModule.java
@@ -128,8 +128,11 @@ public record SpittingModule(LevelingInt shots) implements ModifierModule, Gener
           }
 
           // consume the fluid and durability
-          fluid.shrink(amount * shots);
-          TANK_HELPER.setFluid(tool, fluid);
+          Player player = ModifierUtil.asPlayer(entity);
+          if (player == null || !player.isCreative()) {
+            fluid.shrink(amount * shots);
+            TANK_HELPER.setFluid(tool, fluid);
+          }
           // stop using doesn't know the slot, so just figure it out
           ToolDamageUtil.damageAnimated(tool, shots, entity, modifier.getId());
         }

--- a/src/main/java/slimeknights/tconstruct/tools/modules/interaction/SpittingModule.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modules/interaction/SpittingModule.java
@@ -128,8 +128,7 @@ public record SpittingModule(LevelingInt shots) implements ModifierModule, Gener
           }
 
           // consume the fluid and durability
-          Player player = ModifierUtil.asPlayer(entity);
-          if (player == null || !player.isCreative()) {
+          if (ModifierUtil.consumesResources(entity)) {
             fluid.shrink(amount * shots);
             TANK_HELPER.setFluid(tool, fluid);
           }

--- a/src/main/java/slimeknights/tconstruct/tools/modules/interaction/SplashingModule.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modules/interaction/SplashingModule.java
@@ -33,6 +33,7 @@ import slimeknights.tconstruct.library.module.HookProvider;
 import slimeknights.tconstruct.library.module.ModuleHook;
 import slimeknights.tconstruct.library.tools.definition.module.ToolHooks;
 import slimeknights.tconstruct.library.tools.definition.module.aoe.AreaOfEffectIterator.AOEMatchType;
+import slimeknights.tconstruct.library.tools.helper.ModifierUtil;
 import slimeknights.tconstruct.library.tools.helper.ToolDamageUtil;
 import slimeknights.tconstruct.library.tools.item.IModifiable;
 import slimeknights.tconstruct.library.tools.nbt.IToolStackView;
@@ -116,7 +117,7 @@ public record SplashingModule(LevelingValue strength) implements ModifierModule,
             }
 
             // consume the fluid last, if any target used fluid
-            if (!player.isCreative() ) {
+            if (ModifierUtil.consumesResources(player)) {
               if (numTargets > 0) {
                 TANK_HELPER.setFluid(tool, fluid);
               }
@@ -187,7 +188,7 @@ public record SplashingModule(LevelingValue strength) implements ModifierModule,
             }
 
             // update fluid in tool and damage tool
-            if (player == null || !player.isCreative() ) {
+            if (ModifierUtil.consumesResources(player)) {
               if (numTargets > 0) {
                 TANK_HELPER.setFluid(tool, fluid);
               }


### PR DESCRIPTION
Spitting a tool with a tank (e.g. the Swasher) drains the tank in creative mode, even though spilling (melee) doesn't.

SpittingModule.spit() drains the tank unconditionally. It's missing the creative check that SpillingModule and the other tank-draining modules (SlurpingModule, SplashingModule, etc.) already have. The first commit guards the drain with the same player == null || !player.isCreative() check the other modules use. Durability was already creative-safe on its own, so that part is untouched.

The second commit changes no behavior: since that same check was written out by hand in six places, it now lives in one helper, ModifierUtil.consumesResources, the way ToolDamageUtil is already the one place deciding whether durability gets spent. Spilling, spitting, slurping, splashing and use fluid on hit all call it now, and ToolDamageUtil.directDamage does too; FireballModule keeps its own check, since that one skips durability whenever there is no player rather than only for creative players. Happy to drop that commit if you'd rather keep the fix minimal.

Tested in game with an Iron Swasher, tank filled through the game's own UI:

before: three creative spits, tank draining each time
![before](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/5682-before-drain-sequence.png)

after: same spits, tank stays put
![after](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/5682-after-unchanged-spit-live.png)

Survival still drains normally, a mob holding a spitting tool still drains too (the guard is player == null || ..., not player != null && ...), and spilling was already unaffected either way. I re-ran the same checks after the refactor: creative spitting and creative spilling still leave the tank alone, both still drain in survival, and slurping (which also moved onto the helper) is unchanged in creative and still drains in survival.

(#5682)

