### PR TITLE
Use RecipeIngredientRole.CATALYST for catalysts

### DIFF
--- a/src/main/java/slimeknights/tconstruct/plugin/jei/AlloyRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/AlloyRecipeCategory.java
@@ -103,7 +103,7 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
   /**
    * Draws a variable number of fluids
    * @param builder      Builder
-   * @param role         Role of the set of fluids in the recipe
+   * @param role         Role of the fluids in the recipe
    * @param x            X start
    * @param y            Y start
    * @param totalWidth   Total width
@@ -115,7 +115,7 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
    * @param <T> Object type
    * @return Max amount based on fluids
    */
-  public static <T> int drawVariableFluids(IRecipeLayoutBuilder builder, RecipeIngredientRole role, int x, int y, int totalWidth, int height, List<T> fluids, int minAmount, Function<T,List<FluidStack>> mapper, Function<T,IRecipeSlotTooltipCallback> tooltip) {
+  public static <T> int drawVariableFluids(IRecipeLayoutBuilder builder, Function<T,RecipeIngredientRole> role, int x, int y, int totalWidth, int height, List<T> fluids, int minAmount, Function<T,List<FluidStack>> mapper, Function<T,IRecipeSlotTooltipCallback> tooltip) {
     int count = fluids.size();
     int maxAmount = minAmount;
     if (count > 0) {
@@ -133,7 +133,7 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
       for (int i = 0; i < max; i++) {
         int fluidX = x + i * w;
         T ingredient = fluids.get(i);
-        builder.addSlot(role, fluidX, y)
+        builder.addSlot(role.apply(ingredient), fluidX, y)
                .addTooltipCallback(tooltip.apply(ingredient))
                .setFluidRenderer(maxAmount, false, w, height)
                .addIngredients(ForgeTypes.FLUID_STACK, mapper.apply(ingredient));
@@ -141,7 +141,7 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
       // for the last, the width is the full remaining width
       int fluidX = x + max * w;
       T ingredient = fluids.get(max);
-      builder.addSlot(role, fluidX, y)
+      builder.addSlot(role.apply(ingredient), fluidX, y)
              .addTooltipCallback(tooltip.apply(ingredient))
              .setFluidRenderer(maxAmount, false, totalWidth - (w * max), height)
              .addIngredients(ForgeTypes.FLUID_STACK, mapper.apply(ingredient));
@@ -152,7 +152,8 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
   @Override
   public void setRecipe(IRecipeLayoutBuilder builder, AlloyRecipe recipe, IFocusGroup focuses) {
     // inputs
-    int maxAmount = drawVariableFluids(builder, RecipeIngredientRole.INPUT, 19, 11, 48, 32, recipe.getInputs(),recipe.getOutput().getAmount(),
+    int maxAmount = drawVariableFluids(builder, ingredient -> ingredient.catalyst() ? RecipeIngredientRole.CATALYST : RecipeIngredientRole.INPUT,
+                                       19, 11, 48, 32, recipe.getInputs(), recipe.getOutput().getAmount(),
                                        ingredient -> ingredient.fluid().getFluids(),
                                        ingredient -> ingredient.catalyst() ? CATALYST_TOOLTIP : FluidTooltipCallback.UNITS);
 

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/AlloyRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/AlloyRecipeCategory.java
@@ -115,6 +115,25 @@ public class AlloyRecipeCategory implements IRecipeCategory<AlloyRecipe> {
    * @param <T> Object type
    * @return Max amount based on fluids
    */
+  public static <T> int drawVariableFluids(IRecipeLayoutBuilder builder, RecipeIngredientRole role, int x, int y, int totalWidth, int height, List<T> fluids, int minAmount, Function<T,List<FluidStack>> mapper, Function<T,IRecipeSlotTooltipCallback> tooltip) {
+    return drawVariableFluids(builder, i -> role, x, y, totalWidth, height, fluids, minAmount, mapper, tooltip);
+  }
+
+  /**
+   * Draws a variable number of fluids
+   * @param builder      Builder
+   * @param role         Role of the fluids in the recipe
+   * @param x            X start
+   * @param y            Y start
+   * @param totalWidth   Total width
+   * @param height       Tank height
+   * @param fluids       List of fluids to draw
+   * @param minAmount    Minimum tank size
+   * @param mapper       Logic to get a fluid list from the object
+   * @param tooltip      Tooltip callback
+   * @param <T> Object type
+   * @return Max amount based on fluids
+   */
   public static <T> int drawVariableFluids(IRecipeLayoutBuilder builder, Function<T,RecipeIngredientRole> role, int x, int y, int totalWidth, int height, List<T> fluids, int minAmount, Function<T,List<FluidStack>> mapper, Function<T,IRecipeSlotTooltipCallback> tooltip) {
     int count = fluids.size();
     int maxAmount = minAmount;

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/MoldingRecipeCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/MoldingRecipeCategory.java
@@ -100,8 +100,10 @@ public class MoldingRecipeCategory implements IRecipeCategory<MoldingRecipe> {
     // if we have a mold, we are pressing into the table, so draw pressed item on input and output
     Ingredient pattern = recipe.getPattern();
     if (!pattern.isEmpty()) {
-      IRecipeSlotBuilder inputSlot = builder.addInputSlot(3, 1).addIngredients(pattern);
-      if (!recipe.isPatternConsumed()) {
+      boolean patternConsumed = recipe.isPatternConsumed();
+      IRecipeSlotBuilder inputSlot = builder.addSlot(patternConsumed ? RecipeIngredientRole.INPUT : RecipeIngredientRole.CATALYST, 3, 1)
+        .addIngredients(pattern);
+      if (!patternConsumed) {
         IRecipeSlotBuilder preservedSlot = builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 51, 8).addIngredients(pattern);
         builder.createFocusLink(inputSlot, preservedSlot);
       }

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/melting/FoundryCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/melting/FoundryCategory.java
@@ -46,7 +46,7 @@ public class FoundryCategory extends AbstractMeltingCategory {
     builder.addInputSlot(24, 18).addIngredients(recipe.getInput());
 
     // output fluid
-    AlloyRecipeCategory.drawVariableFluids(builder, RecipeIngredientRole.OUTPUT, 96, 4, 32, 32, recipe.getOutputWithByproducts(), FluidValues.METAL_BLOCK, Function.identity(), list -> MeltingFluidCallback.INSTANCE);
+    AlloyRecipeCategory.drawVariableFluids(builder, i -> RecipeIngredientRole.OUTPUT, 96, 4, 32, 32, recipe.getOutputWithByproducts(), FluidValues.METAL_BLOCK, Function.identity(), list -> MeltingFluidCallback.INSTANCE);
 
     // fuel
     builder.addSlot(RecipeIngredientRole.RENDER_ONLY, 4, 4)

--- a/src/main/java/slimeknights/tconstruct/plugin/jei/partbuilder/PartBuilderCategory.java
+++ b/src/main/java/slimeknights/tconstruct/plugin/jei/partbuilder/PartBuilderCategory.java
@@ -19,6 +19,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import slimeknights.tconstruct.TConstruct;
+import slimeknights.tconstruct.common.TinkerTags;
 import slimeknights.tconstruct.library.client.GuiUtil;
 import slimeknights.tconstruct.library.client.materials.MaterialTooltipCache;
 import slimeknights.tconstruct.library.materials.definition.MaterialVariant;
@@ -88,8 +89,10 @@ public class PartBuilderCategory implements IRecipeCategory<IDisplayPartBuilderR
     List<ItemStack> materialItems = recipe.getMaterialItems();
     IRecipeSlotBuilder materialSlot = builder.addInputSlot(25, 16)
       .addItemStacks(materialItems).setStandardSlotBackground();
-    builder.addInputSlot(4, 16)
-      .addItemStacks(recipe.getPatternItems()).setStandardSlotBackground();
+    List<ItemStack> patternItems = recipe.getPatternItems();
+    boolean reusablePattern = !patternItems.isEmpty() && patternItems.stream().allMatch(stack -> stack.is(TinkerTags.Items.REUSABLE_PATTERNS));
+    builder.addSlot(reusablePattern ? RecipeIngredientRole.CATALYST : RecipeIngredientRole.INPUT, 4, 16)
+      .addItemStacks(patternItems).setStandardSlotBackground();
     // patterns
     builder.addInputSlot(46, 16)
       .addIngredient(TConstructJEIConstants.PATTERN_TYPE, recipe.getPattern())


### PR DESCRIPTION
Very minor, this marks ingredients that aren't consumed as "catalysts" which can be useful for some mods that use JEI to calculate recipe trees and things like that.