### PR TITLE
Fix indirect damage applying loot modifiers from the held tool

### DIFF
--- a/src/generated/resources/data/tconstruct/tags/damage_type/is_melee.json
+++ b/src/generated/resources/data/tconstruct/tags/damage_type/is_melee.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:player_attack",
+    "minecraft:mob_attack",
+    "minecraft:mob_attack_no_aggro",
+    "minecraft:sting",
+    "tconstruct:fluid_impact_melee",
+    "tconstruct:fluid_spike_melee"
+  ]
+}

--- a/src/generated/resources/data/tconstruct/tags/damage_type/is_melee.json
+++ b/src/generated/resources/data/tconstruct/tags/damage_type/is_melee.json
@@ -5,6 +5,42 @@
     "minecraft:mob_attack_no_aggro",
     "minecraft:sting",
     "tconstruct:fluid_impact_melee",
-    "tconstruct:fluid_spike_melee"
+    "tconstruct:fluid_spike_melee",
+    {
+      "id": "twilightforest:ghast_tear",
+      "required": false
+    },
+    {
+      "id": "twilightforest:hydra_bite",
+      "required": false
+    },
+    {
+      "id": "twilightforest:squish",
+      "required": false
+    },
+    {
+      "id": "twilightforest:axing",
+      "required": false
+    },
+    {
+      "id": "twilightforest:slam",
+      "required": false
+    },
+    {
+      "id": "twilightforest:yeeted",
+      "required": false
+    },
+    {
+      "id": "twilightforest:ant",
+      "required": false
+    },
+    {
+      "id": "twilightforest:clamped",
+      "required": false
+    },
+    {
+      "id": "twilightforest:spiked",
+      "required": false
+    }
   ]
 }

--- a/src/generated/resources/data/tconstruct/tags/damage_type/loot_modifier_whitelist.json
+++ b/src/generated/resources/data/tconstruct/tags/damage_type/loot_modifier_whitelist.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "#tconstruct:protection/melee",
+    "tconstruct:piercing",
+    "tconstruct:fluid_fire_melee",
+    "tconstruct:fluid_cold_melee",
+    "tconstruct:fluid_magic_melee",
+    "tconstruct:water_melee"
+  ]
+}

--- a/src/generated/resources/data/tconstruct/tags/damage_type/loot_modifier_whitelist.json
+++ b/src/generated/resources/data/tconstruct/tags/damage_type/loot_modifier_whitelist.json
@@ -5,6 +5,8 @@
     "tconstruct:fluid_fire_melee",
     "tconstruct:fluid_cold_melee",
     "tconstruct:fluid_magic_melee",
-    "tconstruct:water_melee"
+    "tconstruct:water_melee",
+    "tconstruct:explosion_melee",
+    "tconstruct:mob_explosion_melee"
   ]
 }

--- a/src/generated/resources/data/tconstruct/tags/damage_type/loot_modifier_whitelist.json
+++ b/src/generated/resources/data/tconstruct/tags/damage_type/loot_modifier_whitelist.json
@@ -1,6 +1,6 @@
 {
   "values": [
-    "#tconstruct:protection/melee",
+    "#tconstruct:is_melee",
     "tconstruct:piercing",
     "tconstruct:fluid_fire_melee",
     "tconstruct:fluid_cold_melee",

--- a/src/generated/resources/data/tconstruct/tags/damage_type/protection/melee.json
+++ b/src/generated/resources/data/tconstruct/tags/damage_type/protection/melee.json
@@ -1,12 +1,7 @@
 {
   "values": [
-    "minecraft:player_attack",
-    "minecraft:mob_attack",
-    "minecraft:mob_attack_no_aggro",
+    "#tconstruct:is_melee",
     "minecraft:cramming",
-    "minecraft:sting",
-    "tconstruct:fluid_impact_melee",
-    "tconstruct:fluid_spike_melee",
     {
       "id": "twilightforest:ghast_tear",
       "required": false

--- a/src/generated/resources/data/tconstruct/tags/damage_type/protection/melee.json
+++ b/src/generated/resources/data/tconstruct/tags/damage_type/protection/melee.json
@@ -1,42 +1,6 @@
 {
   "values": [
     "#tconstruct:is_melee",
-    "minecraft:cramming",
-    {
-      "id": "twilightforest:ghast_tear",
-      "required": false
-    },
-    {
-      "id": "twilightforest:hydra_bite",
-      "required": false
-    },
-    {
-      "id": "twilightforest:squish",
-      "required": false
-    },
-    {
-      "id": "twilightforest:axing",
-      "required": false
-    },
-    {
-      "id": "twilightforest:slam",
-      "required": false
-    },
-    {
-      "id": "twilightforest:yeeted",
-      "required": false
-    },
-    {
-      "id": "twilightforest:ant",
-      "required": false
-    },
-    {
-      "id": "twilightforest:clamped",
-      "required": false
-    },
-    {
-      "id": "twilightforest:spiked",
-      "required": false
-    }
+    "minecraft:cramming"
   ]
 }

--- a/src/main/java/slimeknights/tconstruct/common/TinkerTags.java
+++ b/src/main/java/slimeknights/tconstruct/common/TinkerTags.java
@@ -922,6 +922,8 @@ public class TinkerTags {
 
     /** Damage types that can use modifiers. */
     public static final TagKey<DamageType> MODIFIER_WHITELIST = local("modifier_whitelist");
+    /** Damage types where the held tool is responsible for the kill, allowing it to apply loot modifiers such as severing. Projectiles instead use the modifiers stored on the projectile. */
+    public static final TagKey<DamageType> LOOT_MODIFIER_WHITELIST = local("loot_modifier_whitelist");
 
     private static TagKey<DamageType> local(String name) {
       return TagKey.create(Registries.DAMAGE_TYPE, getResource(name));

--- a/src/main/java/slimeknights/tconstruct/common/TinkerTags.java
+++ b/src/main/java/slimeknights/tconstruct/common/TinkerTags.java
@@ -907,6 +907,9 @@ public class TinkerTags {
 
   public static class DamageTypes {
     private static void init() {}
+    /** Damage types dealt by a melee attack, notably excluding damage that is merely in melee range such as cramming. Shared by the melee protection modifier and the loot modifier whitelist. */
+    public static final TagKey<DamageType> IS_MELEE = local("is_melee");
+
     /** Damage types reduced by the melee protection modifier */
     public static final TagKey<DamageType> MELEE_PROTECTION = local("protection/melee");
     /** Damage types reduced by the projectile protection modifier */

--- a/src/main/java/slimeknights/tconstruct/common/data/tags/DamageTypeTagProvider.java
+++ b/src/main/java/slimeknights/tconstruct/common/data/tags/DamageTypeTagProvider.java
@@ -59,6 +59,7 @@ import static slimeknights.tconstruct.common.TinkerDamageTypes.WATER;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.BLAST_PROTECTION;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.FALL_PROTECTION;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.FIRE_PROTECTION;
+import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.IS_MELEE;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.LOOT_MODIFIER_WHITELIST;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.MAGIC_PROTECTION;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.MELEE_PROTECTION;
@@ -86,14 +87,18 @@ public class DamageTypeTagProvider extends DamageTypeTagsProvider {
     // whole reason these are a pair is so we can tag one as projectile
     tag(IS_PROJECTILE).add(THROWN_TOOL, FISHING_HOOK, FLUID_IMPACT.ranged(), FLUID_FIRE.ranged(), FLUID_COLD.ranged(), FLUID_MAGIC.ranged(), WATER.ranged(), FLUID_SPIKE.ranged(), EXPLOSION.ranged(), MOB_EXPLOSION.ranged());
 
+    // damage caused by a melee attack, shared by the melee protection modifier and the loot modifier whitelist
+    tag(IS_MELEE).add(PLAYER_ATTACK, MOB_ATTACK, MOB_ATTACK_NO_AGGRO, STING, FLUID_IMPACT.melee(), FLUID_SPIKE.melee());
+
     // modifiers
     tag(MODIFIER_WHITELIST).add(MOB_ATTACK, MOB_ATTACK_NO_AGGRO);
     // loot modifiers come from the held tool, so limit them to melee damage the tool is responsible for
     // projectiles are not needed here, they use the modifiers stored on the projectile instead
-    tag(LOOT_MODIFIER_WHITELIST).addTag(MELEE_PROTECTION).add(PIERCING, FLUID_FIRE.melee(), FLUID_COLD.melee(), FLUID_MAGIC.melee(), WATER.melee());
+    tag(LOOT_MODIFIER_WHITELIST).addTag(IS_MELEE).add(PIERCING, FLUID_FIRE.melee(), FLUID_COLD.melee(), FLUID_MAGIC.melee(), WATER.melee());
 
     // protection modifier tags
-    tag(MELEE_PROTECTION).add(PLAYER_ATTACK, MOB_ATTACK, MOB_ATTACK_NO_AGGRO, CRAMMING, STING, FLUID_IMPACT.melee(), FLUID_SPIKE.melee());
+    // cramming is not an attack, so it gets protection without making the held tool responsible for the kill
+    tag(MELEE_PROTECTION).addTag(IS_MELEE).add(CRAMMING);
     tag(PROJECTILE_PROTECTION).addTag(IS_PROJECTILE).add(FALLING_ANVIL, FALLING_BLOCK, FALLING_STALACTITE);
     tag(FIRE_PROTECTION).addTags(IS_FIRE, IS_LIGHTNING).add(SHOCK);
     tag(BLAST_PROTECTION).addTag(IS_EXPLOSION);

--- a/src/main/java/slimeknights/tconstruct/common/data/tags/DamageTypeTagProvider.java
+++ b/src/main/java/slimeknights/tconstruct/common/data/tags/DamageTypeTagProvider.java
@@ -108,7 +108,8 @@ public class DamageTypeTagProvider extends DamageTypeTagsProvider {
     // TF support
     String tf = "twilightforest";
     addOptional(MODIFIER_WHITELIST, tf, "axing", "slam", "ant");
-    addOptional(MELEE_PROTECTION, tf, "ghast_tear", "hydra_bite", "squish", "axing", "slam", "yeeted", "ant", "clamped", "spiked");
+    // all of these are attacks made by a TF mob, and mobs can use looting, so they belong on the shared melee tag
+    addOptional(IS_MELEE, tf, "ghast_tear", "hydra_bite", "squish", "axing", "slam", "yeeted", "ant", "clamped", "spiked");
     addOptional(MAGIC_PROTECTION, tf, "haunt", "ominous_fire", "twilight_scepter");
     addOptional(PROJECTILE_PROTECTION, tf, "falling_ice");
     // anything "magic" is good against lich shields, so tag our magic fluids

--- a/src/main/java/slimeknights/tconstruct/common/data/tags/DamageTypeTagProvider.java
+++ b/src/main/java/slimeknights/tconstruct/common/data/tags/DamageTypeTagProvider.java
@@ -59,6 +59,7 @@ import static slimeknights.tconstruct.common.TinkerDamageTypes.WATER;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.BLAST_PROTECTION;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.FALL_PROTECTION;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.FIRE_PROTECTION;
+import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.LOOT_MODIFIER_WHITELIST;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.MAGIC_PROTECTION;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.MELEE_PROTECTION;
 import static slimeknights.tconstruct.common.TinkerTags.DamageTypes.MODIFIER_WHITELIST;
@@ -87,6 +88,9 @@ public class DamageTypeTagProvider extends DamageTypeTagsProvider {
 
     // modifiers
     tag(MODIFIER_WHITELIST).add(MOB_ATTACK, MOB_ATTACK_NO_AGGRO);
+    // loot modifiers come from the held tool, so limit them to melee damage the tool is responsible for
+    // projectiles are not needed here, they use the modifiers stored on the projectile instead
+    tag(LOOT_MODIFIER_WHITELIST).addTag(MELEE_PROTECTION).add(PIERCING, FLUID_FIRE.melee(), FLUID_COLD.melee(), FLUID_MAGIC.melee(), WATER.melee());
 
     // protection modifier tags
     tag(MELEE_PROTECTION).add(PLAYER_ATTACK, MOB_ATTACK, MOB_ATTACK_NO_AGGRO, CRAMMING, STING, FLUID_IMPACT.melee(), FLUID_SPIKE.melee());

--- a/src/main/java/slimeknights/tconstruct/common/data/tags/DamageTypeTagProvider.java
+++ b/src/main/java/slimeknights/tconstruct/common/data/tags/DamageTypeTagProvider.java
@@ -94,7 +94,7 @@ public class DamageTypeTagProvider extends DamageTypeTagsProvider {
     tag(MODIFIER_WHITELIST).add(MOB_ATTACK, MOB_ATTACK_NO_AGGRO);
     // loot modifiers come from the held tool, so limit them to melee damage the tool is responsible for
     // projectiles are not needed here, they use the modifiers stored on the projectile instead
-    tag(LOOT_MODIFIER_WHITELIST).addTag(IS_MELEE).add(PIERCING, FLUID_FIRE.melee(), FLUID_COLD.melee(), FLUID_MAGIC.melee(), WATER.melee());
+    tag(LOOT_MODIFIER_WHITELIST).addTag(IS_MELEE).add(PIERCING, FLUID_FIRE.melee(), FLUID_COLD.melee(), FLUID_MAGIC.melee(), WATER.melee(), EXPLOSION.melee(), MOB_EXPLOSION.melee());
 
     // protection modifier tags
     // cramming is not an attack, so it gets protection without making the held tool responsible for the kill

--- a/src/main/java/slimeknights/tconstruct/tools/modifiers/ModifierLootModifier.java
+++ b/src/main/java/slimeknights/tconstruct/tools/modifiers/ModifierLootModifier.java
@@ -3,6 +3,7 @@ package slimeknights.tconstruct.tools.modifiers;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.item.ItemStack;
@@ -66,7 +67,9 @@ public class ModifierLootModifier extends LootModifier {
       }
 
       // not a projectile causing it, fetch the killer entity directly from loot context
-      if (context.getParamOrNull(LootContextParams.KILLER_ENTITY) instanceof LivingEntity living) {
+      // requires a melee damage source, the held tool is not responsible for kills it did not make such as explosions
+      DamageSource damageSource = context.getParamOrNull(LootContextParams.DAMAGE_SOURCE);
+      if (damageSource != null && damageSource.is(TinkerTags.DamageTypes.LOOT_MODIFIER_WHITELIST) && context.getParamOrNull(LootContextParams.KILLER_ENTITY) instanceof LivingEntity living) {
         stack = living.getItemBySlot(ModifierLootingHandler.getLootingSlot(living));
       }
     }


### PR DESCRIPTION
Killing a mob with something other than your held tool (TNT you lit, for example) still applies the tool's loot modifiers, like severing heads, as if the tool made the kill.

Went with the damage source tag approach from the issue comment. ModifierLootModifier only falls back to the killer entity's held item when the damage source is in a new tag, tconstruct:loot_modifier_whitelist. It pulls in #tconstruct:protection/melee and adds piercing and the melee halves of the fluid damage pairs, since those are damage the held tool dealt itself. The projectile branch is untouched.

Thorns and spiny are deliberately out of the tag, going with purely melee for now. Bleeding is out too, so a mob that dies to the lacerating bleed tick no longer drops a severing head. That's a behavior change rather than something I wanted to quietly tag around; adding tconstruct:bleeding later restores it.

Tested in game, cleaver pushed to guaranteed severing chance, six zombies ringed around a block of TNT:

before: TNT goes off, six heads on the ground
![before](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/5699v2-before-tnt-heads.png)

after: same explosion, no heads
![after](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/5699v2-after-tnt-no-heads.png)

after: the bleed-tick kill, no head either
![bleed](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/5699v2-after-bleed-no-heads.png)

Three melee kills in the same session still gave three heads, so severing on direct hits is unaffected.

(#5699)


