### PR TITLE
Fix smeltery fuel gauge ignoring other fuel tanks when the current one empties

### DIFF
--- a/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MultitankFuelModule.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MultitankFuelModule.java
@@ -14,7 +14,6 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.templates.EmptyFluidHandler;
 import slimeknights.mantle.block.entity.MantleBlockEntity;
 import slimeknights.mantle.util.WeakConsumerWrapper;
-import slimeknights.tconstruct.library.recipe.fuel.MeltingFuel;
 import slimeknights.tconstruct.library.utils.Util;
 
 import javax.annotation.Nonnull;
@@ -22,7 +21,6 @@ import javax.annotation.Nullable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.function.Supplier;
 
 /** Fuel module that supports multiple tanks, selecting just one for the fuel result */
@@ -229,67 +227,50 @@ public class MultitankFuelModule extends FuelModule implements IFluidHandler {
 
   @Override
   public FuelInfo getFuelInfo() {
-    // if there is no position, means we have not yet consumed fuel. Just fetch the first tank
-    // TODO: should we try to find a valid fuel tank? might be a bit confusing if they have multiple tanks in the structure before melting
-    // however, a valid tank is a lot more effort to find
-
-    // Y of big negative is how the UI syncs null
-    BlockPos mainTank = lastPos;
-    if (mainTank.getY() == NULL_POS.getY()) {
-      // if no first, return no fuel info
-      List<BlockPos> positions = tankSupplier.get();
-      if (positions.isEmpty()) {
-        return FuelInfo.EMPTY;
-      }
-      mainTank = positions.get(0);
-      assert mainTank != null;
-    }
-
-    // fetch primary fuel handler
-    if (fluidHandler == null) {
-      LazyOptional<IFluidHandler> fluidCap = getTankHandlers().getOrDefault(mainTank, LazyOptional.empty());
+    // fetch the primary fuel handler, the tank we last pulled fuel from
+    // Y of big negative is how the UI syncs null, meaning we have not yet consumed fuel
+    if (fluidHandler == null && lastPos.getY() != NULL_POS.getY()) {
+      LazyOptional<IFluidHandler> fluidCap = getTankHandlers().getOrDefault(lastPos, LazyOptional.empty());
       if (fluidCap.isPresent()) {
         fluidHandler = fluidCap;
-        fluidHandler.addListener(fluidListener);
-      } else {
-        // ensure handlers is set
-        fluidHandler = LazyOptional.empty();
+        fluidCap.addListener(fluidListener);
       }
+    }
+
+    // two cases leave us with no tank to show despite the structure holding fuel: we never consumed fuel so we have no handler,
+    // and the tank we did consume from was drained dry while we are still burning the fuel we took out of it
+    // in both cases promote the first tank containing fluid, caching the handler so the search does not repeat next frame
+    // note we search for fluid rather than for fuel, skipping the recipe lookup as there is little use in non-fuels in the smeltery walls
+    if (fluidHandler == null || fluidHandler.orElse(EmptyFluidHandler.INSTANCE).getFluidInTank(0).isEmpty()) {
+      for (LazyOptional<IFluidHandler> tankCap : getTankHandlers().values()) {
+        if (!tankCap.orElse(EmptyFluidHandler.INSTANCE).getFluidInTank(0).isEmpty()) {
+          clearLastListener();
+          fluidHandler = tankCap;
+          tankCap.addListener(fluidListener);
+          break;
+        }
+      }
+      // if no tank contains fluid we cache nothing, so the search runs again next frame until fuel returns
+      // caching the lack of a tank saves that loop, but leaves the gauge empty after refueling a structure that ran dry
     }
 
     // determine what fluid we have and hpw many other fluids we have
     FuelInfo info = super.getFuelInfo();
-    // the main tank may have been drained dry while we are still burning the fuel we pulled out of it,
-    // which leaves nothing to display despite the other tanks being full. promote the first tank with fluid instead
-    if (info.isEmpty()) {
-      for (Entry<BlockPos,LazyOptional<IFluidHandler>> entry : getTankHandlers().entrySet()) {
-        IFluidHandler handler = entry.getValue().orElse(EmptyFluidHandler.INSTANCE);
-        FluidStack fluid = handler.getFluidInTank(0);
-        if (!fluid.isEmpty()) {
-          // FuelInfo.of returns a new instance for a non-empty fluid, needed as the loop below mutates the info
-          MeltingFuel recipe = findRecipe(fluid.getFluid());
-          info = FuelInfo.of(fluid, handler.getTankCapacity(0), recipe == null ? 0 : recipe.getTemperature());
-          mainTank = entry.getKey();
-          break;
-        }
-      }
-    }
     // add extra fluid display
     if (!info.isEmpty()) {
       // add display info from each handler
-      FuelInfo mainInfo = info;
       FluidStack currentFuel = info.getFluid();
-      for (Entry<BlockPos,LazyOptional<IFluidHandler>> entry : getTankHandlers().entrySet()) {
-        if (!mainTank.equals(entry.getKey())) {
-          entry.getValue().ifPresent(handler -> {
-            // sum if empty (more capacity) or the same fluid (more amount and capacity)
-            FluidStack fluid = handler.getFluidInTank(0);
-            if (fluid.isEmpty()) {
-              mainInfo.add(0, handler.getTankCapacity(0));
-            } else if (currentFuel.isFluidEqual(fluid)) {
-              mainInfo.add(fluid.getAmount(), handler.getTankCapacity(0));
-            }
-          });
+      for (LazyOptional<IFluidHandler> tankCap : getTankHandlers().values()) {
+        // skip the main tank, the info above is already its contents
+        if (tankCap != fluidHandler) {
+          IFluidHandler handler = tankCap.orElse(EmptyFluidHandler.INSTANCE);
+          // sum if empty (more capacity) or the same fluid (more amount and capacity)
+          FluidStack fluid = handler.getFluidInTank(0);
+          if (fluid.isEmpty()) {
+            info.add(0, handler.getTankCapacity(0));
+          } else if (currentFuel.isFluidEqual(fluid)) {
+            info.add(fluid.getAmount(), handler.getTankCapacity(0));
+          }
         }
       }
     }

--- a/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MultitankFuelModule.java
+++ b/src/main/java/slimeknights/tconstruct/smeltery/block/entity/module/MultitankFuelModule.java
@@ -14,6 +14,7 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.templates.EmptyFluidHandler;
 import slimeknights.mantle.block.entity.MantleBlockEntity;
 import slimeknights.mantle.util.WeakConsumerWrapper;
+import slimeknights.tconstruct.library.recipe.fuel.MeltingFuel;
 import slimeknights.tconstruct.library.utils.Util;
 
 import javax.annotation.Nonnull;
@@ -258,9 +259,25 @@ public class MultitankFuelModule extends FuelModule implements IFluidHandler {
 
     // determine what fluid we have and hpw many other fluids we have
     FuelInfo info = super.getFuelInfo();
+    // the main tank may have been drained dry while we are still burning the fuel we pulled out of it,
+    // which leaves nothing to display despite the other tanks being full. promote the first tank with fluid instead
+    if (info.isEmpty()) {
+      for (Entry<BlockPos,LazyOptional<IFluidHandler>> entry : getTankHandlers().entrySet()) {
+        IFluidHandler handler = entry.getValue().orElse(EmptyFluidHandler.INSTANCE);
+        FluidStack fluid = handler.getFluidInTank(0);
+        if (!fluid.isEmpty()) {
+          // FuelInfo.of returns a new instance for a non-empty fluid, needed as the loop below mutates the info
+          MeltingFuel recipe = findRecipe(fluid.getFluid());
+          info = FuelInfo.of(fluid, handler.getTankCapacity(0), recipe == null ? 0 : recipe.getTemperature());
+          mainTank = entry.getKey();
+          break;
+        }
+      }
+    }
     // add extra fluid display
     if (!info.isEmpty()) {
       // add display info from each handler
+      FuelInfo mainInfo = info;
       FluidStack currentFuel = info.getFluid();
       for (Entry<BlockPos,LazyOptional<IFluidHandler>> entry : getTankHandlers().entrySet()) {
         if (!mainTank.equals(entry.getKey())) {
@@ -268,9 +285,9 @@ public class MultitankFuelModule extends FuelModule implements IFluidHandler {
             // sum if empty (more capacity) or the same fluid (more amount and capacity)
             FluidStack fluid = handler.getFluidInTank(0);
             if (fluid.isEmpty()) {
-              info.add(0, handler.getTankCapacity(0));
+              mainInfo.add(0, handler.getTankCapacity(0));
             } else if (currentFuel.isFluidEqual(fluid)) {
-              info.add(fluid.getAmount(), handler.getTankCapacity(0));
+              mainInfo.add(fluid.getAmount(), handler.getTankCapacity(0));
             }
           });
         }


### PR DESCRIPTION
This is the "no fuel found" half of #4881, the part left open after the fluid doubling fix. The guess on the issue was a sync issue with the current fuel; it is not, server and client agree on the current tank the whole time. It is display logic in `MultitankFuelModule#getFuelInfo()`.

That method resolves a main tank, asks the superclass for its contents, then walks the other tanks to sum them into the gauge. The sum is behind one check, `MultitankFuelModule.java:262`:

```java
    FuelInfo info = super.getFuelInfo();
    // add extra fluid display
    if (!info.isEmpty()) {
```

`super.getFuelInfo()` only reads the main tank, and `FuelInfo.of` short circuits to the shared empty instance the moment that tank reads empty (`FuelModule.java:266-268`). So an empty main tank skips the aggregation entirely and every other tank is dropped, however full. `GuiFuelModule` then draws nothing and the tooltip falls to `gui.tconstruct.melting.fuel.empty`.

The main tank reads empty while the smeltery is still burning because fuel is banked. `findFuel` drains a whole charge at once and stores a tick countdown, and `SmelteryBlockEntity.heat()` only looks for fuel again when that countdown hits zero (`SmelteryBlockEntity.java:72-73`). For the whole burn-down of the last charge, `lastPos` still points at the tank that is now empty, correctly, and the gauge concludes there is no fuel. When the charge runs out `findFuel` moves on and the gauge fixes itself, which is why it shows briefly, and a rejoin clears it because that resets `lastPos`.

The fix promotes the first tank that still holds fluid when the main tank reads empty, then aggregates as before. Nothing is written back, `fluidHandler` and `lastPos` are untouched and the promotion is recomputed per frame, so there is no protocol or server side change.

One thing worth your call: the scan promotes the first tank with fluid, not the first tank with valid fuel, matching the TODO already in that method about a valid tank being more effort to find. The promoted tank still goes through one `findRecipe` for the temperature, so a non-fuel fluid gets temperature 0 and the tooltip already renders that as "Invalid melting fuel!". The visible cost is a structure holding some non-fuel fluid in a tank ahead of the real fuel tank, where the gauge would point at the wrong one. Happy to make it require valid fuel if you would rather.

Tested on a tiny smeltery with two seared fuel tanks, one holding a single 50 mB lava charge and the other four buckets, melting raw iron so the charge is actually consumed. On this size the banked charge is 400 ticks, so the wrong display lasts about twenty seconds.

before, the last charge has drained the first tank and the gauge is empty while the other tank holds four buckets:
![before](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/4881-before-no-fuel-found.png)

after, same moment, the gauge shows the tank that still has fuel:
![after](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/4881-after-other-tank-shown.png)

with every tank empty it still reads no fuel found, and a main tank that does have fluid renders exactly as before:
![empty](https://raw.githubusercontent.com/ryancircelli/TinkersConstruct/pr-assets/4881-after-all-tanks-empty.png)

`./gradlew build test` passes, 187 tests.

Report: #4881
