### PR TITLE
Use newer JEI convenience functions

### DIFF
--- a/src/main/java/slimeknights/tconstruct/plugin/jei/AlloyRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/AlloyRecipeCategory.java
@@ -1,7 +1,6 @@
 package slimeknights.tconstruct.plugin.jei;
 
 import lombok.Getter;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -20,7 +19,6 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import slimeknights.mantle.fluid.tooltip.FluidTooltipHandler;
 import slimeknights.tconstruct.TConstruct;
@@ -66,7 +64,7 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
 
   public AlloyRecipeCategory(IGuiHelper helper) {
     this.background = helper.createDrawable(BACKGROUND_LOC, 0, 0, 172, 62);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerSmeltery.smelteryController));
+    this.icon = helper.createDrawableItemLike(TinkerSmeltery.smelteryController);
     this.arrow = helper.drawableBuilder(BACKGROUND_LOC, 172, 0, 24, 17).buildAnimated(200, StartDirection.LEFT, false);
     this.tank = helper.createDrawable(BACKGROUND_LOC, 172, 17, 16, 16);
   }
@@ -159,7 +157,7 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
                                        ingredient -> ingredient.catalyst() ? CATALYST_TOOLTIP : FluidTooltipCallback.UNITS);
 
     // output
-    builder.addSlot(RecipeIngredientRole.OUTPUT, 137, 11)
+    builder.addOutputSlot(137, 11)
            .addTooltipCallback(FluidTooltipCallback.UNITS)
            .setFluidRenderer(maxAmount, false, 16, 32)
            .addIngredient(ForgeTypes.FLUID_STACK, recipe.getOutput());

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/JEIPlugin.java
@@ -257,17 +257,16 @@ public class JEIPlugin implements IModPlugin {
 
   /**
    * Adds an item as a casting catalyst, and as a molding catalyst if it has molding recipes
-   * @param registry     Catalyst regisry
+   * @param registry     Catalyst registry
    * @param item         Item to add
    * @param ownCategory  Category to always add
    * @param type         Molding recipe type
    */
   private static void addCastingCatalyst(IRecipeCatalystRegistration registry, ItemLike item, mezz.jei.api.recipe.RecipeType<IDisplayableCastingRecipe> ownCategory, RecipeType<MoldingRecipe> type) {
-    ItemStack stack = new ItemStack(item);
-    registry.addRecipeCatalyst(stack, ownCategory);
+    registry.addRecipeCatalyst(item, ownCategory);
     assert Minecraft.getInstance().level != null;
     if (!Minecraft.getInstance().level.getRecipeManager().byType(type).isEmpty()) {
-      registry.addRecipeCatalyst(stack, TConstructJEIConstants.MOLDING);
+      registry.addRecipeCatalyst(item, TConstructJEIConstants.MOLDING);
     }
   }
 
@@ -281,25 +280,25 @@ public class JEIPlugin implements IModPlugin {
   @Override
   public void registerRecipeCatalysts(IRecipeCatalystRegistration registry) {
     // tables
-    registry.addRecipeCatalyst(new ItemStack(TinkerTables.craftingStation), RecipeTypes.CRAFTING);
-    registry.addRecipeCatalyst(new ItemStack(TinkerTables.partBuilder), TConstructJEIConstants.PART_BUILDER);
-    registry.addRecipeCatalyst(new ItemStack(TinkerTables.tinkerStation), TConstructJEIConstants.MODIFIERS, TConstructJEIConstants.TOOL_BUILDING);
-    registry.addRecipeCatalyst(new ItemStack(TinkerTables.tinkersAnvil), TConstructJEIConstants.MODIFIERS, TConstructJEIConstants.TOOL_BUILDING);
-    registry.addRecipeCatalyst(new ItemStack(TinkerTables.scorchedAnvil), TConstructJEIConstants.MODIFIERS, TConstructJEIConstants.TOOL_BUILDING);
-    registry.addRecipeCatalyst(new ItemStack(TinkerTables.modifierWorktable), TConstructJEIConstants.MODIFIER_WORKTABLE);
+    registry.addRecipeCatalyst(TinkerTables.craftingStation, RecipeTypes.CRAFTING);
+    registry.addRecipeCatalyst(TinkerTables.partBuilder, TConstructJEIConstants.PART_BUILDER);
+    registry.addRecipeCatalyst(TinkerTables.tinkerStation, TConstructJEIConstants.MODIFIERS, TConstructJEIConstants.TOOL_BUILDING);
+    registry.addRecipeCatalyst(TinkerTables.tinkersAnvil, TConstructJEIConstants.MODIFIERS, TConstructJEIConstants.TOOL_BUILDING);
+    registry.addRecipeCatalyst(TinkerTables.scorchedAnvil, TConstructJEIConstants.MODIFIERS, TConstructJEIConstants.TOOL_BUILDING);
+    registry.addRecipeCatalyst(TinkerTables.modifierWorktable, TConstructJEIConstants.MODIFIER_WORKTABLE);
 
     // smeltery
-    registry.addRecipeCatalyst(new ItemStack(TinkerSmeltery.searedMelter), TConstructJEIConstants.MELTING);
-    registry.addRecipeCatalyst(new ItemStack(TinkerSmeltery.searedHeater), RecipeTypes.FUELING);
+    registry.addRecipeCatalyst(TinkerSmeltery.searedMelter, TConstructJEIConstants.MELTING);
+    registry.addRecipeCatalyst(TinkerSmeltery.searedHeater, RecipeTypes.FUELING);
     addCastingCatalyst(registry, TinkerSmeltery.searedTable, TConstructJEIConstants.CASTING_TABLE, TinkerRecipeTypes.MOLDING_TABLE.get());
     addCastingCatalyst(registry, TinkerSmeltery.searedBasin, TConstructJEIConstants.CASTING_BASIN, TinkerRecipeTypes.MOLDING_BASIN.get());
-    registry.addRecipeCatalyst(new ItemStack(TinkerSmeltery.smelteryController), TConstructJEIConstants.MELTING, TConstructJEIConstants.ALLOY, TConstructJEIConstants.ENTITY_MELTING);
+    registry.addRecipeCatalyst(TinkerSmeltery.smelteryController, TConstructJEIConstants.MELTING, TConstructJEIConstants.ALLOY, TConstructJEIConstants.ENTITY_MELTING);
 
     // foundry
-    registry.addRecipeCatalyst(new ItemStack(TinkerSmeltery.scorchedAlloyer), TConstructJEIConstants.ALLOY);
+    registry.addRecipeCatalyst(TinkerSmeltery.scorchedAlloyer, TConstructJEIConstants.ALLOY);
     addCastingCatalyst(registry, TinkerSmeltery.scorchedTable, TConstructJEIConstants.CASTING_TABLE, TinkerRecipeTypes.MOLDING_TABLE.get());
     addCastingCatalyst(registry, TinkerSmeltery.scorchedBasin, TConstructJEIConstants.CASTING_BASIN, TinkerRecipeTypes.MOLDING_BASIN.get());
-    registry.addRecipeCatalyst(new ItemStack(TinkerSmeltery.foundryController), TConstructJEIConstants.FOUNDRY);
+    registry.addRecipeCatalyst(TinkerSmeltery.foundryController, TConstructJEIConstants.FOUNDRY);
 
     // modifiers
     addModifierCatalyst(registry, TinkerTags.Modifiers.CRAFTING, RecipeTypes.CRAFTING);
@@ -342,18 +341,18 @@ public class JEIPlugin implements IModPlugin {
       }
       return IIngredientSubtypeInterpreter.NONE;
     };
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.craftingStation.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.partBuilder.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.tinkerStation.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.modifierWorktable.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.smelteryController.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.searedDrain.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.searedDuct.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.searedChute.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.foundryController.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.scorchedDrain.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.scorchedDuct.asItem(), tables);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.scorchedChute.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerTables.craftingStation.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerTables.partBuilder.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerTables.tinkerStation.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerTables.modifierWorktable.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.smelteryController.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.searedDrain.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.searedDuct.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.searedChute.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.foundryController.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.scorchedDrain.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.scorchedDuct.asItem(), tables);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.scorchedChute.asItem(), tables);
 
     // anvils have both texture and material blocks
     IIngredientSubtypeInterpreter<ItemStack> anvils = (stack, context) -> {
@@ -366,42 +365,42 @@ public class JEIPlugin implements IModPlugin {
       }
       return IIngredientSubtypeInterpreter.NONE;
     };
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.tinkersAnvil.asItem(), anvils);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerTables.scorchedAnvil.asItem(), anvils);
+    registry.registerSubtypeInterpreter(TinkerTables.tinkersAnvil.asItem(), anvils);
+    registry.registerSubtypeInterpreter(TinkerTables.scorchedAnvil.asItem(), anvils);
 
     // potions
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerFluids.potion.asItem(), (PotionSubtypeInterpreter<ItemStack>)ItemStack::getTag);
+    registry.registerSubtypeInterpreter(TinkerFluids.potion.asItem(), (PotionSubtypeInterpreter<ItemStack>)ItemStack::getTag);
     registry.registerSubtypeInterpreter(ForgeTypes.FLUID_STACK, TinkerFluids.potion.get(), (PotionSubtypeInterpreter<FluidStack>)FluidStack::getTag);
 
     // parts
     for (Holder<Item> item : BuiltInRegistries.ITEM.getTagOrEmpty(TinkerTags.Items.TOOL_PARTS)) {
-      registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, item.value(), ToolPartSubtypeInterpreter.INSTANCE);
+      registry.registerSubtypeInterpreter(item.value(), ToolPartSubtypeInterpreter.INSTANCE);
     }
 
     // tools
     for (Holder<Item> holder : BuiltInRegistries.ITEM.getTagOrEmpty(TinkerTags.Items.MULTIPART_TOOL)) {
       Item item = holder.value();
-      registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, item, holder.is(TinkerTags.Items.SINGLEPART_TOOL) ? ToolSubtypeInterpreter.FIRST : ToolSubtypeInterpreter.INGREDIENT);
+      registry.registerSubtypeInterpreter(item, holder.is(TinkerTags.Items.SINGLEPART_TOOL) ? ToolSubtypeInterpreter.FIRST : ToolSubtypeInterpreter.INGREDIENT);
     }
 
     // fluid containers have types based on fluid, don't bother with different sizes
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.copperCan.get(), (stack, context) -> CopperCanItem.getSubtype(stack));
+    registry.registerSubtypeInterpreter(TinkerSmeltery.copperCan.get(), (stack, context) -> CopperCanItem.getSubtype(stack));
     IIngredientSubtypeInterpreter<ItemStack> tankInterpreter = (stack, context) -> TankItem.getSubtype(stack);
     for (TankType type : TankType.values()) {
-      registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.searedTank.get(type).asItem(), tankInterpreter);
-      registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.scorchedTank.get(type).asItem(), tankInterpreter);
+      registry.registerSubtypeInterpreter(TinkerSmeltery.searedTank.get(type).asItem(), tankInterpreter);
+      registry.registerSubtypeInterpreter(TinkerSmeltery.scorchedTank.get(type).asItem(), tankInterpreter);
     }
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.searedLantern.asItem(), tankInterpreter);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.scorchedLantern.asItem(), tankInterpreter);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.searedFluidCannon.asItem(), tankInterpreter);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.scorchedFluidCannon.asItem(), tankInterpreter);
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerSmeltery.endFluidCannon.asItem(), tankInterpreter);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.searedLantern.asItem(), tankInterpreter);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.scorchedLantern.asItem(), tankInterpreter);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.searedFluidCannon.asItem(), tankInterpreter);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.scorchedFluidCannon.asItem(), tankInterpreter);
+    registry.registerSubtypeInterpreter(TinkerSmeltery.endFluidCannon.asItem(), tankInterpreter);
 
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerModifiers.creativeSlotItem.get(), (stack, context) -> {
+    registry.registerSubtypeInterpreter(TinkerModifiers.creativeSlotItem.get(), (stack, context) -> {
       SlotType slotType = CreativeSlotItem.getSlot(stack);
       return slotType != null ? slotType.getName() : "";
     });
-    registry.registerSubtypeInterpreter(VanillaTypes.ITEM_STACK, TinkerModifiers.modifierCrystal.get(), (stack, context) -> {
+    registry.registerSubtypeInterpreter(TinkerModifiers.modifierCrystal.get(), (stack, context) -> {
       ModifierId id = ModifierCrystalItem.getModifier(stack);
       return id == null ? "" : id.toString();
     });

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/MoldingRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/MoldingRecipeCategory.java
@@ -1,9 +1,9 @@
 package slimeknights.tconstruct.plugin.jei;
 
 import lombok.Getter;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
@@ -16,7 +16,6 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import slimeknights.mantle.client.SafeClientAccess;
 import slimeknights.tconstruct.TConstruct;
@@ -24,9 +23,6 @@ import slimeknights.tconstruct.library.client.GuiUtil;
 import slimeknights.tconstruct.library.recipe.TinkerRecipeTypes;
 import slimeknights.tconstruct.library.recipe.molding.MoldingRecipe;
 import slimeknights.tconstruct.smeltery.TinkerSmeltery;
-
-import java.util.Collections;
-import java.util.List;
 
 /** Recipe category for molding casts */
 public class MoldingRecipeCategory implements IRecipeCategory<MoldingRecipe> {
@@ -38,7 +34,7 @@ public class MoldingRecipeCategory implements IRecipeCategory<MoldingRecipe> {
   private final IDrawable icon;
   private final IDrawable table, basin, downArrow, upArrow;
   public MoldingRecipeCategory(IGuiHelper helper) {
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerSmeltery.blankSandCast.get()));
+    this.icon = helper.createDrawableItemLike(TinkerSmeltery.blankSandCast);
     this.table = helper.createDrawable(BACKGROUND_LOC, 117, 0, 16, 16);
     this.basin = helper.createDrawable(BACKGROUND_LOC, 117, 16, 16, 16);
     this.downArrow = helper.createDrawable(BACKGROUND_LOC, 70, 55, 6, 6);
@@ -86,26 +82,25 @@ public class MoldingRecipeCategory implements IRecipeCategory<MoldingRecipe> {
   }
 
   @Override
-  public List<Component> getTooltipStrings(MoldingRecipe recipe, IRecipeSlotsView slots, double mouseX, double mouseY) {
+  public void getTooltip(ITooltipBuilder tooltip, MoldingRecipe recipe, IRecipeSlotsView slots, double mouseX, double mouseY) {
     if (recipe.isPatternConsumed() && !recipe.getPattern().isEmpty() && GuiUtil.isHovered((int)mouseX, (int)mouseY, 50, 7, 18, 18)) {
-      return Collections.singletonList(TOOLTIP_PATTERN_CONSUMED);
+      tooltip.add(TOOLTIP_PATTERN_CONSUMED);
     }
-    return Collections.emptyList();
   }
 
   @Override
   public void setRecipe(IRecipeLayoutBuilder builder, MoldingRecipe recipe, IFocusGroup focuses) {
     // basic input output
-    builder.addSlot(RecipeIngredientRole.INPUT, 3, 24).addIngredients(recipe.getMaterial());
+    builder.addInputSlot(3, 24).addIngredients(recipe.getMaterial());
     RegistryAccess access = SafeClientAccess.getRegistryAccess();
     if (access != null) {
-      builder.addSlot(RecipeIngredientRole.OUTPUT, 51, 24).addItemStack(recipe.getResultItem(access));
+      builder.addOutputSlot(51, 24).addItemStack(recipe.getResultItem(access));
     }
 
     // if we have a mold, we are pressing into the table, so draw pressed item on input and output
     Ingredient pattern = recipe.getPattern();
     if (!pattern.isEmpty()) {
-      IRecipeSlotBuilder inputSlot = builder.addSlot(RecipeIngredientRole.INPUT, 3, 1).addIngredients(pattern);
+      IRecipeSlotBuilder inputSlot = builder.addInputSlot(3, 1).addIngredients(pattern);
       if (!recipe.isPatternConsumed()) {
         IRecipeSlotBuilder preservedSlot = builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 51, 8).addIngredients(pattern);
         builder.createFocusLink(inputSlot, preservedSlot);

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/ToolBuildingCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/ToolBuildingCategory.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import lombok.Getter;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
@@ -86,7 +87,7 @@ public class ToolBuildingCategory implements IRecipeCategory<ToolBuildingRecipe>
 
     IRecipeSlotBuilder firstSlot = null;
     for (int i = 0; i < layoutSlots.size(); i++) {
-      IRecipeSlotBuilder slot = builder.addSlot(RecipeIngredientRole.INPUT, layoutSlots.get(i).getX() + X_OFFSET, layoutSlots.get(i).getY() + Y_OFFSET)
+      IRecipeSlotBuilder slot = builder.addInputSlot(layoutSlots.get(i).getX() + X_OFFSET, layoutSlots.get(i).getY() + Y_OFFSET)
              .addItemStacks(partsAndExtras.get(i));
       if (i == 0) {
         firstSlot = slot;
@@ -95,7 +96,7 @@ public class ToolBuildingCategory implements IRecipeCategory<ToolBuildingRecipe>
 
     // create a focus link between result and first slot if same size
     List<ItemStack> result = recipe.getDisplayOutput();
-    IRecipeSlotBuilder resultSlot = builder.addSlot(RecipeIngredientRole.OUTPUT, WIDTH - 26, 23)
+    IRecipeSlotBuilder resultSlot = builder.addOutputSlot(WIDTH - 26, 23)
       .addItemStacks(result).setOutputSlotBackground();
     if (result.size() > 1 && partsAndExtras.get(0).size() == result.size()) {
       builder.createFocusLink(resultSlot, firstSlot);
@@ -147,10 +148,10 @@ public class ToolBuildingCategory implements IRecipeCategory<ToolBuildingRecipe>
   }
 
   @Override
-  public List<Component> getTooltipStrings(ToolBuildingRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
-    return recipe.requiresAnvil() && GuiUtil.isHovered((int) mouseX, (int) mouseY, 76, 44, ITEM_SIZE, ITEM_SIZE) ?
-      List.of(TConstruct.makeTranslation("jei", "tinkering.tool_building.anvil")) :
-      List.of();
+  public void getTooltip(ITooltipBuilder tooltip, ToolBuildingRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
+    if (recipe.requiresAnvil() && GuiUtil.isHovered((int)mouseX, (int)mouseY, 76, 44, ITEM_SIZE, ITEM_SIZE)) {
+      tooltip.add(TConstruct.makeTranslation("jei", "tinkering.tool_building.anvil"));
+    }
   }
 
   @Nonnull

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/casting/AbstractCastingCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/casting/AbstractCastingCategory.java
@@ -4,10 +4,10 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import lombok.Getter;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
@@ -32,7 +32,6 @@ import slimeknights.tconstruct.plugin.jei.util.FluidTooltipCallback;
 
 import javax.annotation.Nullable;
 import java.awt.Color;
-import java.util.Collections;
 import java.util.List;
 
 /** Shared base logic for the two casting recipe types */
@@ -53,7 +52,7 @@ public abstract class AbstractCastingCategory implements IRecipeCategory<IDispla
 
   protected AbstractCastingCategory(IGuiHelper guiHelper, Block icon, IDrawable block) {
     this.background = guiHelper.createDrawable(BACKGROUND_LOC, 0, 0, 117, 54);
-    this.icon = guiHelper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(icon));
+    this.icon = guiHelper.createDrawableItemLike(icon);
     this.tankOverlay = guiHelper.createDrawable(BACKGROUND_LOC, 133, 0, 32, 32);
     this.castConsumed = guiHelper.createDrawable(BACKGROUND_LOC, 141, 32, 13, 11);
     this.castKept = guiHelper.createDrawable(BACKGROUND_LOC, 141, 43, 13, 11);
@@ -93,17 +92,16 @@ public abstract class AbstractCastingCategory implements IRecipeCategory<IDispla
   }
 
   @Override
-  public List<Component> getTooltipStrings(IDisplayableCastingRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
+  public void getTooltip(ITooltipBuilder tooltip, IDisplayableCastingRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
     if (recipe.hasCast() && GuiUtil.isHovered((int)mouseX, (int)mouseY, 63, 39, 13, 11)) {
-      return Collections.singletonList(Component.translatable(recipe.isConsumed() ? KEY_CAST_CONSUMED : KEY_CAST_KEPT));
+      tooltip.add(Component.translatable(recipe.isConsumed() ? KEY_CAST_CONSUMED : KEY_CAST_KEPT));
     }
-    return Collections.emptyList();
   }
 
   @Override
   public void setRecipe(IRecipeLayoutBuilder builder, IDisplayableCastingRecipe recipe, IFocusGroup focuses) {
     List<ItemStack> outputs = recipe.getOutputs();
-    IRecipeSlotBuilder output = builder.addSlot(RecipeIngredientRole.OUTPUT, 93, 18).addItemStacks(recipe.getOutputs());
+    IRecipeSlotBuilder output = builder.addOutputSlot(93, 18).addItemStacks(recipe.getOutputs());
     // items
     List<ItemStack> casts = recipe.getCastItems();
     if (!casts.isEmpty()) {
@@ -118,7 +116,7 @@ public abstract class AbstractCastingCategory implements IRecipeCategory<IDispla
     // tank fluids
     int capacity = FluidValues.METAL_BLOCK;
     List<FluidStack> inputs = recipe.getFluids();
-    IRecipeSlotBuilder tank = builder.addSlot(RecipeIngredientRole.INPUT, 3, 3)
+    IRecipeSlotBuilder tank = builder.addInputSlot(3, 3)
            .addTooltipCallback(FluidTooltipCallback.UNITS)
            .setFluidRenderer(capacity, false, 32, 32)
            .setOverlay(tankOverlay, 0, 0)

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/entity/EntityMeltingRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/entity/EntityMeltingRecipeCategory.java
@@ -95,7 +95,7 @@ public class EntityMeltingRecipeCategory implements IRecipeCategory<EntityMeltin
   public void setRecipe(IRecipeLayoutBuilder builder, EntityMeltingRecipe recipe, IFocusGroup focuses) {
     // inputs, filtered by spawn egg item
     EntityIngredient input = recipe.getIngredient();
-    IIngredientAcceptor<?> entities = builder.addSlot(RecipeIngredientRole.INPUT, 19, 11)
+    IIngredientAcceptor<?> entities = builder.addInputSlot(19, 11)
                                              .setCustomRenderer(MantleJEIConstants.ENTITY_TYPE, entityRenderer)
                                              .addIngredients(MantleJEIConstants.ENTITY_TYPE, input.getDisplay());
     // add spawn eggs as hidden inputs
@@ -103,7 +103,7 @@ public class EntityMeltingRecipeCategory implements IRecipeCategory<EntityMeltin
     builder.createFocusLink(entities, eggs);
 
     // output
-    builder.addSlot(RecipeIngredientRole.OUTPUT, 115, 11)
+    builder.addOutputSlot(115, 11)
            .setFluidRenderer(FluidValues.INGOT * 2, false, 16, 32)
            .addTooltipCallback(new FluidTooltip(recipe.getDamage())) // object is cheap, no need to cache
            .addIngredient(ForgeTypes.FLUID_STACK, recipe.getOutput());

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/entity/SeveringCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/entity/SeveringCategory.java
@@ -31,7 +31,7 @@ public class SeveringCategory implements IRecipeCategory<SeveringRecipe> {
   @Getter
   private final IDrawable icon;
   public SeveringCategory(IGuiHelper helper) {
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, TinkerTools.cleaver.get().getRenderTool());
+    this.icon = helper.createDrawableItemStack(TinkerTools.cleaver.get().getRenderTool());
   }
 
   @Override
@@ -62,14 +62,14 @@ public class SeveringCategory implements IRecipeCategory<SeveringRecipe> {
   @Override
   public void setRecipe(IRecipeLayoutBuilder builder, SeveringRecipe recipe, IFocusGroup focuses) {
     EntityIngredient input = recipe.getIngredient();
-    IIngredientAcceptor<?> entities = builder.addSlot(RecipeIngredientRole.INPUT, 3, 3)
+    IIngredientAcceptor<?> entities = builder.addInputSlot(3, 3)
            .setCustomRenderer(MantleJEIConstants.ENTITY_TYPE, entityRenderer)
            .addIngredients(MantleJEIConstants.ENTITY_TYPE, input.getDisplay());
     IIngredientAcceptor<?> eggs = builder.addInvisibleIngredients(RecipeIngredientRole.INPUT).addItemStacks(input.getEggs());
     builder.createFocusLink(entities, eggs);
 
     // output
-    builder.addSlot(RecipeIngredientRole.OUTPUT, 76, 11).addItemStack(recipe.getOutput()).setOutputSlotBackground();
+    builder.addOutputSlot(76, 11).addItemStack(recipe.getOutput()).setOutputSlotBackground();
   }
 
   @Override

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/material/MaterialsCraftingExtension.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/material/MaterialsCraftingExtension.java
@@ -1,7 +1,6 @@
 package slimeknights.tconstruct.plugin.jei.material;
 
 import com.google.common.collect.Streams;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.ingredient.ICraftingGridHelper;
@@ -99,7 +98,7 @@ public class MaterialsCraftingExtension<T extends CraftingRecipe & MaterialsCraf
       width = height = getShapelessSize(inputStacks.size());
       builder.setShapeless();
     }
-    List<IRecipeSlotBuilder> inputs = craftingGridHelper.createAndSetInputs(builder, VanillaTypes.ITEM_STACK, inputStacks, width, height);
+    List<IRecipeSlotBuilder> inputs = craftingGridHelper.createAndSetInputs(builder, inputStacks, width, height);
     IRecipeSlotBuilder output = craftingGridHelper.createAndSetOutputs(builder, result);
     if (inputs.size() != 9) {
       Mantle.logger.error("Failed to create focus link for {} as the layout {} is not 3x3", recipe.getId(), builder.getClass().getName());

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/melting/AbstractMeltingCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/melting/AbstractMeltingCategory.java
@@ -4,6 +4,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import lombok.RequiredArgsConstructor;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
 import mezz.jei.api.gui.drawable.IDrawableAnimated.StartDirection;
@@ -29,7 +30,6 @@ import slimeknights.tconstruct.library.recipe.melting.MeltingRecipe;
 import slimeknights.tconstruct.plugin.jei.util.FluidTooltipCallback;
 
 import java.awt.Color;
-import java.util.Collections;
 import java.util.List;
 
 /** Shared logic between melting and foundry */
@@ -94,17 +94,17 @@ public abstract class AbstractMeltingCategory implements IRecipeCategory<Melting
   }
 
   @Override
-  public List<Component> getTooltipStrings(MeltingRecipe recipe, IRecipeSlotsView slots, double mouseXD, double mouseYD) {
+  public void getTooltip(ITooltipBuilder tooltip, MeltingRecipe recipe, IRecipeSlotsView slots, double mouseXD, double mouseYD) {
     int mouseX = (int)mouseXD;
     int mouseY = (int)mouseYD;
     if (recipe.getOreType() != null && GuiUtil.isHovered(mouseX, mouseY, 87, 31, 16, 16)) {
-      return Collections.singletonList(TOOLTIP_ORE);
+      tooltip.add(TOOLTIP_ORE);
+      return;
     }
     // time tooltip
     if (GuiUtil.isHovered(mouseX, mouseY, 56, 18, 24, 17)) {
-      return Collections.singletonList(Component.translatable(KEY_COOLING_TIME, recipe.getTime() / 4));
+      tooltip.add(Component.translatable(KEY_COOLING_TIME, recipe.getTime() / 4));
     }
-    return Collections.emptyList();
   }
 
   /** Adds amounts to outputs and temperatures to fuels */

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/melting/FoundryCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/melting/FoundryCategory.java
@@ -1,7 +1,6 @@
 package slimeknights.tconstruct.plugin.jei.melting;
 
 import lombok.Getter;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -10,7 +9,6 @@ import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
 import slimeknights.tconstruct.TConstruct;
 import slimeknights.tconstruct.library.recipe.FluidValues;
 import slimeknights.tconstruct.library.recipe.melting.MeltingRecipe;
@@ -29,7 +27,7 @@ public class FoundryCategory extends AbstractMeltingCategory {
 
   public FoundryCategory(IGuiHelper helper) {
     super(helper);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerSmeltery.foundryController));
+    this.icon = helper.createDrawableItemLike(TinkerSmeltery.foundryController);
   }
 
   @Override
@@ -45,7 +43,7 @@ public class FoundryCategory extends AbstractMeltingCategory {
   @Override
   public void setRecipe(IRecipeLayoutBuilder builder, MeltingRecipe recipe, IFocusGroup focuses) {
     // input
-    builder.addSlot(RecipeIngredientRole.INPUT, 24, 18).addIngredients(recipe.getInput());
+    builder.addInputSlot(24, 18).addIngredients(recipe.getInput());
 
     // output fluid
     AlloyRecipeCategory.drawVariableFluids(builder, RecipeIngredientRole.OUTPUT, 96, 4, 32, 32, recipe.getOutputWithByproducts(), FluidValues.METAL_BLOCK, Function.identity(), list -> MeltingFluidCallback.INSTANCE);

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/melting/MeltingCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/melting/MeltingCategory.java
@@ -2,7 +2,6 @@ package slimeknights.tconstruct.plugin.jei.melting;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -16,7 +15,6 @@ import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import slimeknights.mantle.fluid.tooltip.FluidTooltipHandler;
@@ -55,7 +53,7 @@ public class MeltingCategory extends AbstractMeltingCategory {
 
   public MeltingCategory(IGuiHelper helper) {
     super(helper);
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerSmeltery.searedMelter));
+    this.icon = helper.createDrawableItemLike(TinkerSmeltery.searedMelter);
     this.solidFuel = helper.drawableBuilder(BACKGROUND_LOC, 164, 0, 18, 20).build();
   }
 
@@ -83,7 +81,7 @@ public class MeltingCategory extends AbstractMeltingCategory {
   @Override
   public void setRecipe(IRecipeLayoutBuilder builder, MeltingRecipe recipe, IFocusGroup focuses) {
     // input
-    builder.addSlot(RecipeIngredientRole.INPUT, 24, 18).addIngredients(recipe.getInput());
+    builder.addInputSlot(24, 18).addIngredients(recipe.getInput());
 
     // output
     OreRateType oreType = recipe.getOreType();
@@ -95,7 +93,7 @@ public class MeltingCategory extends AbstractMeltingCategory {
     } else {
       tooltip = MeltingFluidCallback.INSTANCE;
     }
-    builder.addSlot(RecipeIngredientRole.OUTPUT, 96, 4)
+    builder.addOutputSlot(96, 4)
       .addTooltipCallback(tooltip)
       .setFluidRenderer(FluidValues.METAL_BLOCK, false, 32, 32)
       .setOverlay(tankOverlay, 0, 0)

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/modifiers/ModifierRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/modifiers/ModifierRecipeCategory.java
@@ -2,9 +2,9 @@ package slimeknights.tconstruct.plugin.jei.modifiers;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import lombok.Getter;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
@@ -41,7 +41,6 @@ import slimeknights.tconstruct.tools.item.CreativeSlotItem;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,7 +51,7 @@ public class ModifierRecipeCategory implements IRecipeCategory<IDisplayModifierR
   private static final Component TITLE = TConstruct.makeTranslation("jei", "modifiers.title");
 
   // translation
-  private static final List<Component> TEXT_INCREMENTAL = Collections.singletonList(TConstruct.makeTranslation("jei", "modifiers.incremental"));
+  private static final Component TEXT_INCREMENTAL = TConstruct.makeTranslation("jei", "modifiers.incremental");
   private static final String KEY_MIN = TConstruct.makeTranslationKey("jei", "modifiers.level.min");
   private static final String KEY_MAX = TConstruct.makeTranslationKey("jei", "modifiers.level.max");
   private static final String KEY_RANGE = TConstruct.makeTranslationKey("jei", "modifiers.level.range");
@@ -65,7 +64,7 @@ public class ModifierRecipeCategory implements IRecipeCategory<IDisplayModifierR
   private final IDrawable requirements, incremental;
   private final IDrawable[] slotIcons;
   public ModifierRecipeCategory(IGuiHelper helper) {
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, CreativeSlotItem.withSlot(new ItemStack(TinkerModifiers.creativeSlotItem), SlotType.UPGRADE));
+    this.icon = helper.createDrawableItemStack(CreativeSlotItem.withSlot(new ItemStack(TinkerModifiers.creativeSlotItem), SlotType.UPGRADE));
     this.slotIcons = new IDrawable[6];
     for (int i = 0; i < 6; i++) {
       slotIcons[i] = helper.createDrawable(BACKGROUND_LOC, 128 + i * 16, 0, 16, 16);
@@ -151,31 +150,31 @@ public class ModifierRecipeCategory implements IRecipeCategory<IDisplayModifierR
   }
 
   @Override
-  public List<Component> getTooltipStrings(IDisplayModifierRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
+  public void getTooltip(ITooltipBuilder tooltip, IDisplayModifierRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
     int checkX = (int) mouseX;
     int checkY = (int) mouseY;
     ModifierEntry result = recipe.getDisplayResult();
     if (GuiUtil.isHovered(checkX, checkY, 66, 58, 16, 16)) {
       Component requirements = result.getHook(ModifierHooks.REQUIREMENTS).requirementsError(result);
       if (requirements != null) {
-        return Collections.singletonList(requirements);
+        tooltip.add(requirements);
+        return;
       }
     }
     if (recipe.isIncremental() && GuiUtil.isHovered(checkX, checkY, 83, 59, 16, 16)) {
-      return TEXT_INCREMENTAL;
+      tooltip.add(TEXT_INCREMENTAL);
+      return;
     }
     SlotCount slots = recipe.getSlots();
     if (slots == null && GuiUtil.isHovered(checkX, checkY, 102, 58, 24, 16)) {
-      return SlotIngredientRenderer.INPUT.getTooltip(null, TooltipFlag.NORMAL);
+      tooltip.addAll(SlotIngredientRenderer.INPUT.getTooltip(null, TooltipFlag.NORMAL));
     }
-    
-    return Collections.emptyList();
   }
 
   /** Adds an input slot with the icon */
   private void addInput(IRecipeLayoutBuilder builder, IDisplayModifierRecipe recipe, int index, int x, int y) {
     List<ItemStack> stacks = recipe.getDisplayItems(index);
-    IRecipeSlotBuilder slot = builder.addSlot(RecipeIngredientRole.INPUT, x, y)
+    IRecipeSlotBuilder slot = builder.addInputSlot(x, y)
       .addItemStacks(stacks)
       .setStandardSlotBackground();
     // show icon if the slot is empty
@@ -194,7 +193,7 @@ public class ModifierRecipeCategory implements IRecipeCategory<IDisplayModifierR
     addInput(builder, recipe, 4,  7, 58);
 
     // modifiers
-    builder.addSlot(RecipeIngredientRole.OUTPUT, 3, 3)
+    builder.addOutputSlot(3, 3)
       .setCustomRenderer(TConstructJEIConstants.MODIFIER_TYPE, modifierRenderer)
       .addIngredient(TConstructJEIConstants.MODIFIER_TYPE, recipe.getDisplayResult());
 
@@ -212,7 +211,7 @@ public class ModifierRecipeCategory implements IRecipeCategory<IDisplayModifierR
     // JEI is currently being dumb and using ingredient subtypes within recipe focuses
     // we use a more strict subtype for tools in ingredients so they all show in JEI, but do not care in recipes
     // thus, manually handle the focuses
-    IFocus<ItemStack> focus = focuses.getFocuses(VanillaTypes.ITEM_STACK).filter(f -> f.getRole() == RecipeIngredientRole.CATALYST).findFirst().orElse(null);
+    IFocus<ItemStack> focus = focuses.getItemStackFocuses(RecipeIngredientRole.CATALYST).findFirst().orElse(null);
     if (focus != null) {
       Item item = focus.getTypedValue().getIngredient().getItem();
       for (ItemStack stack : toolWithoutModifier) {
@@ -236,7 +235,7 @@ public class ModifierRecipeCategory implements IRecipeCategory<IDisplayModifierR
     // modifier slots
     SlotCount slots = recipe.getSlots();
     if (slots != null) {
-      builder.addSlot(RecipeIngredientRole.INPUT, 102, 58)
+      builder.addInputSlot(102, 58)
         .setCustomRenderer(TConstructJEIConstants.SLOT_TYPE, SlotIngredientRenderer.INPUT)
         .addIngredient(TConstructJEIConstants.SLOT_TYPE, recipe.getSlots());
     }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/modifiers/ModifierWorktableCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/modifiers/ModifierWorktableCategory.java
@@ -1,9 +1,9 @@
 package slimeknights.tconstruct.plugin.jei.modifiers;
 
 import lombok.Getter;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
+import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
@@ -22,7 +22,6 @@ import slimeknights.tconstruct.library.recipe.worktable.IModifierWorktableRecipe
 import slimeknights.tconstruct.plugin.jei.TConstructJEIConstants;
 import slimeknights.tconstruct.tables.TinkerTables;
 
-import java.util.Collections;
 import java.util.List;
 
 public class ModifierWorktableCategory implements IRecipeCategory<IModifierWorktableRecipe> {
@@ -35,7 +34,7 @@ public class ModifierWorktableCategory implements IRecipeCategory<IModifierWorkt
   private final IDrawable[] slotIcons;
   private final IDrawable modifierButton;
   public ModifierWorktableCategory(IGuiHelper helper) {
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerTables.modifierWorktable));
+    this.icon = helper.createDrawableItemLike(TinkerTables.modifierWorktable);
     this.toolIcon = helper.createDrawable(BACKGROUND_LOC, 128, 0, 16, 16);
     this.slotIcons = new IDrawable[] {
       helper.createDrawable(BACKGROUND_LOC, 176, 0, 16, 16),
@@ -71,11 +70,10 @@ public class ModifierWorktableCategory implements IRecipeCategory<IModifierWorkt
   }
 
   @Override
-  public List<Component> getTooltipStrings(IModifierWorktableRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
+  public void getTooltip(ITooltipBuilder tooltip, IModifierWorktableRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
     if (mouseY >= 2 && mouseY <= 12) {
-      return List.of(recipe.getDescription(null));
+      tooltip.add(recipe.getDescription(null));
     }
-    return Collections.emptyList();
   }
 
   @Override
@@ -90,7 +88,7 @@ public class ModifierWorktableCategory implements IRecipeCategory<IModifierWorkt
     // input items
     for (int i = 0; i < 2; i++) {
       List<ItemStack> stacks = recipe.getDisplayItems(i);
-      IRecipeSlotBuilder slot = builder.addSlot(RecipeIngredientRole.INPUT, 43 + i*18, 16)
+      IRecipeSlotBuilder slot = builder.addInputSlot(43 + i*18, 16)
         .addItemStacks(stacks)
         .setStandardSlotBackground();
       if (stacks.isEmpty()) {

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/partbuilder/PartBuilderCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/partbuilder/PartBuilderCategory.java
@@ -1,7 +1,6 @@
 package slimeknights.tconstruct.plugin.jei.partbuilder;
 
 import lombok.Getter;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -40,7 +39,7 @@ public class PartBuilderCategory implements IRecipeCategory<IDisplayPartBuilderR
   private final IDrawable icon;
   private final IDrawable patternButton;
   public PartBuilderCategory(IGuiHelper helper) {
-    this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(TinkerTables.partBuilder));
+    this.icon = helper.createDrawableItemLike(TinkerTables.partBuilder);
     this.patternButton = helper.createDrawable(BACKGROUND_LOC, 45, 132, 18, 18);
   }
 
@@ -87,19 +86,19 @@ public class PartBuilderCategory implements IRecipeCategory<IDisplayPartBuilderR
   public void setRecipe(IRecipeLayoutBuilder builder, IDisplayPartBuilderRecipe recipe, IFocusGroup focuses) {
     // items
     List<ItemStack> materialItems = recipe.getMaterialItems();
-    IRecipeSlotBuilder materialSlot = builder.addSlot(RecipeIngredientRole.INPUT, 25, 16)
+    IRecipeSlotBuilder materialSlot = builder.addInputSlot(25, 16)
       .addItemStacks(materialItems).setStandardSlotBackground();
-    builder.addSlot(RecipeIngredientRole.INPUT,  4, 16)
+    builder.addInputSlot(4, 16)
       .addItemStacks(recipe.getPatternItems()).setStandardSlotBackground();
     // patterns
-    builder.addSlot(RecipeIngredientRole.INPUT, 46, 16)
+    builder.addInputSlot(46, 16)
       .addIngredient(TConstructJEIConstants.PATTERN_TYPE, recipe.getPattern())
       .setBackground(patternButton, -1, -1);
     // TODO: material ingredient input?
 
     // output
     List<ItemStack> resultItems = recipe.getResultItems();
-    IRecipeSlotBuilder resultSlot = builder.addSlot(RecipeIngredientRole.OUTPUT, 96, 15)
+    IRecipeSlotBuilder resultSlot = builder.addOutputSlot(96, 15)
       .addItemStacks(resultItems).setOutputSlotBackground();
 
     // add focus link between materials and result; practically we only the size for result to be >1 for focus link; but better to be safe

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/transfer/TinkerStationTransferInfo.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/transfer/TinkerStationTransferInfo.java
@@ -1,7 +1,6 @@
 package slimeknights.tconstruct.plugin.jei.transfer;
 
 import lombok.Getter;
-import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.ingredient.IRecipeSlotView;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.recipe.RecipeIngredientRole;
@@ -101,7 +100,7 @@ public class TinkerStationTransferInfo<T> implements IRecipeTransferInfo<TinkerS
       IRecipeSlotView slotView = slotViews.get(i);
       // if it is not empty and it contains an item stack, thats a problem
       // the item stack check is because we show modifier slots as an "input"
-      if (!slotView.isEmpty() && slotView.getDisplayedIngredient(VanillaTypes.ITEM_STACK).isPresent()) {
+      if (!slotView.isEmpty() && slotView.getDisplayedItemStack().isPresent()) {
         return false;
       }
     }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/util/FluidTooltipCallback.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/util/FluidTooltipCallback.java
@@ -20,7 +20,7 @@ public interface FluidTooltipCallback extends IRecipeSlotTooltipCallback {
   /** Default instance, simply replaces mb units with our unit handler. */
   FluidTooltipCallback UNITS = (fluid, recipeSlotView, tooltip) -> FluidTooltipHandler.appendMaterial(fluid, tooltip);
 
-  /** Default instance, simply replaces mb units with our unit handler. */
+  /** Instance that removes the amount from fluid tooltips. */
   FluidTooltipCallback NO_AMOUNT = (fluid, recipeSlotView, tooltip) -> {};
 
   @Override


### PR DESCRIPTION
No logic changes here, just updating to use some newer JEI methods.
All these methods are available within the current minimum-jei-version for TC.

Most of these are to avoid having to specify verbose basic things like `VanillaTypes.ITEM_STACK` or `RecipeIngredientRole.INPUT`